### PR TITLE
Make the assay coverage index shared and test-precise in CI

### DIFF
--- a/.github/workflows/assay-index.yml
+++ b/.github/workflows/assay-index.yml
@@ -1,0 +1,80 @@
+name: Assay Index
+
+# Keeps the shared coverage index warm. Every push to a protected branch
+# refreshes the index at that commit and saves it to the actions cache, where
+# pull-request runs of the Assay Dogfood workflow restore it read-only.
+#
+# The index validates per package: a record built here stays usable for any
+# later merge-base as long as that package (and its dependency closure) is
+# unchanged, and index.Build reuses fingerprint-valid records, so this job is
+# incremental — a typical push re-collects only the packages the push touched.
+#
+# assay is built with -buildvcs=false so its cache identity comes from the
+# binary's content instead of the commit it was built at; a vcs-stamped build
+# would invalidate the whole index on every push.
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - develop
+    paths:
+      - "services/**"
+      - "shared/**"
+      - "tools/**"
+      - "go.work"
+      - "go.work.sum"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ASSAY_CACHE: /home/runner/.cache/assay
+
+jobs:
+  index:
+    name: Refresh coverage index
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+        with:
+          cache-key: assay
+
+      - name: Restore previous index
+        uses: actions/cache/restore@v4
+        with:
+          path: /home/runner/.cache/assay
+          key: assay-index-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            assay-index-${{ runner.os }}-
+
+      - name: Build assay
+        working-directory: tools/assay
+        run: go build -trimpath -buildvcs=false -o /tmp/assay ./cmd/assay
+
+      # Package failures (environment-dependent tests, for example) leave those
+      # packages without records — selection falls back to whole-package runs
+      # for them, which is safe. They must not stop the cache from saving.
+      - name: Build coverage index
+        run: |
+          /tmp/assay index --quiet --no-color \
+            || echo "::warning::assay index reported package failures; affected packages fall back to package-precise selection"
+
+      - name: Save index
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: /home/runner/.cache/assay
+          key: assay-index-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/assay-select.yml
+++ b/.github/workflows/assay-select.yml
@@ -1,12 +1,18 @@
 name: Assay Dogfood
 
 # Dogfooding, deliberately non-blocking: on every Go PR, assay reports which
-# test packages the diff can actually reach. The selection lands in the job
-# summary where reviewers can sanity-check it against their intuition; once it
-# has earned trust, `assay run` can replace the run-everything test job.
+# tests the diff can actually reach. The selection lands in the job summary
+# where reviewers can sanity-check it against their intuition; once it has
+# earned trust, `assay run` can replace the run-everything test job.
 #
-# No coverage index exists in CI, so selection is package-precise, not
-# test-precise — that is the honest baseline mode, never an unsound one.
+# The Assay Index workflow keeps a coverage index warm in the actions cache on
+# every push to the base branches. When the restored index covers the PR's
+# merge-base, selection narrows to the individual tests that execute the
+# changed lines; packages whose records are stale (or missing after a cache
+# miss) fall back to whole-package selection, which is the safe direction.
+#
+# assay is built with -buildvcs=false so its cache identity matches the index
+# job's build; a vcs-stamped binary would reject every cached record.
 
 on:
   pull_request:
@@ -27,6 +33,9 @@ concurrency:
 
 permissions:
   contents: read
+
+env:
+  ASSAY_CACHE: /home/runner/.cache/assay
 
 jobs:
   select:
@@ -50,9 +59,17 @@ jobs:
         with:
           cache-key: assay
 
+      - name: Restore coverage index
+        uses: actions/cache/restore@v4
+        with:
+          path: /home/runner/.cache/assay
+          key: assay-index-${{ runner.os }}-${{ github.event.pull_request.base.sha }}
+          restore-keys: |
+            assay-index-${{ runner.os }}-
+
       - name: Build assay
         working-directory: tools/assay
-        run: go build -o /tmp/assay ./cmd/assay
+        run: go build -trimpath -buildvcs=false -o /tmp/assay ./cmd/assay
 
       - name: Select affected tests
         run: |
@@ -63,5 +80,5 @@ jobs:
             /tmp/assay select --since "origin/${GITHUB_BASE_REF}" --verbose --no-color 2>&1
             echo '```'
             echo
-            echo "_Package-precise selection (no coverage index in CI). See tools/assay/README.md._"
+            echo "_Line-level narrowing engages per package when the cached coverage index matches the merge-base; stale or missing records fall back to whole-package selection. See tools/assay/README.md._"
           } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/tools/assay/README.md
