### PR TITLE
Rework dispatch timeline into an ops triage workstation

### DIFF
--- a/client/src/routes/shipment/_components/command-center/store.ts
+++ b/client/src/routes/shipment/_components/command-center/store.ts
@@ -1,24 +1,52 @@
 import { createSelectors } from "@/lib/utils";
 import { create } from "zustand";
-import { devtools } from "zustand/middleware";
+import { devtools, persist } from "zustand/middleware";
+import type { TimelineDensity } from "./timeline/constants";
 
 /**
  * Zustand store for ephemeral, cross-component UI state that doesn't belong in
- * the URL. Right now that's only `highlightId` — the row currently being
- * pointed at by either the table cursor or (in Phase 3) a map pin. Saved-view
- * selection, filter chips, view mode, expansion, and pagination all live in
- * the URL via `useCommandCenterUrl`.
+ * the URL: `highlightId` (the row currently pointed at by the table cursor or
+ * a map pin) and the dispatch timeline's workstation state — which driver rows
+ * are collapsed (ephemeral, the roster changes daily) and the preferred row
+ * density (persisted, it's a personal setting). Saved-view selection, filter
+ * chips, view mode, expansion, and pagination all live in the URL via
+ * `useCommandCenterUrl`.
  */
 interface CommandCenterState {
   highlightId: string | null;
   setHighlightId: (id: string | null) => void;
+  collapsedRowKeys: Record<string, true>;
+  toggleRowCollapsed: (key: string) => void;
+  setCollapsedRowKeys: (keys: Record<string, true>) => void;
+  timelineDensity: TimelineDensity;
+  setTimelineDensity: (density: TimelineDensity) => void;
 }
 
 const baseStore = create<CommandCenterState>()(
-  devtools((set) => ({
-    highlightId: null,
-    setHighlightId: (id) => set({ highlightId: id }),
-  })),
+  devtools(
+    persist(
+      (set) => ({
+        highlightId: null,
+        setHighlightId: (id) => set({ highlightId: id }),
+        collapsedRowKeys: {},
+        toggleRowCollapsed: (key) =>
+          set((state) => ({
+            collapsedRowKeys: state.collapsedRowKeys[key]
+              ? Object.fromEntries(
+                  Object.entries(state.collapsedRowKeys).filter(([existing]) => existing !== key),
+                )
+              : { ...state.collapsedRowKeys, [key]: true },
+          })),
+        setCollapsedRowKeys: (keys) => set({ collapsedRowKeys: keys }),
+        timelineDensity: "comfortable",
+        setTimelineDensity: (density) => set({ timelineDensity: density }),
+      }),
+      {
+        name: "cc-timeline-prefs",
+        partialize: (state) => ({ timelineDensity: state.timelineDensity }),
+      },
+    ),
+  ),
 );
 
 export const useCommandCenterStore = createSelectors(baseStore);

--- a/client/src/routes/shipment/_components/command-center/timeline/bar-detail-popover.tsx
+++ b/client/src/routes/shipment/_components/command-center/timeline/bar-detail-popover.tsx
@@ -1,7 +1,7 @@
 import { ShipmentStatusBadge } from "@/components/status-badge";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent } from "@/components/ui/popover";
