### PR TITLE
fix(client): regenerate codegen artifacts to unblock GraphQL Codegen check

### DIFF
--- a/client/packages/graphql/src/generated/fragment-masking.ts
+++ b/client/packages/graphql/src/generated/fragment-masking.ts
@@ -14,11 +14,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
     : never
   : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function getFragmentData<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function getFragmentData<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/client/packages/graphql/src/generated/fragment-masking.ts
+++ b/client/packages/graphql/src/generated/fragment-masking.ts
@@ -14,6 +14,11 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
     : never
   : never;
 
+// return partial if `fragmentType` is partial e.g. because of conditional directives
+export function getFragmentData<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>
+): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function getFragmentData<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/client/packages/shared/src/types/generated/error-enums.ts
+++ b/client/packages/shared/src/types/generated/error-enums.ts
@@ -28,6 +28,7 @@ export const ErrorCode = z.enum([
   "COMPLIANCE_VIOLATION",
   "RESOURCE_IN_USE",
   "BREAKING_CHANGE",
+  "NOT_IMPLEMENTED",
 ]);
 
 export type ErrorCode = z.infer<typeof ErrorCode>;


### PR DESCRIPTION
# Description

Follow-up to #536, which merged while the **GraphQL Codegen** check was red. This regenerates the two stale generated artifacts so the check passes on `master` again.

The first commit fixes a regression introduced by #536. The second is pre-existing drift that keeps the same check red and is cleanly separable — see Scope.

## Related Issue or Discussion

Follow-up to #536 (merged as `dd82733`). The failing check on that PR: https://github.com/emoss08/Trenova/actions/runs/31556051152/job/93988585852

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Tests
- [ ] Build, CI, or infrastructure

## Scope

**`client/packages/shared/src/types/generated/error-enums.ts`** — one line. #536 added `ErrNotImplemented` to `services/tms/pkg/errortypes/enums.go` (backing the HTTP 501 returned when a capability is unavailable on SQLite) without rerunning `scripts/generate-error-enums.mjs`. That generator exists precisely so a new Go error code cannot fall through `parseProblemType` as `null` with nothing failing, so leaving it stale defeats its purpose. Regenerated, adding `"NOT_IMPLEMENTED"` to the `ErrorCode` enum.

**`client/packages/graphql/src/generated/fragment-masking.ts`** — five lines, **not caused by #536**. The committed file predates a client-preset update that added a partial-fragment overload to `getFragmentData`. It is independent of the SQLite work, but `codegen:check` regenerates everything and stays red until it is committed. It is isolated in its own commit and can be dropped if you would rather handle it separately — the check will remain red until it lands somewhere.

No hand-editing: both files are the verbatim output of the generators.

## Validation

- [ ] `cd services/tms && task test`
- [ ] `cd services/tms && task lint`
- [ ] `cd client && pnpm build`
- [ ] `cd client && pnpm lint`
- [x] Other: `pnpm --filter @trenova/graphql codegen:check` — passes (this is the check that failed on #536)
- [x] Other: `node client/packages/graphql/scripts/generate-error-enums.mjs` — reports 20 ErrorCode, 11 ProblemType; working tree clean after commit

Only the codegen check was run. This changes nothing but generated TypeScript, and `codegen:check` is the check that was failing; the broader Go and client suites are unaffected by these two files and are exercised by the other CI jobs.

## Deployment Notes

No migrations, config, or env changes. Generated artifacts only.

Note that `master` currently has a failing GraphQL Codegen check until this lands.

## Checklist

- [x] I kept the change focused and reviewable.
- [x] I followed `AGENTS.md`, `CLAUDE.md`, and existing repository patterns.
- [ ] I added or updated tests for behavior changes, or explained why tests are not applicable. — no behavior change; both files are generator output, and `codegen:check` in CI is the test that guards them.
- [x] I updated relevant documentation, examples, migrations, or configuration.
- [x] I did not include secrets, credentials, private customer data, unrelated refactors, or placeholder code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXYnxBszfwkNUeeAcVSSNf)_