+++ b/tools/assay/README.md
@@ -167,23 +167,37 @@ attributed to that test's window in single-process mode, where fresh processes
 attributed it to every test. Package-level `init` and `var` initialisers are
 unaffected: their window is merged into every test.
 
-### The index is pinned to a commit
+### The index is pinned to content
 
-An index describes one tree. A diff has two sides, and the index's line numbers
-only mean anything in the coordinates of the tree it was built from — so
-narrowing engages **only when a record's commit equals the selection's base
-commit**, and looks up base-side line numbers. Anything else runs in full.
+An index describes one tree, and its line numbers only mean anything in the
+coordinates of the tree it was built from. Rather than demanding an exact
+commit match, each record is validated **by content**: narrowing engages for a
+package when the selection's base tree has byte-identical digests for that
+package's files, its dependency closure, the module files, and the same
+toolchain — which is exactly the condition under which the record's line
+coordinates are still correct. A record built at one commit keeps serving
+later merge-bases until something it depends on actually changes; a package
+whose content moved falls back to a full run.
 
 In practice:
 
 - **Locally**: `assay index` at a clean `HEAD`, then edit. `assay run` diffs
   against `HEAD`, which is what the index describes, so narrowing engages.
-- **In CI**: index on the base branch and cache it, or index the merge-base
-  commit in the job. `assay select --since "$BASE"` then matches.
+- **In CI**: refresh the index on pushes to the base branch and cache it
+  (`assay index` reuses fingerprint-valid records, so the refresh only
+  re-collects what the push changed). PR jobs restore the cache and
+  `assay select --since "$BASE"` narrows every package whose content still
+  matches the merge-base. See `.github/workflows/assay-index.yml` and
+  `assay-select.yml` in this repository for the working pair.
 
-`assay index` refuses to run on a dirty tree, because the records would claim to
-describe `HEAD` while actually describing something else. `--allow-dirty` builds
-them anyway and marks them unusable for narrowing.
+Build assay with `-buildvcs=false` in CI: cache identity comes from the
+binary's content, so two runs that compile the same assay source trust each
+other's records, while a vcs-stamped build would change identity on every
+commit and reject the entire cache.
+
+`assay index` refuses to run on a dirty tree, because the records would claim
+to describe `HEAD` while actually describing something else. `--allow-dirty`
+builds them anyway and marks them unusable for narrowing.
 
 ### What narrowing refuses to do
 
@@ -207,7 +221,8 @@ And per package:
 
 | Condition | Behaviour |
 |---|---|
-| No index record, or one from a different commit | Run in full |
+| No index record whose content matches the base tree | Run in full |
+| Record built from a dirty tree | Run in full |
 | Record degraded (a coverage path could not be resolved) | Run in full |
 | A test in the record but not attributable — skipped, panicked, no profile | Always selected |
 | Reached by any change with no line attribution | Run in full |

--- a/tools/assay/README.md
+++ b/tools/assay/README.md
@@ -35,22 +35,53 @@ See [BENCHMARKS.md](BENCHMARKS.md).
 
 ## Install
 
