### PR TITLE
Bump assay to v0.7.1 in CI workflows

### DIFF
--- a/.github/workflows/assay-index.yml
+++ b/.github/workflows/assay-index.yml
@@ -64,7 +64,7 @@ jobs:
       # identity is stable across runs of the same version.
       - name: Install assay
         run: |
-          GOBIN=/tmp go install github.com/emoss08/assay/cmd/assay@v0.7.0
+          GOBIN=/tmp go install github.com/emoss08/assay/cmd/assay@v0.7.1
 
       # The setup-go action's dependency download can rewrite go.work.sum in
       # the checkout; assay's dirty-tree guard would then refuse to index at

--- a/.github/workflows/assay-select.yml
+++ b/.github/workflows/assay-select.yml
@@ -71,7 +71,7 @@ jobs:
       # identity is stable across runs of the same version.
       - name: Install assay
         run: |
-          GOBIN=/tmp go install github.com/emoss08/assay/cmd/assay@v0.7.0
+          GOBIN=/tmp go install github.com/emoss08/assay/cmd/assay@v0.7.1
 
       # The setup-go action's dependency download can rewrite go.work.sum in
       # the checkout; a modified module file is a blocking change that would


### PR DESCRIPTION
# Description

Bumps the pinned assay version in the index and dogfood workflows from v0.7.0 to v0.7.1, picking up the dirty-check hardening (assay no longer refuses to index over `go.sum`/`go.work.sum` churn its own graph load introduced) and terminal-width-aware progress rendering.

## Type of Change

- [x] Build, CI, or infrastructure

## Scope

- `.github/workflows/assay-index.yml`, `assay-select.yml` — `go install …@v0.7.0` → `@v0.7.1`

## Validation

- The v0.7.1 release is published with all platform binaries and the tag is resolvable.
- A full module load across all five workspace modules leaves the checkout pristine with the committed `go.work.sum`.

## Checklist

- [x] I kept the change focused and reviewable.
- [x] I did not include secrets, credentials, or unrelated refactors.

https://claude.ai/code/session_014bqJRctWJTMAZGg9U41mfk

---
_Generated by [Claude Code](https://claude.ai/code/session_014bqJRctWJTMAZGg9U41mfk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Assay validation tool to version 0.7.1 in automated workflows.
  - Ensures workflow checks use the latest configured Assay version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->