### PR TITLE
Add user profile settings page

### DIFF
--- a/services/tms/internal/api/handlers/user.go
+++ b/services/tms/internal/api/handlers/user.go
@@ -154,16 +154,15 @@ func (h *UserHandler) me(c *gin.Context) {
 func (h *UserHandler) updateMe(c *gin.Context) {
 	authCtx := context.GetAuthContext(c)
 
-	entity := new(tenant.User)
-	if err := c.ShouldBindJSON(entity); err != nil {
+	req := new(repositories.UpdateMeRequest)
+	if err := c.ShouldBindJSON(req); err != nil {
 		h.eh.HandleError(c, err)
 		return
 	}
 
-	entity.ID = authCtx.UserID
-	context.AddContextToRequest(authCtx, entity)
-
-	entity, err := h.service.Update(c.Request.Context(), entity, authCtx.UserID)
+	context.AddContextToRequest(authCtx, req)
+	req.UserID = authCtx.UserID
+	entity, err := h.service.UpdateMe(c.Request.Context(), req)
 	if err != nil {
 		h.eh.HandleError(c, err)
 		return

--- a/services/tms/internal/core/ports/repositories/user.go
+++ b/services/tms/internal/core/ports/repositories/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/emoss08/trenova/internal/core/domain/tenant"
+	"github.com/emoss08/trenova/pkg/domaintypes"
 	"github.com/emoss08/trenova/pkg/pagination"
 	"github.com/emoss08/trenova/pkg/pulid"
 )
@@ -49,6 +50,17 @@ type ListUserRequest struct {
 	IncludeRoles bool
 }
 
+type UpdateMeRequest struct {
+	UserID       pulid.ID               `json:"userId"`
+	OrgID        pulid.ID               `json:"orgId"`
+	BuID         pulid.ID               `json:"buId"`
+	Name         string                 `json:"name"         form:"name"`
+	Username     string                 `json:"username"     form:"username"`
+	EmailAddress string                 `json:"emailAddress" form:"emailAddress"`
+	Timezone     string                 `json:"timezone"     form:"timezone"`
+	TimeFormat   domaintypes.TimeFormat `json:"timeFormat"   form:"timeFormat"`
+}
+
 type UserRepository interface {
 	GetOption(ctx context.Context, req GetUserByIDRequest) (*tenant.User, error)
 	SelectOptions(
@@ -62,8 +74,9 @@ type UserRepository interface {
 	GetByIDs(ctx context.Context, opts GetUsersByIDsRequest) ([]*tenant.User, error)
 	GetSystemUser(ctx context.Context) (*tenant.User, error)
 	UpdateLastLogin(ctx context.Context, userID pulid.ID) error
-	Create(ctx context.Context, u *tenant.User) (*tenant.User, error)
 	Update(ctx context.Context, u *tenant.User) (*tenant.User, error)
+	UpdateMe(ctx context.Context, req *UpdateMeRequest) (*tenant.User, error)
+	Create(ctx context.Context, u *tenant.User) (*tenant.User, error)
 	SwitchOrganization(ctx context.Context, userID, newOrgID pulid.ID) (*tenant.User, error)
 	ChangePassword(ctx context.Context, req *ChangePasswordRequest) (*tenant.User, error)
 }

--- a/services/tms/internal/core/services/user/service.go
+++ b/services/tms/internal/core/services/user/service.go
@@ -140,6 +140,13 @@ func (s *Service) Create(
 	return createdEntity, nil
 }
 
+func (s *Service) UpdateMe(
+	ctx context.Context,
+	req *repositories.UpdateMeRequest,
+) (*tenant.User, error) {
+	return s.repo.UpdateMe(ctx, req)
+}
+
 func (s *Service) Update(
 	ctx context.Context,
 	u *tenant.User,

--- a/ui/src/app/auth/_components/change-password-form.tsx
+++ b/ui/src/app/auth/_components/change-password-form.tsx
@@ -1,8 +1,3 @@
-/*
- * Copyright 2025 Eric Moss
- * Licensed under FSL-1.1-ALv2 (Functional Source License 1.1, Apache 2.0 Future)
- * Full license: https://github.com/emoss08/Trenova/blob/master/LICENSE.md */
-
 import { PasswordField } from "@/components/fields/sensitive-input-field";
 import { FormSaveButton } from "@/components/ui/button";
 import { Form, FormControl, FormGroup } from "@/components/ui/form";
@@ -63,34 +58,41 @@ export function ChangePasswordForm({
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
-      <FormGroup className="gap-1" cols={1}>
-        <FormControl>
-          <PasswordField
-            control={control}
-            name="currentPassword"
-            label="Current password"
-            placeholder="Enter your current password"
-            rules={{ required: true }}
-          />
-        </FormControl>
-        <FormControl>
-          <PasswordField
-            control={control}
-            name="newPassword"
-            label="New password"
-            placeholder="Enter your new password"
-            rules={{ required: true }}
-          />
-        </FormControl>
-        <FormControl>
-          <PasswordField
-            control={control}
-            name="confirmPassword"
-            label="Confirm password"
-            placeholder="Confirm your new password"
-            rules={{ required: true }}
-          />
-        </FormControl>
+      <div className="flex min-h-[368px] flex-col px-4 py-2">
+        <FormGroup cols={1}>
+          <FormControl>
+            <PasswordField
+              control={control}
+              name="currentPassword"
+              label="Current password"
+              placeholder="Enter your current password"
+              description="The current password you want to change"
+              rules={{ required: true }}
+            />
+          </FormControl>
+          <FormControl>
+            <PasswordField
+              control={control}
+              name="newPassword"
+              label="New password"
+              placeholder="Enter your new password"
+              description="The new password you want to set"
+              rules={{ required: true }}
+            />
+          </FormControl>
+          <FormControl>
+            <PasswordField
+              control={control}
+              name="confirmPassword"
+              label="Confirm password"
+              placeholder="Confirm your new password"
+              rules={{ required: true }}
+              description="The confirm password you want to set"
+            />
+          </FormControl>
+        </FormGroup>
+      </div>
+      <div className="flex justify-end border-t px-4 py-2">
         <FormSaveButton
           size="lg"
           type="submit"
@@ -99,7 +101,7 @@ export function ChangePasswordForm({
           isSubmitting={isSubmitting}
           disabled={isSubmitting}
         />
-      </FormGroup>
+      </div>
     </Form>
   );
 }

--- a/ui/src/components/nav-user.tsx
+++ b/ui/src/components/nav-user.tsx
@@ -9,7 +9,7 @@ import type { UserSchema } from "@/lib/schemas/user-schema";
 import { useUser } from "@/stores/user-store";
 import { faUpRightFromSquare } from "@fortawesome/pro-regular-svg-icons";
 import { CaretSortIcon } from "@radix-ui/react-icons";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { LicenseInformation } from "./license-information";
 import { Theme, useTheme } from "./theme-provider";
@@ -27,6 +27,7 @@ import {
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
 import { Icon } from "./ui/icons";
+import { UserSettingsDialog } from "./user-settings-dialog";
 
 export function UserAvatar({ user }: { user: UserSchema | null }) {
   if (!user) {
@@ -54,6 +55,24 @@ export function NavUser() {
   const user = useUser();
 
   const [licenseDialogOpen, setLicenseDialogOpen] = useState(false);
+  const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
+
+  // Keybind support for opening settings (Ctrl+Shift+S or Cmd+Shift+S)
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === "S" &&
+        event.shiftKey &&
+        (event.ctrlKey || event.metaKey)
+      ) {
+        event.preventDefault();
+        setSettingsDialogOpen(true);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   const handleLogout = async () => {
     toast.promise(logout, {
@@ -99,7 +118,11 @@ export function NavUser() {
                 <UserAvatar user={user} />
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
-              <DropdownMenuItem title="Account Settings" />
+              <DropdownMenuItem
+                title="Account Settings"
+                onClick={() => setSettingsDialogOpen(true)}
+                className="cursor-pointer"
+              />
               <DropdownMenuItem title="Notifications" />
               <DropdownMenuSub>
                 <DropdownMenuSubTrigger>Switch Theme</DropdownMenuSubTrigger>
@@ -167,6 +190,13 @@ export function NavUser() {
         <LicenseInformation
           open={licenseDialogOpen}
           onOpenChange={setLicenseDialogOpen}
+        />
+      )}
+      {user && settingsDialogOpen && (
+        <UserSettingsDialog
+          open={settingsDialogOpen}
+          onOpenChange={setSettingsDialogOpen}
+          user={user}
         />
       )}
     </>

--- a/ui/src/components/providers.tsx
+++ b/ui/src/components/providers.tsx
@@ -2,7 +2,7 @@ import { PermissionProvider } from "@/contexts/permission-context";
 import { APIError } from "@/types/errors";
 import { HelmetProvider } from "@dr.pogodin/react-helmet";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-// import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { NuqsAdapter } from "nuqs/adapters/react-router/v7";
 import { ThemeProvider } from "./theme-provider";
 import { Toaster } from "./ui/sonner";
@@ -35,7 +35,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
           >
             <WebSocketProvider>
               <ThemeProvider defaultTheme="dark" storageKey="trenova-ui-theme">
-                {/* <ReactQueryDevtools /> */}
+                <ReactQueryDevtools />
                 {children}
                 <Toaster position="top-center" />
               </ThemeProvider>

--- a/ui/src/components/ui/sidebar.tsx
+++ b/ui/src/components/ui/sidebar.tsx
@@ -289,7 +289,7 @@ const Sidebar = React.forwardRef<
         {/* Hover trigger zone - only visible when collapsed */}
         {state === "collapsed" && !isMobile && (
           <div
-            className="fixed left-0 top-0 z-40 h-full w-5 cursor-pointer"
+            className="fixed top-0 left-0 z-40 h-full w-5 cursor-pointer"
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
             aria-label="Hover to reveal sidebar"
@@ -384,7 +384,7 @@ const SidebarTrigger = React.forwardRef<
     >
       <Icon icon={faSidebar} className="size-4 text-foreground" />
       {state === "collapsed" && (
-        <span className="absolute left-7 top-5 block size-1.5 rounded-full bg-purple-600 ring-2 ring-background" />
+        <span className="absolute top-5 left-7 block size-1.5 rounded-full bg-purple-600 ring-2 ring-background" />
       )}
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
@@ -616,7 +616,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full select-none items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full cursor-pointer items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] select-none group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -862,5 +862,6 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
-  useSidebar,
+  useSidebar
 };
+

--- a/ui/src/components/user-profile-form.tsx
+++ b/ui/src/components/user-profile-form.tsx
@@ -2,90 +2,68 @@ import { InputField } from "@/components/fields/input-field";
 import { SelectField } from "@/components/fields/select-field";
 import { FormSaveButton } from "@/components/ui/button";
 import { Form, FormControl, FormGroup } from "@/components/ui/form";
+import { useApiMutation } from "@/hooks/use-api-mutation";
 import { timeFormatChoices } from "@/lib/choices";
-import type { UserSchema } from "@/lib/schemas/user-schema";
+import {
+  updateMeSchema,
+  UpdateMeSchema,
+  type UserSchema,
+} from "@/lib/schemas/user-schema";
 import { TIMEZONES } from "@/lib/timezone/timezone";
 import { api } from "@/services/api";
 import { useAuthActions } from "@/stores/user-store";
-import type { APIError } from "@/types/errors";
-import { TimeFormat } from "@/types/user";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation } from "@tanstack/react-query";
+import { useCallback, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import * as z from "zod";
 
-// Schema for profile update - only editable fields
-const profileUpdateSchema = z.object({
-  name: z
-    .string()
-    .min(1, { error: "Name is required" })
-    .regex(/^[a-zA-Z]+(\s[a-zA-Z]+)*$/, {
-      error: "Name can only contain letters and spaces",
-    }),
-  username: z
-    .string()
-    .min(1, { error: "Username is required" })
-    .max(20, { error: "Username must be less than 20 characters" })
-    .regex(/^[a-zA-Z0-9]+$/, { error: "Username must be alphanumeric" }),
-  emailAddress: z.email({ error: "Invalid email address" }),
-  timezone: z.string().min(1, { error: "Timezone is required" }).max(50, {
-    error: "Timezone must be less than 50 characters",
-  }),
-  timeFormat: z.enum(TimeFormat, { error: "Time format is required" }),
-});
-
-type ProfileUpdateSchema = z.infer<typeof profileUpdateSchema>;
-
-interface UserProfileFormProps {
+export function UserProfileForm({
+  user,
+  onSuccess,
+}: {
   user: UserSchema;
   onSuccess?: () => void;
-}
-
-export function UserProfileForm({ user, onSuccess }: UserProfileFormProps) {
-  const { setUser } = useAuthActions();
-
-  const mutation = useMutation({
-    mutationFn: async (values: ProfileUpdateSchema) =>
-      await api.user.updateMe(values),
-  });
-
+}) {
   const {
     control,
     handleSubmit,
     setError,
-    formState: { isSubmitting, isDirty },
-  } = useForm<ProfileUpdateSchema>({
-    resolver: zodResolver(profileUpdateSchema),
-    defaultValues: {
-      name: user.name,
-      username: user.username,
-      emailAddress: user.emailAddress,
-      timezone: user.timezone,
-      timeFormat: user.timeFormat,
-    },
+    reset,
+    formState: { errors, isSubmitSuccessful, isSubmitting, isDirty },
+  } = useForm<UpdateMeSchema>({
+    resolver: zodResolver(updateMeSchema),
+    defaultValues: user,
   });
 
-  async function onSubmit(values: ProfileUpdateSchema) {
-    try {
-      const updatedUser = await mutation.mutateAsync(values);
-      setUser(updatedUser);
+  const { setUser } = useAuthActions();
+
+  const mutation = useApiMutation({
+    mutationFn: async (values: UpdateMeSchema) =>
+      await api.user.updateMe(values),
+    onSuccess: (data) => {
+      setUser(data);
       toast.success("Profile updated successfully");
       onSuccess?.();
-    } catch (error) {
-      const err = error as APIError;
-      if (err.isValidationError()) {
-        err.getFieldErrors().forEach((fieldError) => {
-          const fieldName = fieldError.name as keyof ProfileUpdateSchema;
-          setError(fieldName, {
-            message: fieldError.reason,
-          });
-        });
-      } else {
-        toast.error(err.data?.detail || "Failed to update profile");
-      }
+    },
+    resourceName: "User",
+    setFormError: setError,
+  });
+
+  useEffect(() => {
+    if (isSubmitSuccessful) {
+      reset(user);
     }
-  }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSubmitSuccessful, user]);
+
+  console.log(errors);
+
+  const onSubmit = useCallback(
+    async (values: UpdateMeSchema) => {
+      await mutation.mutateAsync(values);
+    },
+    [mutation],
+  );
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>

--- a/ui/src/components/user-profile-form.tsx
+++ b/ui/src/components/user-profile-form.tsx
@@ -1,13 +1,10 @@
-/*
- * Copyright 2025 Eric Moss
- * Licensed under FSL-1.1-ALv2 (Functional Source License 1.1, Apache 2.0 Future)
- * Full license: https://github.com/emoss08/Trenova/blob/master/LICENSE.md */
-
 import { InputField } from "@/components/fields/input-field";
 import { SelectField } from "@/components/fields/select-field";
 import { FormSaveButton } from "@/components/ui/button";
 import { Form, FormControl, FormGroup } from "@/components/ui/form";
+import { timeFormatChoices } from "@/lib/choices";
 import type { UserSchema } from "@/lib/schemas/user-schema";
+import { TIMEZONES } from "@/lib/timezone/timezone";
 import { api } from "@/services/api";
 import { useAuthActions } from "@/stores/user-store";
 import type { APIError } from "@/types/errors";
@@ -23,7 +20,10 @@ const profileUpdateSchema = z.object({
   name: z
     .string()
     .min(1, "Name is required")
-    .regex(/^[a-zA-Z]+(\s[a-zA-Z]+)*$/, "Name can only contain letters and spaces"),
+    .regex(
+      /^[a-zA-Z]+(\s[a-zA-Z]+)*$/,
+      "Name can only contain letters and spaces",
+    ),
   username: z
     .string()
     .min(1, "Username is required")
@@ -35,22 +35,6 @@ const profileUpdateSchema = z.object({
 });
 
 type ProfileUpdateSchema = z.infer<typeof profileUpdateSchema>;
-
-// Common timezone options
-const TIMEZONE_OPTIONS = [
-  { value: "America/New_York", label: "Eastern Time (ET)" },
-  { value: "America/Chicago", label: "Central Time (CT)" },
-  { value: "America/Denver", label: "Mountain Time (MT)" },
-  { value: "America/Los_Angeles", label: "Pacific Time (PT)" },
-  { value: "America/Anchorage", label: "Alaska Time (AKT)" },
-  { value: "Pacific/Honolulu", label: "Hawaii Time (HT)" },
-  { value: "UTC", label: "UTC" },
-];
-
-const TIME_FORMAT_OPTIONS = [
-  { value: TimeFormat.TwelveHour, label: "12-hour (AM/PM)" },
-  { value: TimeFormat.TwentyFourHour, label: "24-hour" },
-];
 
 interface UserProfileFormProps {
   user: UserSchema;
@@ -139,7 +123,7 @@ export function UserProfileForm({ user, onSuccess }: UserProfileFormProps) {
             control={control}
             name="timezone"
             label="Timezone"
-            options={TIMEZONE_OPTIONS}
+            options={TIMEZONES}
             placeholder="Select timezone"
             rules={{ required: true }}
           />
@@ -149,7 +133,7 @@ export function UserProfileForm({ user, onSuccess }: UserProfileFormProps) {
             control={control}
             name="timeFormat"
             label="Time Format"
-            options={TIME_FORMAT_OPTIONS}
+            options={timeFormatChoices}
             placeholder="Select time format"
             rules={{ required: true }}
           />

--- a/ui/src/components/user-profile-form.tsx
+++ b/ui/src/components/user-profile-form.tsx
@@ -19,19 +19,20 @@ import * as z from "zod";
 const profileUpdateSchema = z.object({
   name: z
     .string()
-    .min(1, "Name is required")
-    .regex(
-      /^[a-zA-Z]+(\s[a-zA-Z]+)*$/,
-      "Name can only contain letters and spaces",
-    ),
+    .min(1, { error: "Name is required" })
+    .regex(/^[a-zA-Z]+(\s[a-zA-Z]+)*$/, {
+      error: "Name can only contain letters and spaces",
+    }),
   username: z
     .string()
-    .min(1, "Username is required")
-    .max(20, "Username must be less than 20 characters")
-    .regex(/^[a-zA-Z0-9]+$/, "Username must be alphanumeric"),
-  emailAddress: z.string().email("Invalid email address"),
-  timezone: z.string().min(1, "Timezone is required"),
-  timeFormat: z.enum(TimeFormat),
+    .min(1, { error: "Username is required" })
+    .max(20, { error: "Username must be less than 20 characters" })
+    .regex(/^[a-zA-Z0-9]+$/, { error: "Username must be alphanumeric" }),
+  emailAddress: z.email({ error: "Invalid email address" }),
+  timezone: z.string().min(1, { error: "Timezone is required" }).max(50, {
+    error: "Timezone must be less than 50 characters",
+  }),
+  timeFormat: z.enum(TimeFormat, { error: "Time format is required" }),
 });
 
 type ProfileUpdateSchema = z.infer<typeof profileUpdateSchema>;
@@ -88,56 +89,65 @@ export function UserProfileForm({ user, onSuccess }: UserProfileFormProps) {
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
-      <FormGroup className="gap-4" cols={1}>
-        <FormControl>
-          <InputField
-            control={control}
-            name="name"
-            label="Full Name"
-            placeholder="Enter your full name"
-            rules={{ required: true }}
-          />
-        </FormControl>
-        <FormControl>
-          <InputField
-            control={control}
-            name="username"
-            label="Username"
-            placeholder="Enter your username"
-            rules={{ required: true }}
-            maxLength={20}
-          />
-        </FormControl>
-        <FormControl>
-          <InputField
-            control={control}
-            name="emailAddress"
-            label="Email Address"
-            type="email"
-            placeholder="Enter your email address"
-            rules={{ required: true }}
-          />
-        </FormControl>
-        <FormControl>
-          <SelectField
-            control={control}
-            name="timezone"
-            label="Timezone"
-            options={TIMEZONES}
-            placeholder="Select timezone"
-            rules={{ required: true }}
-          />
-        </FormControl>
-        <FormControl>
-          <SelectField
-            control={control}
-            name="timeFormat"
-            label="Time Format"
-            options={timeFormatChoices}
-            placeholder="Select time format"
-            rules={{ required: true }}
-          />
-        </FormControl>
+      <div className="flex flex-col px-4 py-2">
+        <FormGroup cols={1}>
+          <FormControl>
+            <InputField
+              control={control}
+              name="name"
+              label="Full Name"
+              placeholder="Enter your full name"
+              rules={{ required: true }}
+              description="The name you want to be displayed in the system"
+            />
+          </FormControl>
+          <FormControl>
+            <InputField
+              control={control}
+              name="username"
+              label="Username"
+              placeholder="Enter your username"
+              rules={{ required: true }}
+              maxLength={20}
+              description="The username you want to use to login to the system"
+            />
+          </FormControl>
+          <FormControl>
+            <InputField
+              control={control}
+              name="emailAddress"
+              label="Email Address"
+              type="email"
+              placeholder="Enter your email address"
+              rules={{ required: true }}
+              description="The email address you want to use to receive notifications and other communications from the system"
+            />
+          </FormControl>
+          <FormControl>
+            <SelectField
+              control={control}
+              name="timezone"
+              label="Timezone"
+              options={TIMEZONES}
+              placeholder="Select timezone"
+              rules={{ required: true }}
+              description="The timezone you want to use to display the time in the system"
+            />
+          </FormControl>
+          <FormControl>
+            <SelectField
+              control={control}
+              name="timeFormat"
+              label="Time Format"
+              options={timeFormatChoices}
+              placeholder="Select time format"
+              rules={{ required: true }}
+              description="The time format you want to use to display the time in the system"
+            />
+          </FormControl>
+        </FormGroup>
+      </div>
+      <div className="flex justify-end border-t px-4 py-2">
         <FormSaveButton
           size="lg"
           type="submit"
@@ -146,7 +156,7 @@ export function UserProfileForm({ user, onSuccess }: UserProfileFormProps) {
           isSubmitting={isSubmitting}
           disabled={isSubmitting || !isDirty}
         />
-      </FormGroup>
+      </div>
     </Form>
   );
 }

--- a/ui/src/components/user-profile-form.tsx
+++ b/ui/src/components/user-profile-form.tsx
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2025 Eric Moss
+ * Licensed under FSL-1.1-ALv2 (Functional Source License 1.1, Apache 2.0 Future)
+ * Full license: https://github.com/emoss08/Trenova/blob/master/LICENSE.md */
+
+import { InputField } from "@/components/fields/input-field";
+import { SelectField } from "@/components/fields/select-field";
+import { FormSaveButton } from "@/components/ui/button";
+import { Form, FormControl, FormGroup } from "@/components/ui/form";
+import type { UserSchema } from "@/lib/schemas/user-schema";
+import { api } from "@/services/api";
+import { useAuthActions } from "@/stores/user-store";
+import type { APIError } from "@/types/errors";
+import { TimeFormat } from "@/types/user";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import * as z from "zod";
+
+// Schema for profile update - only editable fields
+const profileUpdateSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Name is required")
+    .regex(/^[a-zA-Z]+(\s[a-zA-Z]+)*$/, "Name can only contain letters and spaces"),
+  username: z
+    .string()
+    .min(1, "Username is required")
+    .max(20, "Username must be less than 20 characters")
+    .regex(/^[a-zA-Z0-9]+$/, "Username must be alphanumeric"),
+  emailAddress: z.string().email("Invalid email address"),
+  timezone: z.string().min(1, "Timezone is required"),
+  timeFormat: z.enum(TimeFormat),
+});
+
+type ProfileUpdateSchema = z.infer<typeof profileUpdateSchema>;
+
+// Common timezone options
+const TIMEZONE_OPTIONS = [
+  { value: "America/New_York", label: "Eastern Time (ET)" },
+  { value: "America/Chicago", label: "Central Time (CT)" },
+  { value: "America/Denver", label: "Mountain Time (MT)" },
+  { value: "America/Los_Angeles", label: "Pacific Time (PT)" },
+  { value: "America/Anchorage", label: "Alaska Time (AKT)" },
+  { value: "Pacific/Honolulu", label: "Hawaii Time (HT)" },
+  { value: "UTC", label: "UTC" },
+];
+
+const TIME_FORMAT_OPTIONS = [
+  { value: TimeFormat.TwelveHour, label: "12-hour (AM/PM)" },
+  { value: TimeFormat.TwentyFourHour, label: "24-hour" },
+];
+
+interface UserProfileFormProps {
+  user: UserSchema;
+  onSuccess?: () => void;
+}
+
+export function UserProfileForm({ user, onSuccess }: UserProfileFormProps) {
+  const { setUser } = useAuthActions();
+
+  const mutation = useMutation({
+    mutationFn: async (values: ProfileUpdateSchema) =>
+      await api.user.updateMe(values),
+  });
+
+  const {
+    control,
+    handleSubmit,
+    setError,
+    formState: { isSubmitting, isDirty },
+  } = useForm<ProfileUpdateSchema>({
+    resolver: zodResolver(profileUpdateSchema),
+    defaultValues: {
+      name: user.name,
+      username: user.username,
+      emailAddress: user.emailAddress,
+      timezone: user.timezone,
+      timeFormat: user.timeFormat,
+    },
+  });
+
+  async function onSubmit(values: ProfileUpdateSchema) {
+    try {
+      const updatedUser = await mutation.mutateAsync(values);
+      setUser(updatedUser);
+      toast.success("Profile updated successfully");
+      onSuccess?.();
+    } catch (error) {
+      const err = error as APIError;
+      if (err.isValidationError()) {
+        err.getFieldErrors().forEach((fieldError) => {
+          const fieldName = fieldError.name as keyof ProfileUpdateSchema;
+          setError(fieldName, {
+            message: fieldError.reason,
+          });
+        });
+      } else {
+        toast.error(err.data?.detail || "Failed to update profile");
+      }
+    }
+  }
+
+  return (
+    <Form onSubmit={handleSubmit(onSubmit)}>
+      <FormGroup className="gap-4" cols={1}>
+        <FormControl>
+          <InputField
+            control={control}
+            name="name"
+            label="Full Name"
+            placeholder="Enter your full name"
+            rules={{ required: true }}
+          />
+        </FormControl>
+        <FormControl>
+          <InputField
+            control={control}
+            name="username"
+            label="Username"
+            placeholder="Enter your username"
+            rules={{ required: true }}
+            maxLength={20}
+          />
+        </FormControl>
+        <FormControl>
+          <InputField
+            control={control}
+            name="emailAddress"
+            label="Email Address"
+            type="email"
+            placeholder="Enter your email address"
+            rules={{ required: true }}
+          />
+        </FormControl>
+        <FormControl>
+          <SelectField
+            control={control}
+            name="timezone"
+            label="Timezone"
+            options={TIMEZONE_OPTIONS}
+            placeholder="Select timezone"
+            rules={{ required: true }}
+          />
+        </FormControl>
+        <FormControl>
+          <SelectField
+            control={control}
+            name="timeFormat"
+            label="Time Format"
+            options={TIME_FORMAT_OPTIONS}
+            placeholder="Select time format"
+            rules={{ required: true }}
+          />
+        </FormControl>
+        <FormSaveButton
+          size="lg"
+          type="submit"
+          title="Save changes"
+          text="Save changes"
+          isSubmitting={isSubmitting}
+          disabled={isSubmitting || !isDirty}
+        />
+      </FormGroup>
+    </Form>
+  );
+}

--- a/ui/src/components/user-settings-dialog.tsx
+++ b/ui/src/components/user-settings-dialog.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 Eric Moss
+ * Licensed under FSL-1.1-ALv2 (Functional Source License 1.1, Apache 2.0 Future)
+ * Full license: https://github.com/emoss08/Trenova/blob/master/LICENSE.md */
+
+import ChangePasswordForm from "@/app/auth/_components/change-password-form";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { VisuallyHidden } from "@/components/ui/visually-hidden";
+import type { UserSchema } from "@/lib/schemas/user-schema";
+import { faLock, faUser } from "@fortawesome/pro-regular-svg-icons";
+import { Icon } from "./ui/icons";
+import { UserProfileForm } from "./user-profile-form";
+
+interface UserSettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  user: UserSchema;
+}
+
+export function UserSettingsDialog({
+  open,
+  onOpenChange,
+  user,
+}: UserSettingsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>User Settings</DialogTitle>
+          <DialogDescription>
+            Manage your profile information and security settings
+          </DialogDescription>
+        </DialogHeader>
+        <DialogBody>
+          <Tabs defaultValue="profile" className="w-full">
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="profile">
+                <Icon icon={faUser} />
+                Profile
+              </TabsTrigger>
+              <TabsTrigger value="password">
+                <Icon icon={faLock} />
+                Password
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="profile" className="mt-4">
+              <UserProfileForm
+                user={user}
+                onSuccess={() => onOpenChange(false)}
+              />
+            </TabsContent>
+            <TabsContent value="password" className="mt-4">
+              <PasswordTabContent onOpenChange={onOpenChange} />
+            </TabsContent>
+          </Tabs>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PasswordTabContent({
+  onOpenChange,
+}: {
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="text-sm text-muted-foreground">
+        <p>Change your password to keep your account secure.</p>
+        <p className="mt-2">
+          Your password must be at least 8 characters long and contain:
+        </p>
+        <ul className="mt-2 list-inside list-disc space-y-1 text-xs">
+          <li>At least one uppercase letter</li>
+          <li>At least one lowercase letter</li>
+          <li>At least one number</li>
+          <li>At least one special character</li>
+        </ul>
+      </div>
+      <ChangePasswordForm onOpenChange={onOpenChange} />
+    </div>
+  );
+}

--- a/ui/src/components/user-settings-dialog.tsx
+++ b/ui/src/components/user-settings-dialog.tsx
@@ -113,8 +113,8 @@ export function UserSettingsDialog({
             </SidebarContent>
           </Sidebar>
           <MainContentOuter>
-            <header className="flex h-16 shrink-0 items-center gap-2 border-b border-border transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-              <div className="flex flex-col items-start gap-0.5 px-4">
+            <header className="flex h-16 shrink-0 items-center border-b border-border transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+              <div className="flex flex-col items-start px-4 leading-tight">
                 <h1 className="text-lg font-medium">{activeTabName}</h1>
                 <p className="text-sm text-muted-foreground">
                   {activeTabDescription}

--- a/ui/src/components/user-settings-dialog.tsx
+++ b/ui/src/components/user-settings-dialog.tsx
@@ -1,8 +1,3 @@
-/*
- * Copyright 2025 Eric Moss
- * Licensed under FSL-1.1-ALv2 (Functional Source License 1.1, Apache 2.0 Future)
- * Full license: https://github.com/emoss08/Trenova/blob/master/LICENSE.md */
-
 import ChangePasswordForm from "@/app/auth/_components/change-password-form";
 import {
   Dialog,
@@ -13,7 +8,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { VisuallyHidden } from "@/components/ui/visually-hidden";
 import type { UserSchema } from "@/lib/schemas/user-schema";
 import { faLock, faUser } from "@fortawesome/pro-regular-svg-icons";
 import { Icon } from "./ui/icons";

--- a/ui/src/lib/choices.tsx
+++ b/ui/src/lib/choices.tsx
@@ -23,6 +23,7 @@ import { NotificationResources } from "@/types/notification";
 import { RoleType } from "@/types/roles-permissions";
 import { ShipmentDocumentType } from "@/types/shipment";
 import { Visibility } from "@/types/table-configuration";
+import { TimeFormat } from "@/types/user";
 import { Endorsement, PTOStatus, PTOType, WorkerType } from "@/types/worker";
 import {
   AccountTypeCategorySchema,
@@ -1080,3 +1081,14 @@ export const accountTypeCategoryChoices = [
     label: "Expense",
   },
 ] satisfies ReadonlyArray<ChoiceProps<AccountTypeSchema["category"]>>;
+
+export const timeFormatChoices = [
+  {
+    value: TimeFormat.TimeFormat12Hour,
+    label: "12-hour",
+  },
+  {
+    value: TimeFormat.TimeFormat24Hour,
+    label: "24-hour",
+  },
+] satisfies ReadonlyArray<ChoiceProps<TimeFormat>>;

--- a/ui/src/lib/schemas/organization-schema.ts
+++ b/ui/src/lib/schemas/organization-schema.ts
@@ -1,9 +1,9 @@
 import { OrganizationType } from "@/types/organization";
 import * as z from "zod";
 import {
-    optionalStringSchema,
-    timestampSchema,
-    versionSchema,
+  optionalStringSchema,
+  timestampSchema,
+  versionSchema,
 } from "./helpers";
 import { usStateSchema } from "./us-state-schema";
 
@@ -66,7 +66,7 @@ export const organizationMembershipSchema = z.object({
   directPolicies: optionalStringSchema.array(),
   joinedAt: timestampSchema,
   grantedById: optionalStringSchema,
-  expiresAt: timestampSchema.optional(),
+  expiresAt: timestampSchema.nullish(),
   isDefault: z.boolean(),
 });
 

--- a/ui/src/lib/schemas/user-schema.ts
+++ b/ui/src/lib/schemas/user-schema.ts
@@ -148,6 +148,32 @@ export const userSchema = z.object({
 
 export type UserSchema = z.infer<typeof userSchema>;
 
+export const updateMeSchema = z.object({
+  id: optionalStringSchema,
+  version: versionSchema,
+  createdAt: timestampSchema,
+  updatedAt: timestampSchema,
+
+  name: z
+    .string()
+    .min(1, { error: "Name is required" })
+    .regex(/^[a-zA-Z]+(\s[a-zA-Z]+)*$/, {
+      error: "Name can only contain letters and spaces",
+    }),
+  username: z
+    .string()
+    .min(1, { error: "Username is required" })
+    .max(20, { error: "Username must be less than 20 characters" })
+    .regex(/^[a-zA-Z0-9]+$/, { error: "Username must be alphanumeric" }),
+  emailAddress: z.email({ error: "Invalid email address" }),
+  timezone: z.string().min(1, { error: "Timezone is required" }).max(50, {
+    error: "Timezone must be less than 50 characters",
+  }),
+  timeFormat: z.enum(TimeFormat, { error: "Time format is required" }),
+});
+
+export type UpdateMeSchema = z.infer<typeof updateMeSchema>;
+
 export const bulkCreateUserSchema = z.object({
   users: z.array(userSchema).min(1, "At least one user is required"),
 });

--- a/ui/src/lib/timezone/timezone.ts
+++ b/ui/src/lib/timezone/timezone.ts
@@ -1,8 +1,3 @@
-/*
- * Copyright 2025 Eric Moss
- * Licensed under FSL-1.1-ALv2 (Functional Source License 1.1, Apache 2.0 Future)
- * Full license: https://github.com/emoss08/Trenova/blob/master/LICENSE.md */
-
 import { ChoiceProps } from "@/types/common";
 import tz from "./timezone.json";
 

--- a/ui/src/services/user.ts
+++ b/ui/src/services/user.ts
@@ -23,6 +23,11 @@ export class UserAPI {
     return http.post<UserSchema>("/users/change-password/", request);
   }
 
+  async updateMe(data: Partial<UserSchema>) {
+    const response = await http.put<UserSchema>("/users/me/", data);
+    return response.data;
+  }
+
   async searchUsers(query: string) {
     const response = await http.get<LimitOffsetResponse<UserSchema>>(
       "/users/select-options/",


### PR DESCRIPTION
Add comprehensive user settings functionality with the following features:

Backend changes:
- Add PUT /users/me/ endpoint for users to update their own profile
- Allows users to update profile without requiring admin permissions

Frontend changes:
- Create UserSettingsDialog component with tabbed interface
  - Profile tab: Edit name, username, email, timezone, and time format
  - Password tab: Change password with existing form integration
- Add keyboard shortcut (Ctrl+Shift+S or Cmd+Shift+S) to open settings
- Integrate settings modal trigger in nav-user dropdown menu
- Create UserProfileForm component with validation
- Update user service API to include updateMe method

User experience improvements:
- Modal-based interface for easy access to settings
- Form validation with clear error messages
- Automatic user state update after profile changes
- Disabled save button when no changes are made
- Toast notifications for success/error feedback

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `PUT /users/me/` for self-profile updates and a modal user settings UI with profile editing and password change.
> 
> - **Backend**:
>   - **Endpoint**: Add `PUT /users/me/` in `internal/api/handlers/user.go` with handler `updateMe`.
>   - **Service/Repo**:
>     - Add `UpdateMe(ctx, req)` passthrough in `internal/core/services/user/service.go`.
>     - Extend repo contract with `UpdateMeRequest` and `UpdateMe` in `internal/core/ports/repositories/user.go`.
>     - Implement `UpdateMe` in `internal/infrastructure/postgres/.../user.go` updating `name`, `username`, `email_address`, `timezone`, `time_format` with tenant scoping and returning refreshed `User`.
> - **Frontend**:
>   - **Settings Modal**: New `UserSettingsDialog` with tabs: `Profile` and `Change Password`.
>     - `UserProfileForm`: Edit `name`, `username`, `emailAddress`, `timezone`, `timeFormat`; validates with `updateMeSchema`; calls `api.user.updateMe`; updates user store.
>     - Integrates into `nav-user` dropdown; adds keyboard shortcut `Ctrl/Cmd+Shift+S` to open.
>   - **Forms/UX**: Enhance change-password form layout/descriptions; disable save when unchanged; toast feedback.
>   - **API/Utils**: Add `user.updateMe` client method; add `timeFormatChoices`; minor schema tweaks (`expiresAt` nullish).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3019174b713540fa669b2ba21605c0ca61448b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->