-**Released binaries.** Every `assay/vX.Y.Z` tag publishes a GitHub release with
-binaries for linux, macOS and windows on amd64 and arm64, with checksums.
-Download, unpack, put `assay` on your PATH:
+**Released binaries** — the recommended path. Every `assay/vX.Y.Z` tag
+publishes a [GitHub release](https://github.com/emoss08/Trenova/releases) with
+binaries for linux, macOS and windows on amd64 and arm64, plus a sha256
+checksum file.
+
+Linux and macOS — substitute your platform for `linux_amd64`
+(`darwin_arm64` for Apple silicon):
 
 ```bash
-tar -xzf assay_<version>_linux_amd64.tar.gz
-install assay_<version>_linux_amd64/assay ~/.local/bin/
+v=0.6.0
+curl -fsSLO "https://github.com/emoss08/Trenova/releases/download/assay/v${v}/assay_${v}_linux_amd64.tar.gz"
+curl -fsSLO "https://github.com/emoss08/Trenova/releases/download/assay/v${v}/assay_${v}_checksums.txt"
+sha256sum --check --ignore-missing "assay_${v}_checksums.txt"
+tar -xzf "assay_${v}_linux_amd64.tar.gz"
+install "assay_${v}_linux_amd64/assay" ~/.local/bin/
 ```
 
-**From source.** assay lives in this monorepo as a self-contained module; it
-builds anywhere Go 1.26 does:
+(`~/.local/bin` must be on your PATH; any directory that is works. On macOS,
+`shasum -a 256 --check` replaces `sha256sum --check`.)
+
+Windows, in PowerShell — the archive ships `assay.exe`, ready to run:
+
+```powershell
+$v = "0.6.0"
+Invoke-WebRequest "https://github.com/emoss08/Trenova/releases/download/assay/v$v/assay_${v}_windows_amd64.zip" -OutFile "assay_${v}_windows_amd64.zip"
+Expand-Archive "assay_${v}_windows_amd64.zip" -DestinationPath .
+Move-Item "assay_${v}_windows_amd64\assay.exe" "$env:USERPROFILE\go\bin\assay.exe"
+```
+
+(`$env:USERPROFILE\go\bin` is on PATH when Go is installed; any PATH directory
+works.)
+
+**From source.** assay lives in this monorepo as a self-contained module, so
+`go install github.com/emoss08/assay/...@latest` cannot resolve it — install
+from a checkout instead. It builds anywhere Go 1.26 does:
 
 ```bash
-cd tools/assay
-go build -o "$(go env GOPATH)/bin/assay" ./cmd/assay
+git clone https://github.com/emoss08/Trenova
+cd Trenova/tools/assay
+go install ./cmd/assay
 ```
+
+`go install` puts the binary in `go env GOBIN` (default: `$(go env GOPATH)/bin`)
+under the right name for the platform — `assay` on unix, `assay.exe` on
+windows. Prefer it over `go build -o <path>`: a hand-written output path
+without `.exe` produces a file Windows will not execute, so typing `assay`
+opens the file in your editor instead of running the tool.
 
 A source build reports `assay devel-<commit>` from `assay version`, so a bug
 report always says exactly which code produced it; release binaries report

--- a/tools/assay/internal/cache/fingerprint.go
+++ b/tools/assay/internal/cache/fingerprint.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"runtime/debug"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -176,17 +175,37 @@ func BuildIdentity() string {
 	return identity
 }
 
-func executableIdentity() string {
-	path, err := os.Executable()
-	if err != nil {
-		return ""
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return ""
-	}
+var (
+	exeIdentityOnce sync.Once
+	exeIdentity     string
+)
 
-	return " exe=" + strconv.FormatInt(info.Size(), 10) + ":" + strconv.FormatInt(info.ModTime().UnixNano(), 10)
+// executableIdentity distinguishes source builds that carry no usable version
+// metadata. It hashes the binary's content: rebuilds that produce an identical
+// binary keep their cache entries valid, while any real change to the tool
+// invalidates them. A size+mtime heuristic would churn the identity on every
+// rebuild even when nothing changed, which defeats index reuse across CI runs
+// that compile assay from source.
+func executableIdentity() string {
+	exeIdentityOnce.Do(func() {
+		path, err := os.Executable()
+		if err != nil {
+			return
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return
+		}
+		defer file.Close()
+
+		h := blake3.New()
+		if _, err := io.Copy(h, file); err != nil {
+			return
+		}
+		exeIdentity = " exe=" + hex.EncodeToString(h.Sum(nil)[:16])
+	})
+
+	return exeIdentity
 }
 
 func writeField(h io.Writer, value string) {

--- a/tools/assay/internal/cache/fingerprint_test.go
+++ b/tools/assay/internal/cache/fingerprint_test.go
@@ -175,6 +175,18 @@ func TestBuildIdentityIsNonEmptyAndPinsDevBuilds(t *testing.T) {
 		"a dev build has no release version, so the executable itself must pin the key")
 }
 
+func TestExecutableIdentityIsContentDerivedAndStable(t *testing.T) {
+	first := executableIdentity()
+	second := executableIdentity()
+
+	require.NotEmpty(t, first)
+	assert.Equal(t, first, second)
+	assert.Regexp(t, `^ exe=[0-9a-f]{32}$`, first,
+		"the identity must come from the binary's content, not its size or mtime — "+
+			"a CI rebuild of identical source has a fresh mtime but must keep cached "+
+			"index records valid")
+}
+
 func TestScanExposesPerFileDigests(t *testing.T) {
 	root := writeTree(t, baseTree())
 

--- a/tools/assay/internal/cli/index.go
+++ b/tools/assay/internal/cli/index.go
@@ -28,9 +28,9 @@ func newIndexCommand(opts *options) *cobra.Command {
 		Use:   "index",
 		Short: "Build the line-to-test coverage index",
 		Long: "index records which source lines each test executes, running every test in a\n" +
-			"package inside one coverage-instrumented process. The result is pinned to the\n" +
-			"current commit: narrowing only engages when a selection's base commit matches\n" +
-			"the commit the index was built at.\n\n" +
+			"package inside one coverage-instrumented process. Records validate per package\n" +
+			"by content: narrowing engages for any selection whose base tree matches the\n" +
+			"indexed content of that package and its dependencies, even across commits.\n\n" +
 			"Build it on your default branch, or on the commit you will diff against.",
 		Args: cobra.NoArgs,
 		Example: "  assay index\n" +

--- a/tools/assay/internal/selection/narrow.go
+++ b/tools/assay/internal/selection/narrow.go
@@ -1,7 +1,6 @@
 package selection
 
 import (
-	"fmt"
 	"path/filepath"
 	"sort"
 
@@ -221,9 +220,16 @@ func planFor(in planInput) PackagePlan {
 
 		return plan
 	}
-	if record.IndexedAt != in.baseCommit {
-		plan.FullReason = fmt.Sprintf("index was built at %s, base is %s",
-			vcs.ShortSHA(record.IndexedAt), vcs.ShortSHA(in.baseCommit))
+	// The record was fetched by a fingerprint computed from the base commit's
+	// tree digests, so its content — this package's files, its dependency
+	// closure, module files, toolchain — is proven identical to what was
+	// indexed, and the base tree's line numbers land in the same coordinates
+	// even when the record was built at a different commit. The one record
+	// that must never narrow is a dirty-tree build: its fingerprint describes
+	// HEAD while its coverage describes uncommitted edits, so it is stored
+	// with no commit at all.
+	if record.IndexedAt == "" {
+		plan.FullReason = "index record was built from a dirty tree"
 
 		return plan
 	}

--- a/tools/assay/internal/selection/narrow_test.go
+++ b/tools/assay/internal/selection/narrow_test.go
@@ -68,6 +68,41 @@ func (h narrowHarness) narrow(t *testing.T, changes []vcs.Change) selection.Narr
 	})
 }
 
+func (h narrowHarness) narrowWithIndexCommit(
+	t *testing.T,
+	changes []vcs.Change,
+	commit string,
+) selection.Narrowed {
+	t.Helper()
+
+	store, err := cache.NewStore(t.TempDir())
+	require.NoError(t, err)
+
+	_, err = index.Build(t.Context(), index.Options{
+		Root:        h.root,
+		Commit:      commit,
+		Graph:       h.graph,
+		TreeDigests: testfixture.Digests(t, h.root),
+		Store:       store,
+		Env:         testfixture.Env(),
+		Jobs:        2,
+	})
+	require.NoError(t, err)
+
+	loader := index.NewLoader(
+		store,
+		index.NewFingerprinter(h.graph, testfixture.Digests(t, h.root), nil),
+	)
+	result := selection.Select(selection.Options{Graph: h.graph, Changes: changes})
+
+	return selection.Narrow(result, selection.NarrowOptions{
+		Graph:      h.graph,
+		Loader:     loader,
+		Changes:    changes,
+		BaseCommit: baseCommit,
+	})
+}
+
 func (h narrowHarness) calcChange(line int) vcs.Change {
 	return vcs.Change{
 		Path:      filepath.Join(h.root, "calc", "calc.go"),
@@ -158,7 +193,7 @@ func TestNarrowFallsBackOnNonGoFile(t *testing.T) {
 		"coverage tracks Go lines only")
 }
 
-func TestNarrowFallsBackWhenIndexCommitDiffers(t *testing.T) {
+func TestNarrowSurvivesIndexFromAnotherCommit(t *testing.T) {
 	h := newNarrowHarness(t)
 	changes := []vcs.Change{h.calcChange(testfixture.CalcAddBodyLine)}
 
@@ -172,8 +207,23 @@ func TestNarrowFallsBackWhenIndexCommitDiffers(t *testing.T) {
 		})
 
 	plan := planFor(t, got, testfixture.Module+"/calc")
-	assert.Contains(t, plan.FullReason, "index was built at",
-		"an index from a different commit has stale line numbers")
+	assert.Empty(t, plan.FullReason,
+		"the fingerprint lookup already proved the record content-identical to the "+
+			"base tree, so a different build commit must not force a full run — a CI "+
+			"index built at the branch tip has to serve merge-bases behind it")
+	assert.NotEmpty(t, plan.Tests)
+}
+
+func TestNarrowRejectsDirtyTreeRecords(t *testing.T) {
+	h := newNarrowHarness(t)
+	changes := []vcs.Change{h.calcChange(testfixture.CalcAddBodyLine)}
+
+	got := h.narrowWithIndexCommit(t, changes, "")
+
+	plan := planFor(t, got, testfixture.Module+"/calc")
+	assert.Contains(t, plan.FullReason, "dirty tree",
+		"a dirty-tree record's fingerprint describes HEAD while its coverage "+
+			"describes uncommitted edits; it must never narrow")
 }
 
 func TestNarrowFallsBackWithoutBaseCommit(t *testing.T) {


### PR DESCRIPTION
# Description

Turns the assay dogfood workflow from package-precise into test-precise by sharing the coverage index across CI runs through the actions cache.

Three changes make that possible:

1. **Content-based record validation.** Narrowing previously required a record's build commit to exactly equal the selection's merge-base, so a cached index could only serve a PR by winning a race against master advancing. The fingerprint lookup already proves a record content-identical to the base tree — the package's files, its dependency closure, module files, and toolchain — which is exactly the condition under which its line coordinates remain correct. Validation is now content-based, and a record built at one commit keeps serving later merge-bases until something it depends on actually changes. The one hard refusal kept is dirty-tree records, whose fingerprints describe `HEAD` while their coverage describes uncommitted edits.

2. **Content-hashed cache identity.** Source builds previously identified themselves by binary size + mtime, so every fresh CI compile of the same source rejected the entire cache. The identity is now a hash of the binary's content; CI builds compile with `-buildvcs=false` so a commit SHA never enters the identity.

3. **A workflow pair.** The new `Assay Index` workflow refreshes the index on pushes to base branches and saves it to the actions cache — incrementally, since `index.Build` reuses fingerprint-valid records and only re-collects what the push changed. The dogfood workflow restores the cache read-only; selection then narrows to individual tests per package wherever the index still matches the merge-base, and falls back to whole-package selection where it does not.

## Related Issue or Discussion

Follow-up to #526, which landed assay with package-precise CI selection as the honest baseline ("No coverage index exists in CI").

## Type of Change

- [x] Feature
- [x] Tests
- [x] Build, CI, or infrastructure

## Scope

- `tools/assay/internal/selection/` — content-based narrowing gate with dirty-tree refusal
- `tools/assay/internal/cache/` — content-hashed executable identity
- `tools/assay/internal/cli/`, `tools/assay/README.md` — documentation of the new contract
- `.github/workflows/assay-index.yml` — new index-refresh workflow (base-branch pushes)
- `.github/workflows/assay-select.yml` — restores the cached index; builds with `-buildvcs=false`

## Validation

Verified end-to-end against this workspace, mirroring the CI topology:

- Records built at one commit by one binary narrowed a selection at another commit made by a separately compiled binary (byte-identical source, fresh mtime) — the exact case the old identity rejected, reproduced before the fix and green after.
- A covered edit (`stringutils.ParseBool`) narrowed to exactly its covering test; an uncovered edit (`stringutils.CapitalizeFirst`, `sliceutils.Dedupe`) dropped the package with the index's proof that no test observes it.
- Cross-commit validation: an index built at the branch tip served a merge-base one commit behind it.
- A warm index refresh re-collected only the one changed package, in under a second.
- New unit tests pin the relaxed gate (`TestNarrowSurvivesIndexFromAnotherCommit`), the dirty-tree refusal (`TestNarrowRejectsDirtyTreeRecords`), and the content-derived identity (`TestExecutableIdentityIsContentDerivedAndStable`).
- Full suite, `-race` on the concurrency-heavy packages, `go vet`, `gofmt`, and windows/darwin cross-compiles all pass.

## Checklist

- [x] I kept the change focused and reviewable.
- [x] I followed existing repository patterns.
- [x] I added tests that fail on the old behavior.
- [x] I updated documentation where behavior changed.
- [x] I did not include secrets, credentials, or unrelated refactors.

https://claude.ai/code/session_014bqJRctWJTMAZGg9U41mfk

---
_Generated by [Claude Code](https://claude.ai/code/session_014bqJRctWJTMAZGg9U41mfk)_