-import { formatToUserTimezone } from "@/lib/date";
+import { formatDurationFromSeconds, formatToUserTimezone } from "@/lib/date";
 import {
   getDestinationLocation,
   getOriginLocation,
@@ -12,15 +12,32 @@ import {
   ArrowLeftRightIcon,
   CircleCheckIcon,
   CircleDashedIcon,
+  CircleDotIcon,
   PencilIcon,
   TableIcon,
+  TimerIcon,
 } from "lucide-react";
-import type { TimelineBar } from "./use-timeline-data";
+import type { TimelineBar, TimelineStopMarker } from "./use-timeline-data";
 
 function parseDecimal(value: unknown): number {
   if (typeof value === "number") return value;
   const parsed = Number(value ?? 0);
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function formatTime(seconds: number) {
+  return formatToUserTimezone(seconds, { showTimeZone: false, showSeconds: false });
+}
+
+function stopTimeDetail(stop: TimelineStopMarker): string {
+  if (stop.actualDeparture) return `dep ${formatTime(stop.actualDeparture)}`;
+  if (stop.actualArrival) return `arr ${formatTime(stop.actualArrival)}`;
+  if (stop.scheduledStart) {
+    return stop.scheduledEnd && stop.scheduledEnd !== stop.scheduledStart
+      ? `${formatTime(stop.scheduledStart)}–${formatTime(stop.scheduledEnd)}`
+      : formatTime(stop.scheduledStart);
+  }
+  return formatTime(stop.time);
 }
 
 type BarDetailPopoverProps = {
@@ -65,6 +82,21 @@ export function BarDetailPopover({
           <ShipmentStatusBadge status={shipment.status} />
         </div>
 
+        {bar.dwell && (
+          <div
+            className={cn(
+              "flex items-center gap-1.5 border-b border-border px-3 py-1.5 text-[10.5px] font-semibold",
+              bar.dwell.severity === "critical"
+                ? "bg-destructive/10 text-destructive"
+                : "bg-warning/10 text-warning",
+            )}
+          >
+            <TimerIcon className="size-3 shrink-0" />
+            Dwelling {formatDurationFromSeconds(bar.dwell.seconds)} at {bar.dwell.locationName}
+            {bar.dwell.severity === "critical" && " · detention risk"}
+          </div>
+        )}
+
         <div className="flex flex-col gap-1.5 px-3 py-2">
           <div className="flex items-baseline justify-between gap-2">
             <span className="truncate font-table text-[11px] font-medium tabular-nums">
@@ -77,10 +109,14 @@ export function BarDetailPopover({
           <ol className="flex flex-col gap-1">
             {bar.stops.map((stop) => {
               const isDone = stop.status === "Completed";
+              const isAtStop =
+                !isDone && !!stop.actualArrival && !stop.actualDeparture && stop.status !== "Canceled";
               return (
                 <li key={stop.id} className="flex items-center gap-1.5 text-[10.5px]">
                   {isDone ? (
                     <CircleCheckIcon className="size-3 shrink-0 text-success" />
+                  ) : isAtStop ? (
+                    <CircleDotIcon className="size-3 shrink-0 animate-pulse text-brand" />
                   ) : (
                     <CircleDashedIcon className="size-3 shrink-0 text-muted-foreground" />
                   )}
@@ -88,7 +124,7 @@ export function BarDetailPopover({
                     {stop.locationName}
                   </span>
                   <span className="ml-auto shrink-0 font-table text-[9.5px] text-muted-foreground tabular-nums">
-                    {formatToUserTimezone(stop.time, { showTimeZone: false, showSeconds: false })}
+                    {stopTimeDetail(stop)}
                   </span>
                 </li>
               );

--- a/client/src/routes/shipment/_components/command-center/timeline/constants.ts
+++ b/client/src/routes/shipment/_components/command-center/timeline/constants.ts
@@ -1,10 +1,28 @@
 export const RAIL_WIDTH_PX = 216;
-export const LANE_HEIGHT_PX = 34;
-export const BAR_HEIGHT_PX = 26;
-export const ROW_PADDING_PX = 10;
 export const DAY_LABEL_HEIGHT_PX = 26;
 export const HOUR_TICK_HEIGHT_PX = 20;
+export const COLLAPSED_ROW_HEIGHT_PX = 25;
+export const COLLAPSED_BAR_HEIGHT_PX = 9;
 
-export function rowHeightPx(laneCount: number): number {
-  return laneCount * LANE_HEIGHT_PX + ROW_PADDING_PX;
+export type TimelineDensity = "comfortable" | "compact";
+
+export type DensityConfig = {
+  laneHeightPx: number;
+  barHeightPx: number;
+  rowPaddingPx: number;
+};
+
+export const DENSITY_CONFIGS: Record<TimelineDensity, DensityConfig> = {
+  comfortable: { laneHeightPx: 34, barHeightPx: 26, rowPaddingPx: 10 },
+  compact: { laneHeightPx: 25, barHeightPx: 19, rowPaddingPx: 6 },
+};
+
+export function rowHeightPx(
+  laneCount: number,
+  density: TimelineDensity,
+  collapsed: boolean,
+): number {
+  if (collapsed) return COLLAPSED_ROW_HEIGHT_PX;
+  const config = DENSITY_CONFIGS[density];
+  return laneCount * config.laneHeightPx + config.rowPaddingPx;
 }

--- a/client/src/routes/shipment/_components/command-center/timeline/exception-strip.tsx
+++ b/client/src/routes/shipment/_components/command-center/timeline/exception-strip.tsx
@@ -1,0 +1,136 @@
+import { cn } from "@/lib/utils";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CircleCheckIcon,
+  EyeIcon,
+  InboxIcon,
+  LayersIcon,
+  TimerIcon,
+  TriangleAlertIcon,
+  XIcon,
+} from "lucide-react";
+import type { TimelineExceptionSummary, TimelineFocus } from "./use-timeline-data";
+
+type ChipTone = "destructive" | "warning";
+
+const CHIP_CONFIG: readonly {
+  id: TimelineFocus;
+  label: string;
+  tone: ChipTone;
+  Icon: typeof TimerIcon;
+}[] = [
+  { id: "late", label: "Late", tone: "destructive", Icon: TriangleAlertIcon },
+  { id: "dwelling", label: "Dwelling", tone: "warning", Icon: TimerIcon },
+  { id: "overlaps", label: "Overlaps", tone: "warning", Icon: LayersIcon },
+  { id: "unassigned", label: "Unassigned", tone: "warning", Icon: InboxIcon },
+  { id: "watch", label: "Watch", tone: "warning", Icon: EyeIcon },
+] as const;
+
+const CHIP_TONE_CLASS: Record<ChipTone, { idle: string; active: string }> = {
+  destructive: {
+    idle: "border-destructive/35 text-destructive hover:bg-destructive/10",
+    active: "border-destructive bg-destructive/15 text-destructive",
+  },
+  warning: {
+    idle: "border-warning/40 text-warning hover:bg-warning/10",
+    active: "border-warning bg-warning/15 text-warning",
+  },
+};
+
+type ExceptionStripProps = {
+  exceptions: TimelineExceptionSummary;
+  focus: TimelineFocus | null;
+  matchCount: number;
+  matchIndex: number;
+  onFocusChange: (focus: TimelineFocus | null) => void;
+  onStep: (direction: 1 | -1) => void;
+};
+
+/**
+ * Triage strip for the dispatch timeline: one glance tells the operator what
+ * needs attention in the visible window, one click isolates it, and the
+ * stepper walks match-by-match so nothing gets missed.
+ */
+export function ExceptionStrip({
+  exceptions,
+  focus,
+  matchCount,
+  matchIndex,
+  onFocusChange,
+  onStep,
+}: ExceptionStripProps) {
+  const visibleChips = CHIP_CONFIG.filter(
+    (chip) => exceptions[chip.id] > 0 || chip.id === focus,
+  );
+  const allClear = visibleChips.length === 0;
+
+  return (
+    <div className="flex min-h-7 flex-wrap items-center gap-1.5 border-b border-border bg-muted/30 px-3 py-1">
+      <span className="text-[9.5px] font-semibold tracking-wide text-muted-foreground uppercase">
+        Attention
+      </span>
+      {allClear ? (
+        <span className="inline-flex items-center gap-1 text-[10.5px] text-muted-foreground">
+          <CircleCheckIcon className="size-3 text-success" />
+          All clear in this window
+        </span>
+      ) : (
+        visibleChips.map(({ id, label, tone, Icon }) => {
+          const isActive = focus === id;
+          return (
+            <button
+              key={id}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => onFocusChange(isActive ? null : id)}
+              className={cn(
+                "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10.5px] font-medium transition-colors",
+                isActive ? CHIP_TONE_CLASS[tone].active : CHIP_TONE_CLASS[tone].idle,
+              )}
+            >
+              <Icon className="size-3" />
+              {label}
+              <span className="font-table text-[10px] font-semibold tabular-nums">
+                {exceptions[id]}
+              </span>
+            </button>
+          );
+        })
+      )}
+      {focus && (
+        <div className="ml-auto flex items-center gap-0.5">
+          <span className="mr-1 font-table text-[10px] text-muted-foreground tabular-nums">
+            {matchCount === 0 ? "No matches" : `${matchIndex + 1} / ${matchCount}`}
+          </span>
+          <button
+            type="button"
+            aria-label="Previous match"
+            disabled={matchCount === 0}
+            onClick={() => onStep(-1)}
+            className="flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+          >
+            <ChevronLeftIcon className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            aria-label="Next match"
+            disabled={matchCount === 0}
+            onClick={() => onStep(1)}
+            className="flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+          >
+            <ChevronRightIcon className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            aria-label="Clear focus"
+            onClick={() => onFocusChange(null)}
+            className="ml-0.5 flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <XIcon className="size-3.5" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/routes/shipment/_components/command-center/timeline/index.tsx
+++ b/client/src/routes/shipment/_components/command-center/timeline/index.tsx
@@ -35,9 +35,10 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { toast } from "sonner";
 import { AssignmentDialog } from "../../assignment-dialog";
 import { useCommandCenterStore } from "../store";
-import { useCommandCenterUrl, type TimelineZoom } from "../url-state";
+import { useCommandCenterUrl, type TimelineSort, type TimelineZoom } from "../url-state";
 import type { CommandCenterTableSummary } from "../command-center-table";
 import { RAIL_WIDTH_PX, rowHeightPx } from "./constants";
+import { ExceptionStrip } from "./exception-strip";
 import {
   buildDayColumns,
   buildHourTicks,
@@ -53,9 +54,12 @@ import { TimelineRowItem } from "./timeline-row";
 import { TimelineToolbar } from "./timeline-toolbar";
 import { BarDetailPopover } from "./bar-detail-popover";
 import {
+  barMatchesFocus,
+  sortTimelineRows,
   UNASSIGNED_ROW_KEY,
   useTimelineData,
   type TimelineBar,
+  type TimelineFocus,
   type TimelineRow,
 } from "./use-timeline-data";
 
@@ -66,6 +70,22 @@ type PendingAssignment = {
   existingAssignment: TimelineBar["assignment"];
   prefill: Partial<AssignmentPayload> | null;
 };
+
+type FocusMatch = {
+  rowIndex: number;
+  bar: TimelineBar;
+};
+
+function computeFocusMatches(rows: TimelineRow[], focus: TimelineFocus | null): FocusMatch[] {
+  if (!focus) return [];
+  const matches: FocusMatch[] = [];
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    for (const bar of rows[rowIndex].bars) {
+      if (barMatchesFocus(bar, focus)) matches.push({ rowIndex, bar });
+    }
+  }
+  return matches;
+}
 
 type CommandCenterTimelineProps = {
   fieldFilters: FieldFilter[];
@@ -80,12 +100,17 @@ export default function CommandCenterTimeline({
   query,
   onSummaryChange,
 }: CommandCenterTimelineProps) {
-  const [{ at, zoom }, setUrl] = useCommandCenterUrl();
+  const [{ at, zoom, tsort }, setUrl] = useCommandCenterUrl();
   const [, setPanelParams] = useQueryStates(panelSearchParamsParser);
   const queryClient = useQueryClient();
 
   const highlightId = useCommandCenterStore.use.highlightId();
   const setHighlightId = useCommandCenterStore.use.setHighlightId();
+  const collapsedRowKeys = useCommandCenterStore.use.collapsedRowKeys();
+  const toggleRowCollapsed = useCommandCenterStore.use.toggleRowCollapsed();
+  const setCollapsedRowKeys = useCommandCenterStore.use.setCollapsedRowKeys();
+  const density = useCommandCenterStore.use.timelineDensity();
+  const setDensity = useCommandCenterStore.use.setTimelineDensity();
   const canAssign = usePermissionStore((state) =>
     state.hasPermission(Resource.Shipment, Operation.Update),
   );
@@ -108,6 +133,7 @@ export default function CommandCenterTimeline({
     fieldFilters,
     filterGroups,
     query,
+    now,
     enabled: true,
   });
 
@@ -127,23 +153,35 @@ export default function CommandCenterTimeline({
     onSummaryChange,
   ]);
 
-  const displayRows = useMemo<TimelineRow[]>(
-    () => (data.unassignedRow ? [data.unassignedRow, ...data.rows] : data.rows),
-    [data.unassignedRow, data.rows],
-  );
+  const displayRows = useMemo<TimelineRow[]>(() => {
+    const sorted = sortTimelineRows(data.rows, tsort);
+    return data.unassignedRow ? [data.unassignedRow, ...sorted] : sorted;
+  }, [data.unassignedRow, data.rows, tsort]);
+
+  const [focus, setFocus] = useState<TimelineFocus | null>(null);
+  const [matchIndex, setMatchIndex] = useState(0);
+  const matches = useMemo(() => computeFocusMatches(displayRows, focus), [displayRows, focus]);
+  const safeMatchIndex = matches.length > 0 ? Math.min(matchIndex, matches.length - 1) : -1;
+
+  useEffect(() => {
+    if (focus && data.exceptions[focus] === 0) setFocus(null);
+  }, [focus, data.exceptions]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const rowVirtualizer = useVirtualizer({
     count: displayRows.length,
     getScrollElement: () => scrollRef.current,
-    estimateSize: (index) => rowHeightPx(displayRows[index].laneCount),
+    estimateSize: (index) => {
+      const row = displayRows[index];
+      return rowHeightPx(row.laneCount, density, !!collapsedRowKeys[row.key]);
+    },
     getItemKey: (index) => displayRows[index].key,
     overscan: 6,
   });
 
   useEffect(() => {
     rowVirtualizer.measure();
-  }, [displayRows, rowVirtualizer]);
+  }, [displayRows, density, collapsedRowKeys, rowVirtualizer]);
 
   const rangeKey = `${range.start}:${zoom}`;
   useLayoutEffect(() => {
@@ -169,6 +207,56 @@ export default function CommandCenterTimeline({
   const suppressClickRef = useRef(false);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+
+  const scrollToMatch = useCallback(
+    (match: FocusMatch) => {
+      rowVirtualizer.scrollToIndex(match.rowIndex, { align: "center" });
+      const el = scrollRef.current;
+      if (el) {
+        const x = secondsToX(match.bar.start, range, zoom);
+        el.scrollLeft = Math.max(0, RAIL_WIDTH_PX + x - el.clientWidth / 3);
+      }
+      setHighlightId(match.bar.shipment.id ?? null);
+    },
+    [range, zoom, rowVirtualizer, setHighlightId],
+  );
+
+  const handleFocusChange = useCallback(
+    (next: TimelineFocus | null) => {
+      setFocus(next);
+      setMatchIndex(0);
+      if (!next) {
+        setHighlightId(null);
+        return;
+      }
+      const nextMatches = computeFocusMatches(displayRows, next);
+      if (nextMatches.length > 0) scrollToMatch(nextMatches[0]);
+    },
+    [displayRows, scrollToMatch, setHighlightId],
+  );
+
+  const handleFocusStep = useCallback(
+    (direction: 1 | -1) => {
+      if (matches.length === 0) return;
+      const current = safeMatchIndex < 0 ? 0 : safeMatchIndex;
+      const next = (current + direction + matches.length) % matches.length;
+      setMatchIndex(next);
+      scrollToMatch(matches[next]);
+    },
+    [matches, safeMatchIndex, scrollToMatch],
+  );
+
+  const allCollapsed =
+    displayRows.length > 0 && displayRows.every((row) => !!collapsedRowKeys[row.key]);
+  const handleToggleCollapseAll = useCallback(() => {
+    if (allCollapsed) {
+      setCollapsedRowKeys({});
+      return;
+    }
+    const next: Record<string, true> = {};
+    for (const row of displayRows) next[row.key] = true;
+    setCollapsedRowKeys(next);
+  }, [allCollapsed, displayRows, setCollapsedRowKeys]);
 
   const handleSelectBar = useCallback((bar: TimelineBar, anchorEl: HTMLElement) => {
     if (suppressClickRef.current) {
@@ -264,6 +352,45 @@ export default function CommandCenterTimeline({
     (next: TimelineZoom) => void setUrl({ zoom: next === "day" ? null : next }),
     [setUrl],
   );
+  const handleSortChange = useCallback(
+    (next: TimelineSort) => void setUrl({ tsort: next === "name" ? null : next }),
+    [setUrl],
+  );
+
+  const hasModalOpen = !!pendingAssignment || !!pendingUnassign;
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
+      if (hasModalOpen) return;
+      const target = event.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.tagName === "SELECT" ||
+          target.isContentEditable ||
+          target.closest('[role="dialog"]'))
+      ) {
+        return;
+      }
+
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        handleShift(-1);
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        handleShift(1);
+      } else if (event.key === "t" || event.key === "T") {
+        handleToday();
+      } else if (event.key === "Escape") {
+        setSelectedBar(null);
+        setFocus(null);
+        setHighlightId(null);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [handleShift, handleToday, hasModalOpen, setHighlightId]);
 
   const isInitialLoading = dataQuery.isLoading;
   const isEmpty = !isInitialLoading && !dataQuery.isError && displayRows.length === 0;
@@ -274,6 +401,9 @@ export default function CommandCenterTimeline({
       <TimelineToolbar
         anchor={anchor}
         zoom={zoom}
+        sort={tsort}
+        density={density}
+        allCollapsed={allCollapsed}
         barCount={data.barCount}
         shipmentCount={data.shipmentCount}
         totalCount={data.totalCount}
@@ -283,7 +413,21 @@ export default function CommandCenterTimeline({
         onToday={handleToday}
         onAnchorSelect={handleAnchorSelect}
         onZoomChange={handleZoomChange}
+        onSortChange={handleSortChange}
+        onDensityChange={setDensity}
+        onToggleCollapseAll={handleToggleCollapseAll}
       />
+
+      {!isInitialLoading && !dataQuery.isError && displayRows.length > 0 && (
+        <ExceptionStrip
+          exceptions={data.exceptions}
+          focus={focus}
+          matchCount={matches.length}
+          matchIndex={safeMatchIndex}
+          onFocusChange={handleFocusChange}
+          onStep={handleFocusStep}
+        />
+      )}
 
       <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
         <div
@@ -346,10 +490,14 @@ export default function CommandCenterTimeline({
                           row={row}
                           range={range}
                           zoom={zoom}
+                          density={density}
+                          collapsed={!!collapsedRowKeys[row.key]}
+                          focus={focus}
                           canvasWidth={canvasWidth}
                           highlightId={highlightId}
                           draggable={canAssign}
                           droppable={canAssign}
+                          onToggleCollapsed={toggleRowCollapsed}
                           onHoverChange={setHighlightId}
                           onSelectBar={handleSelectBar}
                         />

--- a/client/src/routes/shipment/_components/command-center/timeline/timeline-bar.tsx
+++ b/client/src/routes/shipment/_components/command-center/timeline/timeline-bar.tsx
@@ -1,13 +1,13 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { formatToUserTimezone } from "@/lib/date";
+import { formatDurationFromSeconds, formatToUserTimezone } from "@/lib/date";
 import { getDestinationLocation, getOriginLocation, type ShipmentEtaTone } from "@/lib/shipment-utils";
 import { cn } from "@/lib/utils";
 import { useDraggable } from "@dnd-kit/core";
-import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
-import { BAR_HEIGHT_PX, LANE_HEIGHT_PX, ROW_PADDING_PX } from "./constants";
+import { ChevronLeftIcon, ChevronRightIcon, TimerIcon } from "lucide-react";
+import { DENSITY_CONFIGS, type TimelineDensity } from "./constants";
 import { getBarGeometry, type TimeRange } from "./time-scale";
 import type { TimelineZoom } from "../url-state";
-import type { TimelineBar } from "./use-timeline-data";
+import type { TimelineBar, TimelineStopMarker } from "./use-timeline-data";
 
 const BAR_TONE_CLASS: Record<ShipmentEtaTone, string> = {
   ontime: "border-brand/45 bg-brand/12 hover:bg-brand/20",
@@ -36,11 +36,27 @@ function formatTime(seconds: number) {
   return formatToUserTimezone(seconds, { showTimeZone: false, showSeconds: false });
 }
 
+function stopTimesLabel(stop: TimelineStopMarker): string {
+  const parts: string[] = [];
+  if (stop.scheduledStart) {
+    parts.push(
+      stop.scheduledEnd && stop.scheduledEnd !== stop.scheduledStart
+        ? `win ${formatTime(stop.scheduledStart)}–${formatTime(stop.scheduledEnd)}`
+        : formatTime(stop.scheduledStart),
+    );
+  }
+  if (stop.actualArrival) parts.push(`arr ${formatTime(stop.actualArrival)}`);
+  if (stop.actualDeparture) parts.push(`dep ${formatTime(stop.actualDeparture)}`);
+  return parts.join(" · ");
+}
+
 type TimelineBarItemProps = {
   bar: TimelineBar;
   range: TimeRange;
   zoom: TimelineZoom;
+  density: TimelineDensity;
   isHighlighted: boolean;
+  dimmed: boolean;
   draggable: boolean;
   onHoverChange: (shipmentId: string | null) => void;
   onSelect: (bar: TimelineBar, anchor: HTMLElement) => void;
@@ -50,7 +66,9 @@ export function TimelineBarItem({
   bar,
   range,
   zoom,
+  density,
   isHighlighted,
+  dimmed,
   draggable,
   onHoverChange,
   onSelect,
@@ -62,12 +80,14 @@ export function TimelineBarItem({
     disabled: !draggable,
   });
 
+  const { laneHeightPx, barHeightPx, rowPaddingPx } = DENSITY_CONFIGS[density];
   const shipment = bar.shipment;
   const originCode = getOriginLocation(shipment)?.code ?? "—";
   const destCode = getDestinationLocation(shipment)?.code ?? "—";
   const completedStops = bar.stops.filter((s) => s.status === "Completed").length;
   const progress = bar.stops.length > 0 ? completedStops / bar.stops.length : 0;
   const showLabel = geometry.width >= 72;
+  const showDwellBadge = !!bar.dwell && geometry.width >= 40;
   const barSpanSeconds = Math.max(bar.end - bar.start, 1);
 
   return (
@@ -85,14 +105,15 @@ export function TimelineBarItem({
           BAR_TONE_CLASS[bar.tone],
           bar.isCanceled && "border-dashed opacity-60",
           isHighlighted && "shadow-md ring-1 ring-foreground/25",
+          dimmed && "opacity-25",
           isDragging && "opacity-40",
           draggable && "cursor-grab active:cursor-grabbing",
         )}
         style={{
           left: geometry.left,
           width: geometry.width,
-          height: BAR_HEIGHT_PX,
-          top: ROW_PADDING_PX / 2 + bar.laneIndex * LANE_HEIGHT_PX + (LANE_HEIGHT_PX - BAR_HEIGHT_PX) / 2,
+          height: barHeightPx,
+          top: rowPaddingPx / 2 + bar.laneIndex * laneHeightPx + (laneHeightPx - barHeightPx) / 2,
         }}
       >
         {geometry.clippedStart && (
@@ -111,8 +132,25 @@ export function TimelineBarItem({
             </span>
           </span>
         )}
+        {showDwellBadge && bar.dwell && (
+          <span
+            aria-hidden
+            className={cn(
+              "ml-auto flex shrink-0 items-center gap-0.5 rounded-sm px-1 py-px font-table text-[8.5px] font-semibold tabular-nums",
+              bar.dwell.severity === "critical"
+                ? "bg-destructive/90 text-white"
+                : "bg-warning/90 text-white",
+            )}
+          >
+            <TimerIcon className="size-2.5 animate-pulse" />
+            {geometry.width >= 96 && formatDurationFromSeconds(bar.dwell.seconds)}
+          </span>
+        )}
         {geometry.clippedEnd && (
-          <ChevronRightIcon className="ml-auto size-3 shrink-0 text-muted-foreground" aria-hidden />
+          <ChevronRightIcon
+            className={cn("size-3 shrink-0 text-muted-foreground", !showDwellBadge && "ml-auto")}
+            aria-hidden
+          />
         )}
         {bar.stops.map((stop) => {
           const offset = ((Math.min(Math.max(stop.time, bar.start), bar.end) - bar.start) /
@@ -138,7 +176,7 @@ export function TimelineBarItem({
           />
         )}
       </TooltipTrigger>
-      <TooltipContent side="top" className="max-w-64">
+      <TooltipContent side="top" className="max-w-72">
         <div className="flex flex-col gap-1 py-0.5">
           <p className="font-table text-[11px] font-semibold tabular-nums">
             {shipment.proNumber ?? "—"}
@@ -147,10 +185,26 @@ export function TimelineBarItem({
             </span>
           </p>
           <p className="text-[10.5px] opacity-80">{shipment.customer?.name ?? "No customer"}</p>
+          {bar.dwell && (
+            <p
+              className={cn(
+                "flex items-center gap-1 text-[10.5px] font-semibold",
+                bar.dwell.severity === "critical" ? "text-destructive" : "text-warning",
+              )}
+            >
+              <TimerIcon className="size-3" />
+              Dwelling {formatDurationFromSeconds(bar.dwell.seconds)} at {bar.dwell.locationCode}
+            </p>
+          )}
+          {bar.hasOverlap && (
+            <p className="text-[10.5px] font-semibold text-warning">
+              Overlaps another load on this driver
+            </p>
+          )}
           <div className="mt-0.5 flex flex-col gap-0.5">
             {bar.stops.map((stop) => (
               <p key={stop.id} className="font-table text-[10px] tabular-nums opacity-80">
-                {STOP_LABEL[stop.type]} · {stop.locationCode} · {formatTime(stop.time)}
+                {STOP_LABEL[stop.type]} · {stop.locationCode} · {stopTimesLabel(stop)}
               </p>
             ))}
           </div>

--- a/client/src/routes/shipment/_components/command-center/timeline/timeline-row.tsx
+++ b/client/src/routes/shipment/_components/command-center/timeline/timeline-row.tsx
@@ -1,12 +1,33 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
 import { useDroppable } from "@dnd-kit/core";
-import { InboxIcon } from "lucide-react";
-import { RAIL_WIDTH_PX, rowHeightPx } from "./constants";
+import { ChevronDownIcon, ChevronRightIcon, InboxIcon } from "lucide-react";
+import {
+  COLLAPSED_BAR_HEIGHT_PX,
+  RAIL_WIDTH_PX,
+  rowHeightPx,
+  type TimelineDensity,
+} from "./constants";
 import { TimelineBarItem } from "./timeline-bar";
-import type { TimeRange } from "./time-scale";
+import { getBarGeometry, type TimeRange } from "./time-scale";
 import type { TimelineZoom } from "../url-state";
-import { UNASSIGNED_ROW_KEY, type TimelineBar, type TimelineRow } from "./use-timeline-data";
+import {
+  barMatchesFocus,
+  UNASSIGNED_ROW_KEY,
+  type TimelineBar,
+  type TimelineFocus,
+  type TimelineRow,
+  type TimelineRowStats,
+} from "./use-timeline-data";
+import type { ShipmentEtaTone } from "@/lib/shipment-utils";
+
+const STRIP_TONE_CLASS: Record<ShipmentEtaTone, string> = {
+  ontime: "bg-brand/50 hover:bg-brand/70",
+  watch: "bg-warning/60 hover:bg-warning/80",
+  late: "bg-destructive/60 hover:bg-destructive/80",
+  delivered: "bg-success/50 hover:bg-success/70",
+  pending: "bg-muted-foreground/30 hover:bg-muted-foreground/50",
+};
 
 function workerInitials(name: string): string {
   const parts = name.split(/\s+/).filter(Boolean);
@@ -15,14 +36,27 @@ function workerInitials(name: string): string {
   return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
 }
 
+function alertTitle(stats: TimelineRowStats): string {
+  const parts: string[] = [];
+  if (stats.late > 0) parts.push(`${stats.late} late`);
+  if (stats.watch > 0) parts.push(`${stats.watch} at watch`);
+  if (stats.dwelling > 0) parts.push(`${stats.dwelling} dwelling`);
+  if (stats.overlaps > 0) parts.push(`${stats.overlaps} overlapping`);
+  return parts.join(" · ");
+}
+
 type TimelineRowItemProps = {
   row: TimelineRow;
   range: TimeRange;
   zoom: TimelineZoom;
+  density: TimelineDensity;
+  collapsed: boolean;
+  focus: TimelineFocus | null;
   canvasWidth: number;
   highlightId: string | null;
   draggable: boolean;
   droppable: boolean;
+  onToggleCollapsed: (key: string) => void;
   onHoverChange: (shipmentId: string | null) => void;
   onSelectBar: (bar: TimelineBar, anchor: HTMLElement) => void;
 };
@@ -31,10 +65,14 @@ export function TimelineRowItem({
   row,
   range,
   zoom,
+  density,
+  collapsed,
+  focus,
   canvasWidth,
   highlightId,
   draggable,
   droppable,
+  onToggleCollapsed,
   onHoverChange,
   onSelectBar,
 }: TimelineRowItemProps) {
@@ -52,6 +90,7 @@ export function TimelineRowItem({
       ? !!activeBar.assignment
       : activeBar.assignment?.primaryWorker?.id !== row.key);
   const showDropHint = isOver && isValidTarget;
+  const height = rowHeightPx(row.laneCount, density, collapsed);
 
   return (
     <div
@@ -61,62 +100,174 @@ export function TimelineRowItem({
         isUnassigned && "bg-warning/[4%]",
         showDropHint && "bg-brand/10",
       )}
-      style={{ height: rowHeightPx(row.laneCount) }}
+      style={{ height }}
     >
       <div
         className={cn(
-          "sticky left-0 z-30 flex shrink-0 items-center gap-2 border-r border-border bg-card px-2.5",
+          "sticky left-0 z-30 flex shrink-0 items-center gap-1.5 border-r border-border bg-card pr-2.5 pl-1",
           isUnassigned && "bg-[color-mix(in_oklch,var(--warning)_5%,var(--card))]",
           showDropHint && "bg-[color-mix(in_oklch,var(--brand)_8%,var(--card))]",
         )}
         style={{ width: RAIL_WIDTH_PX }}
       >
-        {isUnassigned ? (
-          <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-warning/15 text-warning">
-            <InboxIcon className="size-3.5" />
-          </span>
-        ) : (
-          <Avatar className="size-6 shrink-0">
-            {row.workerProfilePicUrl && (
-              <AvatarImage src={row.workerProfilePicUrl} alt={row.workerName} />
-            )}
-            <AvatarFallback className="text-[9px]">{workerInitials(row.workerName)}</AvatarFallback>
-          </Avatar>
-        )}
+        <button
+          type="button"
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? `Expand ${row.workerName}` : `Collapse ${row.workerName}`}
+          onClick={() => onToggleCollapsed(row.key)}
+          className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          {collapsed ? (
+            <ChevronRightIcon className="size-3.5" />
+          ) : (
+            <ChevronDownIcon className="size-3.5" />
+          )}
+        </button>
+        {!collapsed &&
+          (isUnassigned ? (
+            <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-warning/15 text-warning">
+              <InboxIcon className="size-3.5" />
+            </span>
+          ) : (
+            <Avatar className={cn("shrink-0", density === "compact" ? "size-5" : "size-6")}>
+              {row.workerProfilePicUrl && (
+                <AvatarImage src={row.workerProfilePicUrl} alt={row.workerName} />
+              )}
+              <AvatarFallback className="text-[9px]">
+                {workerInitials(row.workerName)}
+              </AvatarFallback>
+            </Avatar>
+          ))}
         <div className="flex min-w-0 flex-col">
-          <span
-            className={cn(
-              "truncate text-[11.5px] font-medium",
-              isUnassigned && "text-warning",
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span
+              className={cn(
+                "truncate text-[11.5px] font-medium",
+                isUnassigned && "text-warning",
+              )}
+            >
+              {isUnassigned ? "Unassigned" : row.workerName}
+            </span>
+            {row.alert && (
+              <span
+                title={alertTitle(row.stats)}
+                className={cn(
+                  "size-1.5 shrink-0 rounded-full",
+                  row.alert === "late" ? "animate-pulse bg-destructive" : "bg-warning",
+                )}
+              />
             )}
-          >
-            {isUnassigned ? "Unassigned" : row.workerName}
+            {collapsed && (
+              <span className="shrink-0 font-table text-[9.5px] text-muted-foreground tabular-nums">
+                {row.bars.length} {row.bars.length === 1 ? "load" : "loads"}
+              </span>
+            )}
           </span>
-          <span className="truncate font-table text-[9.5px] text-muted-foreground tabular-nums">
-            {isUnassigned
-              ? "Drop here to unassign"
-              : row.equipmentCodes.length > 0
-                ? row.equipmentCodes.join(" · ")
-                : "No tractor"}
-            {" · "}
-            {row.bars.length} {row.bars.length === 1 ? "load" : "loads"}
-          </span>
+          {!collapsed && (
+            <span className="truncate font-table text-[9.5px] text-muted-foreground tabular-nums">
+              {isUnassigned
+                ? "Drop here to unassign"
+                : row.equipmentCodes.length > 0
+                  ? row.equipmentCodes.join(" · ")
+                  : "No tractor"}
+              {" · "}
+              {row.bars.length} {row.bars.length === 1 ? "load" : "loads"}
+            </span>
+          )}
         </div>
       </div>
       <div className="relative shrink-0" style={{ width: canvasWidth }}>
-        {row.bars.map((bar) => (
-          <TimelineBarItem
-            key={bar.moveId}
-            bar={bar}
-            range={range}
-            zoom={zoom}
-            isHighlighted={!!highlightId && highlightId === bar.shipment.id}
-            draggable={draggable}
-            onHoverChange={onHoverChange}
-            onSelect={onSelectBar}
-          />
-        ))}
+        {collapsed
+          ? row.bars.map((bar) => (
+              <CollapsedBarStrip
+                key={bar.moveId}
+                bar={bar}
+                range={range}
+                zoom={zoom}
+                rowHeight={height}
+                dimmed={!!focus && !barMatchesFocus(bar, focus)}
+                isHighlighted={!!highlightId && highlightId === bar.shipment.id}
+                onHoverChange={onHoverChange}
+                onSelect={onSelectBar}
+              />
+            ))
+          : row.bars.map((bar) => (
+              <TimelineBarItem
+                key={bar.moveId}
+                bar={bar}
+                range={range}
+                zoom={zoom}
+                density={density}
+                isHighlighted={!!highlightId && highlightId === bar.shipment.id}
+                dimmed={!!focus && !barMatchesFocus(bar, focus)}
+                draggable={draggable}
+                onHoverChange={onHoverChange}
+                onSelect={onSelectBar}
+              />
+            ))}
       </div>
     </div>
+  );
+}
+
+/**
+ * Collapsed rows keep the shape of the driver's day visible as thin tone
+ * strips: cheap to render (no drag, no portal tooltip), still clickable for
+ * the detail popover.
+ */
+function CollapsedBarStrip({
+  bar,
+  range,
+  zoom,
+  rowHeight,
+  dimmed,
+  isHighlighted,
+  onHoverChange,
+  onSelect,
+}: {
+  bar: TimelineBar;
+  range: TimeRange;
+  zoom: TimelineZoom;
+  rowHeight: number;
+  dimmed: boolean;
+  isHighlighted: boolean;
+  onHoverChange: (shipmentId: string | null) => void;
+  onSelect: (bar: TimelineBar, anchor: HTMLElement) => void;
+}) {
+  const geometry = getBarGeometry(bar.start, bar.end, range, zoom);
+  const proNumber = bar.shipment.proNumber ?? bar.shipment.bol ?? "Shipment";
+
+  return (
+    <button
+      type="button"
+      title={bar.dwell ? `${proNumber} · dwelling` : proNumber}
+      aria-label={`Shipment ${proNumber}`}
+      onClick={(event) => onSelect(bar, event.currentTarget as HTMLElement)}
+      onMouseEnter={() => bar.shipment.id && onHoverChange(bar.shipment.id)}
+      onMouseLeave={() => onHoverChange(null)}
+      className={cn(
+        "absolute cursor-pointer rounded-sm transition-[background-color,opacity] outline-none focus-visible:ring-2 focus-visible:ring-brand",
+        STRIP_TONE_CLASS[bar.tone],
+        bar.isCanceled && "opacity-40",
+        dimmed && "opacity-20",
+        isHighlighted && "ring-1 ring-foreground/40",
+      )}
+      style={{
+        left: geometry.left,
+        width: geometry.width,
+        height: COLLAPSED_BAR_HEIGHT_PX,
+        top: (rowHeight - COLLAPSED_BAR_HEIGHT_PX) / 2,
+      }}
+    >
+      {bar.dwell && (
+        <span
+          aria-hidden
+          className={cn(
+            "absolute -top-0.5 -right-0.5 size-1.5 animate-pulse rounded-full",
+            bar.dwell.severity === "critical" ? "bg-destructive" : "bg-warning",
+          )}
+        />
+      )}
+    </button>
   );
 }

--- a/client/src/routes/shipment/_components/command-center/timeline/timeline-toolbar.tsx
+++ b/client/src/routes/shipment/_components/command-center/timeline/timeline-toolbar.tsx
@@ -1,12 +1,30 @@
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
-import { CalendarIcon, ChevronLeftIcon, ChevronRightIcon, TriangleAlertIcon } from "lucide-react";
+import {
+  ArrowDownUpIcon,
+  CalendarIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronsDownUpIcon,
+  ChevronsUpDownIcon,
+  Rows2Icon,
+  Rows3Icon,
+  TriangleAlertIcon,
+} from "lucide-react";
 import { useState } from "react";
+import type { TimelineDensity } from "./constants";
 import { formatRangeLabel, isTodayAnchor, ZOOM_OPTIONS } from "./time-scale";
-import type { TimelineZoom } from "../url-state";
+import type { TimelineSort, TimelineZoom } from "../url-state";
 
 const LEGEND_ITEMS: readonly { label: string; dotClass: string }[] = [
   { label: "On time", dotClass: "bg-brand" },
@@ -15,9 +33,18 @@ const LEGEND_ITEMS: readonly { label: string; dotClass: string }[] = [
   { label: "Delivered", dotClass: "bg-success" },
 ] as const;
 
+const SORT_OPTIONS: readonly { id: TimelineSort; label: string }[] = [
+  { id: "name", label: "Driver name" },
+  { id: "exceptions", label: "Exceptions first" },
+  { id: "loads", label: "Most loads" },
+] as const;
+
 type TimelineToolbarProps = {
   anchor: Date;
   zoom: TimelineZoom;
+  sort: TimelineSort;
+  density: TimelineDensity;
+  allCollapsed: boolean;
   barCount: number;
   shipmentCount: number;
   totalCount: number;
@@ -27,11 +54,17 @@ type TimelineToolbarProps = {
   onToday: () => void;
   onAnchorSelect: (date: Date) => void;
   onZoomChange: (zoom: TimelineZoom) => void;
+  onSortChange: (sort: TimelineSort) => void;
+  onDensityChange: (density: TimelineDensity) => void;
+  onToggleCollapseAll: () => void;
 };
 
 export function TimelineToolbar({
   anchor,
   zoom,
+  sort,
+  density,
+  allCollapsed,
   barCount,
   shipmentCount,
   totalCount,
@@ -41,8 +74,12 @@ export function TimelineToolbar({
   onToday,
   onAnchorSelect,
   onZoomChange,
+  onSortChange,
+  onDensityChange,
+  onToggleCollapseAll,
 }: TimelineToolbarProps) {
   const [calendarOpen, setCalendarOpen] = useState(false);
+  const isCompact = density === "compact";
 
   return (
     <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-1.5">
@@ -52,6 +89,7 @@ export function TimelineToolbar({
           variant="ghost"
           size="icon-xs"
           aria-label="Previous period"
+          title="Previous period (←)"
           onClick={() => onShift(-1)}
         >
           <ChevronLeftIcon className="size-3.5" />
@@ -60,6 +98,7 @@ export function TimelineToolbar({
           type="button"
           variant="outline"
           size="xxs"
+          title="Jump to today (T)"
           onClick={onToday}
           disabled={isTodayAnchor(anchor)}
         >
@@ -70,6 +109,7 @@ export function TimelineToolbar({
           variant="ghost"
           size="icon-xs"
           aria-label="Next period"
+          title="Next period (→)"
           onClick={() => onShift(1)}
         >
           <ChevronRightIcon className="size-3.5" />
@@ -121,6 +161,62 @@ export function TimelineToolbar({
             {option.label}
           </button>
         ))}
+      </div>
+
+      <div className="flex items-center gap-0.5">
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Sort rows"
+                title={`Sort · ${SORT_OPTIONS.find((o) => o.id === sort)?.label}`}
+              />
+            }
+          >
+            <ArrowDownUpIcon className={cn("size-3.5", sort !== "name" && "text-brand")} />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-40">
+            <DropdownMenuRadioGroup
+              value={sort}
+              onValueChange={(value) => onSortChange(value as TimelineSort)}
+            >
+              {SORT_OPTIONS.map((option) => (
+                <DropdownMenuRadioItem key={option.id} value={option.id}>
+                  {option.label}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label={isCompact ? "Switch to comfortable rows" : "Switch to compact rows"}
+          title={isCompact ? "Switch to comfortable rows" : "Switch to compact rows"}
+          onClick={() => onDensityChange(isCompact ? "comfortable" : "compact")}
+        >
+          {isCompact ? <Rows2Icon className="size-3.5" /> : <Rows3Icon className="size-3.5" />}
+        </Button>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label={allCollapsed ? "Expand all rows" : "Collapse all rows"}
+          title={allCollapsed ? "Expand all rows" : "Collapse all rows"}
+          onClick={onToggleCollapseAll}
+        >
+          {allCollapsed ? (
+            <ChevronsUpDownIcon className="size-3.5" />
+          ) : (
+            <ChevronsDownUpIcon className="size-3.5" />
+          )}
+        </Button>
       </div>
 
       <div className="ml-auto flex items-center gap-3">

--- a/client/src/routes/shipment/_components/command-center/timeline/use-timeline-data.test.ts
+++ b/client/src/routes/shipment/_components/command-center/timeline/use-timeline-data.test.ts
@@ -1,8 +1,15 @@
 import type { Shipment } from "@/types/shipment";
 import { describe, expect, it } from "vitest";
-import { buildTimelineData, UNASSIGNED_ROW_KEY } from "./use-timeline-data";
+import {
+  buildTimelineData,
+  DWELL_CRITICAL_SECONDS,
+  DWELL_WATCH_SECONDS,
+  sortTimelineRows,
+  UNASSIGNED_ROW_KEY,
+} from "./use-timeline-data";
 
 const RANGE = { start: 1_000_000, end: 1_086_400 }; // one-day window
+const NOW = RANGE.start;
 
 type StopSeed = {
   start: number;
@@ -87,7 +94,7 @@ describe("buildTimelineData", () => {
       ]),
     ];
 
-    const data = buildTimelineData(shipments, 2, RANGE);
+    const data = buildTimelineData(shipments, 2, RANGE, NOW);
 
     expect(data.rows).toHaveLength(1);
     expect(data.rows[0].workerName).toBe("Alice Driver");
@@ -117,7 +124,7 @@ describe("buildTimelineData", () => {
       ]),
     ];
 
-    const data = buildTimelineData(shipments, 2, RANGE);
+    const data = buildTimelineData(shipments, 2, RANGE, NOW);
 
     expect(data.rows).toHaveLength(1);
     expect(data.rows[0].laneCount).toBe(2);
@@ -137,7 +144,7 @@ describe("buildTimelineData", () => {
       ]),
     ];
 
-    const data = buildTimelineData(shipments, 1, RANGE);
+    const data = buildTimelineData(shipments, 1, RANGE, NOW);
 
     expect(data.rows).toHaveLength(1);
     expect(data.rows[0].workerName).toBe("Alice Driver");
@@ -161,7 +168,7 @@ describe("buildTimelineData", () => {
       ]),
     ];
 
-    const data = buildTimelineData(shipments, 1, RANGE);
+    const data = buildTimelineData(shipments, 1, RANGE, NOW);
 
     expect(data.rows[0].bars[0].start).toBe(RANGE.start + 8000);
     expect(data.rows[0].bars[0].end).toBe(RANGE.start + 13_000);
@@ -192,7 +199,7 @@ describe("buildTimelineData", () => {
       ]),
     ];
 
-    const data = buildTimelineData(shipments, 2, RANGE);
+    const data = buildTimelineData(shipments, 2, RANGE, NOW);
 
     const aliceRow = data.rows.find((r) => r.key === "wkr_a");
     expect(aliceRow?.bars.map((b) => b.moveId)).toEqual(["mov_live"]);
@@ -214,14 +221,167 @@ describe("buildTimelineData", () => {
       ]),
     ];
 
-    const data = buildTimelineData(shipments, 1, RANGE);
+    const data = buildTimelineData(shipments, 1, RANGE, NOW);
 
     expect(data.rows).toHaveLength(0);
     expect(data.barCount).toBe(0);
   });
 
   it("flags truncation when the server reports more matches than fetched", () => {
-    const data = buildTimelineData([], 400, RANGE);
+    const data = buildTimelineData([], 400, RANGE, NOW);
     expect(data.truncated).toBe(true);
+  });
+
+  it("detects dwell on arrived-but-not-departed stops with severity tiers", () => {
+    const arrival = RANGE.start + 1000;
+    const shipments = [
+      makeShipment("shp_1", "InTransit", [
+        {
+          id: "mov_1",
+          workerId: "wkr_a",
+          stops: [{ start: RANGE.start + 1000, end: RANGE.start + 5000, actualArrival: arrival }],
+        },
+      ]),
+    ];
+
+    const belowThreshold = buildTimelineData(
+      shipments,
+      1,
+      RANGE,
+      arrival + DWELL_WATCH_SECONDS - 60,
+    );
+    expect(belowThreshold.rows[0].bars[0].dwell).toBeNull();
+    expect(belowThreshold.exceptions.dwelling).toBe(0);
+
+    const watching = buildTimelineData(shipments, 1, RANGE, arrival + DWELL_WATCH_SECONDS + 60);
+    expect(watching.rows[0].bars[0].dwell?.severity).toBe("watch");
+    expect(watching.rows[0].bars[0].dwell?.locationCode).toBe("LOC0");
+    expect(watching.exceptions.dwelling).toBe(1);
+    expect(watching.rows[0].alert).toBe("watch");
+
+    const critical = buildTimelineData(shipments, 1, RANGE, arrival + DWELL_CRITICAL_SECONDS + 60);
+    expect(critical.rows[0].bars[0].dwell?.severity).toBe("critical");
+    expect(critical.rows[0].alert).toBe("late");
+  });
+
+  it("does not flag dwell once the stop has departed", () => {
+    const arrival = RANGE.start + 1000;
+    const shipments = [
+      makeShipment("shp_1", "InTransit", [
+        {
+          id: "mov_1",
+          workerId: "wkr_a",
+          stops: [
+            {
+              start: RANGE.start + 1000,
+              end: RANGE.start + 5000,
+              actualArrival: arrival,
+              actualDeparture: arrival + 600,
+            },
+          ],
+        },
+      ]),
+    ];
+
+    const data = buildTimelineData(shipments, 1, RANGE, arrival + DWELL_CRITICAL_SECONDS * 2);
+    expect(data.rows[0].bars[0].dwell).toBeNull();
+  });
+
+  it("flags overlapping live moves on a driver but never the unassigned lane", () => {
+    const shipments = [
+      makeShipment("shp_1", "Assigned", [
+        {
+          id: "mov_1",
+          workerId: "wkr_a",
+          stops: [{ start: RANGE.start + 1000, end: RANGE.start + 30_000 }],
+        },
+      ]),
+      makeShipment("shp_2", "Assigned", [
+        {
+          id: "mov_2",
+          workerId: "wkr_a",
+          stops: [{ start: RANGE.start + 5000, end: RANGE.start + 20_000 }],
+        },
+      ]),
+      makeShipment("shp_3", "New", [
+        { id: "mov_3", stops: [{ start: RANGE.start + 1000, end: RANGE.start + 30_000 }] },
+      ]),
+      makeShipment("shp_4", "New", [
+        { id: "mov_4", stops: [{ start: RANGE.start + 5000, end: RANGE.start + 20_000 }] },
+      ]),
+    ];
+
+    const data = buildTimelineData(shipments, 4, RANGE, NOW);
+
+    expect(data.rows[0].bars.every((bar) => bar.hasOverlap)).toBe(true);
+    expect(data.rows[0].stats.overlaps).toBe(2);
+    expect(data.unassignedRow?.bars.every((bar) => !bar.hasOverlap)).toBe(true);
+    expect(data.exceptions.overlaps).toBe(2);
+    expect(data.exceptions.unassigned).toBe(2);
+  });
+
+  it("counts late loads and marks the row alert", () => {
+    const shipments = [
+      makeShipment("shp_1", "Delayed", [
+        {
+          id: "mov_1",
+          workerId: "wkr_a",
+          workerName: "Alice Driver",
+          stops: [{ start: RANGE.start + 1000, end: RANGE.start + 5000 }],
+        },
+      ]),
+    ];
+
+    const data = buildTimelineData(shipments, 1, RANGE, NOW);
+
+    expect(data.rows[0].bars[0].tone).toBe("late");
+    expect(data.rows[0].stats.late).toBe(1);
+    expect(data.rows[0].alert).toBe("late");
+    expect(data.exceptions.late).toBe(1);
+  });
+});
+
+describe("sortTimelineRows", () => {
+  const shipments = [
+    makeShipment("shp_1", "Delayed", [
+      {
+        id: "mov_1",
+        workerId: "wkr_a",
+        workerName: "Alice Driver",
+        stops: [{ start: RANGE.start + 1000, end: RANGE.start + 5000 }],
+      },
+    ]),
+    makeShipment("shp_2", "Assigned", [
+      {
+        id: "mov_2",
+        workerId: "wkr_b",
+        workerName: "Aaron Hauler",
+        stops: [{ start: RANGE.start + 1000, end: RANGE.start + 5000 }],
+      },
+      {
+        id: "mov_3",
+        workerId: "wkr_b",
+        workerName: "Aaron Hauler",
+        stops: [{ start: RANGE.start + 40_000, end: RANGE.start + 50_000 }],
+      },
+    ]),
+  ];
+
+  it("keeps the name order untouched", () => {
+    const data = buildTimelineData(shipments, 2, RANGE, NOW);
+    expect(sortTimelineRows(data.rows, "name")).toBe(data.rows);
+  });
+
+  it("ranks drivers with exceptions first", () => {
+    const data = buildTimelineData(shipments, 2, RANGE, NOW);
+    const sorted = sortTimelineRows(data.rows, "exceptions");
+    expect(sorted.map((row) => row.workerName)).toEqual(["Alice Driver", "Aaron Hauler"]);
+    expect(data.rows.map((row) => row.workerName)).toEqual(["Aaron Hauler", "Alice Driver"]);
+  });
+
+  it("ranks the busiest drivers first", () => {
+    const data = buildTimelineData(shipments, 2, RANGE, NOW);
+    const sorted = sortTimelineRows(data.rows, "loads");
+    expect(sorted.map((row) => row.workerName)).toEqual(["Aaron Hauler", "Alice Driver"]);
   });
 });

--- a/client/src/routes/shipment/_components/command-center/timeline/use-timeline-data.ts
+++ b/client/src/routes/shipment/_components/command-center/timeline/use-timeline-data.ts
@@ -4,6 +4,7 @@ import type { FieldFilter, FilterGroup } from "@/types/data-table";
 import type { Assignment, Shipment, ShipmentMove, Stop } from "@/types/shipment";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
+import type { TimelineSort } from "../url-state";
 import { packLanes, type TimeRange } from "./time-scale";
 
 /**
@@ -16,6 +17,14 @@ const TIMELINE_FETCH_LIMIT = 250;
 
 export const UNASSIGNED_ROW_KEY = "__unassigned__";
 
+/**
+ * Dwell thresholds mirror the industry's typical two-hour free time at a
+ * facility: flag as "watch" when a driver has been sitting long enough that
+ * detention is approaching, and "critical" once the free-time window is blown.
+ */
+export const DWELL_WATCH_SECONDS = 90 * 60;
+export const DWELL_CRITICAL_SECONDS = 120 * 60;
+
 export type TimelineStopMarker = {
   id: string;
   time: number;
@@ -23,6 +32,18 @@ export type TimelineStopMarker = {
   status: Stop["status"];
   locationCode: string;
   locationName: string;
+  scheduledStart: number | null;
+  scheduledEnd: number | null;
+  actualArrival: number | null;
+  actualDeparture: number | null;
+};
+
+export type TimelineDwell = {
+  stopId: string;
+  locationCode: string;
+  locationName: string;
+  seconds: number;
+  severity: "watch" | "critical";
 };
 
 export type TimelineBar = {
@@ -36,7 +57,18 @@ export type TimelineBar = {
   isCanceled: boolean;
   stops: TimelineStopMarker[];
   laneIndex: number;
+  dwell: TimelineDwell | null;
+  hasOverlap: boolean;
 };
+
+export type TimelineRowStats = {
+  late: number;
+  watch: number;
+  dwelling: number;
+  overlaps: number;
+};
+
+export type TimelineRowAlert = "late" | "watch" | null;
 
 export type TimelineRow = {
   key: string;
@@ -45,7 +77,19 @@ export type TimelineRow = {
   equipmentCodes: string[];
   bars: TimelineBar[];
   laneCount: number;
+  stats: TimelineRowStats;
+  alert: TimelineRowAlert;
 };
+
+export type TimelineExceptionSummary = {
+  late: number;
+  watch: number;
+  dwelling: number;
+  overlaps: number;
+  unassigned: number;
+};
+
+export type TimelineFocus = keyof TimelineExceptionSummary;
 
 export type TimelineData = {
   rows: TimelineRow[];
@@ -54,13 +98,51 @@ export type TimelineData = {
   shipmentCount: number;
   totalCount: number;
   truncated: boolean;
+  exceptions: TimelineExceptionSummary;
 };
+
+/**
+ * Rows come out of buildTimelineData sorted by worker name; the other modes
+ * re-rank without mutating the source array. "Exceptions first" weighs a late
+ * load above a dwelling one above a plain watch so the hottest drivers surface
+ * at the top of the board.
+ */
+export function sortTimelineRows(rows: TimelineRow[], sort: TimelineSort): TimelineRow[] {
+  if (sort === "name") return rows;
+  const sorted = [...rows];
+  if (sort === "loads") {
+    sorted.sort(
+      (a, b) => b.bars.length - a.bars.length || a.workerName.localeCompare(b.workerName),
+    );
+    return sorted;
+  }
+  const score = (row: TimelineRow) =>
+    row.stats.late * 100 + row.stats.dwelling * 40 + row.stats.overlaps * 20 + row.stats.watch * 10;
+  sorted.sort((a, b) => score(b) - score(a) || a.workerName.localeCompare(b.workerName));
+  return sorted;
+}
+
+export function barMatchesFocus(bar: TimelineBar, focus: TimelineFocus): boolean {
+  switch (focus) {
+    case "late":
+      return bar.tone === "late" && !bar.isCanceled;
+    case "watch":
+      return bar.tone === "watch" && !bar.isCanceled;
+    case "dwelling":
+      return bar.dwell !== null;
+    case "overlaps":
+      return bar.hasOverlap;
+    case "unassigned":
+      return !bar.assignment && !bar.isCanceled;
+  }
+}
 
 type UseTimelineDataParams = {
   range: TimeRange;
   fieldFilters: FieldFilter[];
   filterGroups: FilterGroup[] | undefined;
   query: string;
+  now: number;
   enabled: boolean;
 };
 
@@ -69,6 +151,7 @@ export function useTimelineData({
   fieldFilters,
   filterGroups,
   query,
+  now,
   enabled,
 }: UseTimelineDataParams) {
   const dataQuery = useQuery({
@@ -100,8 +183,9 @@ export function useTimelineData({
         (queryData?.results ?? []) as Shipment[],
         queryData?.count ?? 0,
         range,
+        now,
       ),
-    [queryData, range],
+    [queryData, range, now],
   );
 
   return { dataQuery, data };
@@ -111,6 +195,7 @@ export function buildTimelineData(
   shipments: Shipment[],
   totalCount: number,
   range: TimeRange,
+  nowSeconds: number,
 ): TimelineData {
   const rowsByKey = new Map<string, TimelineRow>();
   let barCount = 0;
@@ -142,6 +227,8 @@ export function buildTimelineData(
           equipmentCodes: [],
           bars: [],
           laneCount: 1,
+          stats: { late: 0, watch: 0, dwelling: 0, overlaps: 0 },
+          alert: null,
         };
         rowsByKey.set(key, row);
       }
@@ -151,6 +238,7 @@ export function buildTimelineData(
         row.equipmentCodes.push(tractorCode);
       }
 
+      const isCanceled = shipmentCanceled || moveCanceled;
       row.bars.push({
         moveId: move.id ?? `${shipment.id}-${move.sequence}`,
         shipment,
@@ -158,14 +246,24 @@ export function buildTimelineData(
         assignment,
         start: span.start,
         end: span.end,
-        tone: shipmentCanceled || moveCanceled ? "pending" : tone,
-        isCanceled: shipmentCanceled || moveCanceled,
+        tone: isCanceled ? "pending" : tone,
+        isCanceled,
         stops: span.stops,
         laneIndex: 0,
+        dwell: isCanceled ? null : getBarDwell(span.stops, nowSeconds),
+        hasOverlap: false,
       });
       barCount++;
     }
   }
+
+  const exceptions: TimelineExceptionSummary = {
+    late: 0,
+    watch: 0,
+    dwelling: 0,
+    overlaps: 0,
+    unassigned: 0,
+  };
 
   for (const row of rowsByKey.values()) {
     row.bars.sort((a, b) => a.start - b.start || a.end - b.end);
@@ -174,10 +272,40 @@ export function buildTimelineData(
       row.bars[i].laneIndex = packing.laneByIndex[i];
     }
     row.laneCount = packing.laneCount;
+
+    if (row.key !== UNASSIGNED_ROW_KEY) markOverlaps(row.bars);
+
+    let hasCriticalDwell = false;
+    for (const bar of row.bars) {
+      if (bar.isCanceled) continue;
+      if (bar.tone === "late") row.stats.late++;
+      if (bar.tone === "watch") row.stats.watch++;
+      if (bar.dwell) {
+        row.stats.dwelling++;
+        if (bar.dwell.severity === "critical") hasCriticalDwell = true;
+      }
+      if (bar.hasOverlap) row.stats.overlaps++;
+    }
+
+    if (row.stats.late > 0 || hasCriticalDwell) {
+      row.alert = "late";
+    } else if (row.stats.watch > 0 || row.stats.dwelling > 0 || row.stats.overlaps > 0) {
+      row.alert = "watch";
+    }
+
+    exceptions.late += row.stats.late;
+    exceptions.watch += row.stats.watch;
+    exceptions.dwelling += row.stats.dwelling;
+    exceptions.overlaps += row.stats.overlaps;
   }
 
   const unassignedRow = rowsByKey.get(UNASSIGNED_ROW_KEY) ?? null;
   rowsByKey.delete(UNASSIGNED_ROW_KEY);
+
+  if (unassignedRow) {
+    exceptions.unassigned = unassignedRow.bars.filter((bar) => !bar.isCanceled).length;
+    if (exceptions.unassigned > 0 && !unassignedRow.alert) unassignedRow.alert = "watch";
+  }
 
   const rows = [...rowsByKey.values()].sort((a, b) => a.workerName.localeCompare(b.workerName));
 
@@ -188,7 +316,45 @@ export function buildTimelineData(
     shipmentCount: shipments.length,
     totalCount,
     truncated: totalCount > shipments.length,
+    exceptions,
   };
+}
+
+/**
+ * Two live moves occupying the same clock time on one driver is a probable
+ * double-booking. Bars arrive sorted by start, so a linear forward scan is
+ * enough to flag every overlapping pair.
+ */
+function markOverlaps(bars: TimelineBar[]): void {
+  for (let i = 0; i < bars.length; i++) {
+    if (bars[i].isCanceled) continue;
+    for (let j = i + 1; j < bars.length && bars[j].start < bars[i].end; j++) {
+      if (bars[j].isCanceled) continue;
+      bars[i].hasOverlap = true;
+      bars[j].hasOverlap = true;
+    }
+  }
+}
+
+function getBarDwell(stops: TimelineStopMarker[], nowSeconds: number): TimelineDwell | null {
+  let dwell: TimelineDwell | null = null;
+
+  for (const stop of stops) {
+    if (!stop.actualArrival || stop.actualDeparture) continue;
+    if (stop.status === "Completed" || stop.status === "Canceled") continue;
+    const seconds = nowSeconds - stop.actualArrival;
+    if (seconds < DWELL_WATCH_SECONDS) continue;
+    if (dwell && dwell.seconds >= seconds) continue;
+    dwell = {
+      stopId: stop.id,
+      locationCode: stop.locationCode,
+      locationName: stop.locationName,
+      seconds,
+      severity: seconds >= DWELL_CRITICAL_SECONDS ? "critical" : "watch",
+    };
+  }
+
+  return dwell;
 }
 
 function getWorkerDisplayName(
@@ -231,6 +397,10 @@ function getMoveSpan(move: ShipmentMove): MoveSpan | null {
       status: stop.status,
       locationCode: stop.location?.code ?? "—",
       locationName: stop.location?.name ?? stop.addressLine ?? "Unknown location",
+      scheduledStart,
+      scheduledEnd: stop.scheduledWindowEnd ?? null,
+      actualArrival: stop.actualArrival ?? null,
+      actualDeparture: stop.actualDeparture ?? null,
     });
   }
 

--- a/client/src/routes/shipment/_components/command-center/url-state.ts
+++ b/client/src/routes/shipment/_components/command-center/url-state.ts
@@ -19,6 +19,8 @@ const VIEW_MODES = ["table", "timeline"] as const;
 export type CommandCenterViewMode = (typeof VIEW_MODES)[number];
 const TIMELINE_ZOOMS = ["day", "3day", "week"] as const;
 export type TimelineZoom = (typeof TIMELINE_ZOOMS)[number];
+const TIMELINE_SORTS = ["name", "exceptions", "loads"] as const;
+export type TimelineSort = (typeof TIMELINE_SORTS)[number];
 
 /**
  * URL state for the Shipments Command Center. Backing every cross-cutting bit
@@ -38,6 +40,7 @@ export const commandCenterParser = {
   q: parseAsString.withDefault(""),
   at: parseAsString,
   zoom: parseAsStringLiteral(TIMELINE_ZOOMS).withDefault("day"),
+  tsort: parseAsStringLiteral(TIMELINE_SORTS).withDefault("name"),
 };
 
 export const PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;


### PR DESCRIPTION
Make the command-center timeline collapsible, denser, and
exception-first so a dispatcher can spot and act on problems without
leaving the board:

- Exception triage strip: Late / Dwelling / Overlaps / Unassigned /
  Watch chips with live counts; clicking one dims non-matching loads
  and a stepper walks match-by-match with auto scroll + highlight
- Collapsible driver rows: per-row chevron plus collapse/expand-all;
  collapsed rows keep the day's shape as thin clickable tone strips
- Density modes: comfortable/compact row heights, persisted per user
- Dwell/detention detection: arrived-but-not-departed stops past 90m
  flag "watch", past 2h "critical"; surfaced as pulsing bar badges,
  tooltip and popover banners, and exception counts
- Double-booking detection: overlapping live moves on one driver are
  flagged on bars and in the triage strip
- Row alert dots on the driver rail so collapsed rows still surface
  trouble at a glance
- Row sorting (name / exceptions first / most loads) backed by the
  URL for shareable views
- Richer stop detail: scheduled window vs actual arrive/depart times
  in tooltips and the detail popover, with an "at stop" live marker
- Keyboard shortcuts: arrows shift the window, T jumps to today,
  Escape clears focus and popovers

All derived state stays in the single buildTimelineData pass and row
virtualization is preserved, so the board stays performant at the
250-shipment fetch cap.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015cMjXnYx1mwVcBFKLfUEpr