### PR TITLE
fix(tms): reference the seed_history alias in RecordFailure's upsert

### DIFF
--- a/services/tms/internal/infrastructure/database/seeder/tracker.go
+++ b/services/tms/internal/infrastructure/database/seeder/tracker.go
@@ -172,8 +172,8 @@ func (t *Tracker) RecordFailure(
 		Model(record).
 		On("CONFLICT (name, version, environment) DO UPDATE").
 		Set("applied_at = EXCLUDED.applied_at").
-		Set("status = CASE WHEN seed_history.status = 'Active' " +
-			"THEN seed_history.status ELSE EXCLUDED.status END").
+		Set("status = CASE WHEN sh.status = ? THEN sh.status ELSE EXCLUDED.status END",
+			SeedStatusActive).
 		Set("error = EXCLUDED.error").
 		Exec(ctx)
 	if err != nil {

--- a/services/tms/internal/infrastructure/database/seeder/tracker_integration_test.go
+++ b/services/tms/internal/infrastructure/database/seeder/tracker_integration_test.go
@@ -164,10 +164,6 @@ func TestTracker_RecordFailure_Integration(t *testing.T) {
 	assert.Equal(t, seedErr.Error(), record.Error)
 }
 
-// A seed runs in its own transaction, so a failed re-run of an already applied
-// seed changed nothing: the recorded failure must not demote the successful
-// application, or the next run would apply the seed a second time on top of the
-// data it already created. The failure itself is still recorded on the row.
 func TestTracker_RecordFailure_PreservesSuccess_Integration(t *testing.T) {
 	testutil.RequireIntegration(t)
 

--- a/services/tms/internal/infrastructure/database/seeder/tracker_integration_test.go
+++ b/services/tms/internal/infrastructure/database/seeder/tracker_integration_test.go
@@ -164,7 +164,11 @@ func TestTracker_RecordFailure_Integration(t *testing.T) {
 	assert.Equal(t, seedErr.Error(), record.Error)
 }
 
-func TestTracker_RecordFailure_OverwritesSuccess_Integration(t *testing.T) {
+// A seed runs in its own transaction, so a failed re-run of an already applied
+// seed changed nothing: the recorded failure must not demote the successful
+// application, or the next run would apply the seed a second time on top of the
+// data it already created. The failure itself is still recorded on the row.
+func TestTracker_RecordFailure_PreservesSuccess_Integration(t *testing.T) {
 	testutil.RequireIntegration(t)
 
 	tc, db := testutil.SetupTestDB(t)
@@ -188,7 +192,16 @@ func TestTracker_RecordFailure_OverwritesSuccess_Integration(t *testing.T) {
 	require.NoError(t, err)
 
 	applied, _ = tracker.IsApplied(tc.Ctx, seed, common.EnvDevelopment)
-	assert.False(t, applied, "seed should not be applied after failure")
+	assert.True(t, applied, "a failed re-run must not demote an applied seed")
+
+	var record SeedRecord
+	err = db.NewSelect().
+		Model(&record).
+		Where("name = ?", "FlakySeed").
+		Scan(tc.Ctx)
+	require.NoError(t, err)
+	assert.Equal(t, SeedStatusActive, record.Status)
+	assert.Equal(t, seedErr.Error(), record.Error, "the failure is recorded without demoting the seed")
 }
 
 func TestTracker_GetStatus_Integration(t *testing.T) {


### PR DESCRIPTION
# Description

Bun renders the tracker's insert as `INSERT INTO "seed_history" AS "sh"`, and once a table is aliased Postgres forbids referring to it by its original name. The `CASE` expression added in fcde659 referenced `seed_history.status`, so every `RecordFailure` call has failed with `ERROR: invalid reference to FROM-clause entry for table "seed_history" (SQLSTATE 42P01)` — the reason the **Test Go** workflow's Integration Tests have been red on master since Aug 1. The expression now uses the `sh` alias, with the status literal replaced by the `SeedStatusActive` constant through a placeholder.

The preserve-Active semantics that commit introduced are deliberate, and its comment says why: a seed runs in its own transaction, so a failed re-run of an already applied seed changed nothing, and demoting the row would make the next run apply the seed a second time on top of the data it already created. The stale `TestTracker_RecordFailure_OverwritesSuccess_Integration` still pinned the old demote-on-failure behaviour and could never have passed against the intended query; it is now `TestTracker_RecordFailure_PreservesSuccess_Integration` and pins the intended semantics — the seed stays applied, and the failure is recorded on the row without demoting it.

## Related Issue or Discussion

Diagnosed from the pre-existing Integration Tests failure noted on #526 (`TestTracker_RecordFailure_Integration`, `TestTracker_RecordFailure_OverwritesSuccess_Integration`); fix requested by the maintainer.

## Type of Change

- [x] Bug fix
- [x] Tests

## Scope

- `services/tms/internal/infrastructure/database/seeder/tracker.go` — the `ON CONFLICT DO UPDATE` expression in `RecordFailure`
- `services/tms/internal/infrastructure/database/seeder/tracker_integration_test.go` — the stale test now pins the intended preserve-Active semantics

## Validation

- [x] Other: `go build`, `go vet`, `go test ./internal/infrastructure/database/seeder/...` (unit; integration requires Postgres, unavailable in the sandbox — CI runs it)
- [x] Other: rendered the exact upsert through Bun with pgdialect and verified it emits `INSERT INTO "seed_history" AS "sh" … SET status = CASE WHEN sh.status = 'Active' THEN sh.status ELSE EXCLUDED.status END`
- [ ] `cd services/tms && task test` — integration half needs Docker; not available in this environment
- [ ] `cd client && pnpm build` / `pnpm lint` — no client changes

## Deployment Notes

No migrations, no config changes. Behaviour change is confined to seed bookkeeping: a failed re-run of an already applied seed now records its error without demoting the row, as fcde659 intended.

## Checklist

- [x] I kept the change focused and reviewable.
- [x] I followed `AGENTS.md`, `CLAUDE.md`, and existing repository patterns.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I updated relevant documentation, examples, migrations, or configuration.
- [x] I did not include secrets, credentials, private customer data, unrelated refactors, or placeholder code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bqJRctWJTMAZGg9U41mfk

---
_Generated by [Claude Code](https://claude.ai/code/session_014bqJRctWJTMAZGg9U41mfk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved seed tracking so a failed rerun preserves the previously successful seed status.
  - Failure details are still recorded without overwriting the active state.

- **Tests**
  - Updated integration coverage to verify successful seeds remain active after a failed rerun.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->