### PR TITLE
Fix coalesce function nil handling test

### DIFF
--- a/services/tms/pkg/formula/expression/errors.go
+++ b/services/tms/pkg/formula/expression/errors.go
@@ -54,10 +54,7 @@ var (
 	ErrIndexOfFirstArgumentMustBeStringOrArray = errors.New(
 		"indexOf: first argument must be string or array",
 	)
-	ErrCoalesceAllArgumentsMustBeNonNil = errors.New(
-		"coalesce: all arguments must be non-nil",
-	)
-	ErrNumericOverflow                          = errors.New("numeric overflow")
+	ErrNumericOverflow = errors.New("numeric overflow")
 	ErrDivisionByZero                           = errors.New("division by zero")
 	ErrModuloByZero                             = errors.New("modulo by zero")
 	ErrPowerResultOutOfRange                    = errors.New("power: result out of range")

--- a/services/tms/pkg/formula/expression/functions.go
+++ b/services/tms/pkg/formula/expression/functions.go
@@ -697,7 +697,7 @@ func (f *coalesceFunction) Call(_ *EvaluationContext, args ...any) (any, error) 
 			}
 		}
 	}
-	return nil, ErrCoalesceAllArgumentsMustBeNonNil
+	return nil, nil
 }
 
 func equal(a, b any) bool {


### PR DESCRIPTION
Fix the coalesce function to align with standard behavior in SQL and other languages. When all arguments are nil or falsy values, the function now returns nil instead of throwing an error.

Changes:
- Modified coalesceFunction.Call to return (nil, nil) instead of error
- Removed unused ErrCoalesceAllArgumentsMustBeNonNil error

This fixes the failing test: TestBuiltinFunctions/coalesce_all_nil

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `coalesce` to return `nil` when all arguments are nil/falsy and remove the obsolete `ErrCoalesceAllArgumentsMustBeNonNil`.
> 
> - **Formula engine**:
>   - Update `coalesceFunction.Call` to return `(nil, nil)` when all inputs are `nil`/falsy instead of an error (`services/tms/pkg/formula/expression/functions.go`).
> - **Errors cleanup**:
>   - Remove `ErrCoalesceAllArgumentsMustBeNonNil`; keep `ErrNumericOverflow` intact (`services/tms/pkg/formula/expression/errors.go`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae09713cdf4388795e4ba79248b64a08154f0d2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->