### PR TITLE
Potential fix for code scanning alert no. 157: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -24,6 +24,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests


### PR DESCRIPTION
Potential fix for [https://github.com/emoss08/Trenova/security/code-scanning/157](https://github.com/emoss08/Trenova/security/code-scanning/157)

Add an explicit top-level `permissions` block in `.github/workflows/test-client.yml` so all jobs inherit least-privilege token access.  
Best fix without changing behavior: set:

- `permissions:`
  - `contents: read`

This supports `actions/checkout` and typical read-only workflow operations while preventing unnecessary write scopes. Place it at workflow root (for example, after `concurrency` and before `jobs`) so it applies consistently to `test`, `build`, `storybook`, and `lint` without duplicating config in each job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
