### PR TITLE
fix(lint): resolve golangci-lint findings from the SQLite dialect work

### DIFF
--- a/services/tms/internal/infrastructure/config/config.go
+++ b/services/tms/internal/infrastructure/config/config.go
@@ -140,7 +140,7 @@ type GCPKMSConfig struct {
 	CredentialsMode string        `mapstructure:"credentialsMode" validate:"omitempty,oneof=adc workload-identity credentials-file"`
 	CredentialsFile string        `mapstructure:"credentialsFile"`
 	Timeout         time.Duration `mapstructure:"timeout"`
-	RetryAttempts   int           `mapstructure:"retryAttempts" validate:"omitempty,min=1,max=10"`
+	RetryAttempts   int           `mapstructure:"retryAttempts"   validate:"omitempty,min=1,max=10"`
 }
 
 type SessionConfig struct {
@@ -237,15 +237,15 @@ type CSRFBrowserGuardConfig struct {
 }
 
 type DatabaseConfig struct {
-	Driver           string        `mapstructure:"driver"          validate:"omitempty,oneof=postgres sqlite"`
-	Host             string        `mapstructure:"host"            validate:"required_if=Driver postgres"`
-	Port             int           `mapstructure:"port"            validate:"required_if=Driver postgres,omitempty,min=1,max=65535"`
-	Name             string        `mapstructure:"name"            validate:"required_if=Driver postgres,omitempty,min=1,max=63"`
-	User             string        `mapstructure:"user"            validate:"required_if=Driver postgres,omitempty,min=1,max=63"`
-	Password         string        `mapstructure:"password"        validate:"required_if=Driver postgres"`
-	SSLMode          string        `mapstructure:"sslMode"         validate:"required_if=Driver postgres,omitempty,oneof=disable require verify-ca verify-full"`
-	MaxIdleConns     int           `mapstructure:"maxIdleConns"    validate:"min=1,max=1000"`
-	MaxOpenConns     int           `mapstructure:"maxOpenConns"    validate:"min=1,max=1000"`
+	Driver           string        `mapstructure:"driver"                          validate:"omitempty,oneof=postgres sqlite"`
+	Host             string        `mapstructure:"host"                            validate:"required_if=Driver postgres"`
+	Port             int           `mapstructure:"port"                            validate:"required_if=Driver postgres,omitempty,min=1,max=65535"`
+	Name             string        `mapstructure:"name"                            validate:"required_if=Driver postgres,omitempty,min=1,max=63"`
+	User             string        `mapstructure:"user"                            validate:"required_if=Driver postgres,omitempty,min=1,max=63"`
+	Password         string        `mapstructure:"password"                        validate:"required_if=Driver postgres"`
+	SSLMode          string        `mapstructure:"sslMode"                         validate:"required_if=Driver postgres,omitempty,oneof=disable require verify-ca verify-full"`
+	MaxIdleConns     int           `mapstructure:"maxIdleConns"                    validate:"min=1,max=1000"`
+	MaxOpenConns     int           `mapstructure:"maxOpenConns"                    validate:"min=1,max=1000"`
 	Verbose          bool          `mapstructure:"verbose"`
 	ConnMaxLifetime  time.Duration `mapstructure:"connMaxLifetime"`
 	ConnMaxIdleTime  time.Duration `mapstructure:"connMaxIdleTime"`
@@ -1223,7 +1223,7 @@ type PortalConfig struct {
 type PushConfig struct {
 	VAPIDPublicKey  string `mapstructure:"vapidPublicKey"`
 	VAPIDPrivateKey string `mapstructure:"vapidPrivateKey"`
-	Subject         string `mapstructure:"subject" validate:"omitempty"`
+	Subject         string `mapstructure:"subject"         validate:"omitempty"`
 }
 
 func (c *PushConfig) Enabled() bool {

--- a/services/tms/internal/infrastructure/postgres/repositories/documentcontentrepository/content.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/documentcontentrepository/content.go
@@ -275,7 +275,10 @@ func (r *repository) SearchByResource(
 				Where(docCols.ResourceType.Eq(), req.ResourceType)
 		})
 
-	if query != "" && dbdialect.FromBun(selectQuery.DB()).Supports(dbdialect.CapFullTextSearch) {
+	switch {
+	case query == "":
+		selectQuery = selectQuery.Order(docCols.CreatedAt.OrderDesc())
+	case dbdialect.FromBun(selectQuery.DB()).Supports(dbdialect.CapFullTextSearch):
 		selectQuery = selectQuery.Where(`
 			doc.search_vector @@ websearch_to_tsquery('english', ?)
 			OR dc.search_vector @@ websearch_to_tsquery('english', ?)`,
@@ -289,14 +292,12 @@ func (r *repository) SearchByResource(
 			query,
 			query,
 		)
-	} else if query != "" {
+	default:
 		pattern := "%" + query + "%"
 		selectQuery = selectQuery.Where(
 			"doc.file_name LIKE ? OR doc.original_name LIKE ? OR dc.content_text LIKE ?",
 			pattern, pattern, pattern,
 		).Order(docCols.CreatedAt.OrderDesc())
-	} else {
-		selectQuery = selectQuery.Order(docCols.CreatedAt.OrderDesc())
 	}
 
 	if req.Limit > 0 {

--- a/services/tms/pkg/dbdialect/dbdialect.go
+++ b/services/tms/pkg/dbdialect/dbdialect.go
@@ -1,6 +1,7 @@
 package dbdialect
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -14,7 +15,7 @@ const (
 
 const DefaultKind = Postgres
 
-var ErrUnknownKind = fmt.Errorf("unknown database driver")
+var ErrUnknownKind = errors.New("unknown database driver")
 
 func Parse(value string) (Kind, error) {
 	switch strings.ToLower(strings.TrimSpace(value)) {


### PR DESCRIPTION
# Description

#536 merged with the **Lint** check red. This fixes the three findings it reported, restoring that check on `master`.

## Related Issue or Discussion

Follow-up to #536. Failing job: https://github.com/emoss08/Trenova/actions/runs/31556084730/job/93988689106

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Tests
- [ ] Build, CI, or infrastructure

## Scope

**`internal/infrastructure/postgres/repositories/documentcontentrepository/content.go`** — `gocritic: ifElseChain`. The document content search is now a `switch`, which suits three mutually exclusive cases better than a chain: no query, dialect supports full-text search, and the SQLite `LIKE` fallback. Behaviour is unchanged; the empty-query case moved to the front so each branch is a plain condition.

**`pkg/dbdialect/dbdialect.go`** — `perfsprint: error-format`. `ErrUnknownKind` uses `errors.New` instead of `fmt.Errorf`, since it has no format arguments. `fmt` is still used elsewhere in the file.

**`internal/infrastructure/config/config.go`** — `golines`. The new `driver` and SQLite fields widened the struct tag alignment column in `DatabaseConfig` past the 100-character limit, so the file no longer matched golines output. Reformatted by running golines directly. The diff is 11 lines: `DatabaseConfig`, plus two pre-existing misalignments in `GCPKMSConfig` and `PushConfig` that golines corrects in the same pass.

## Validation

- [ ] `cd services/tms && task test`
- [x] `cd services/tms && task lint` — **not run.** golangci-lint is unavailable in this environment: it is built against Go 1.25 while the module targets Go 1.26, so it exits with `can't load config: the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26)`. golines was run directly against the reported file; the gocritic and perfsprint findings were fixed against the rules as reported. CI is the real verification here.
- [ ] `cd client && pnpm build`
- [ ] `cd client && pnpm lint`
- [x] Other: `go build ./...` — passes
- [x] Other: `go test ./pkg/dbdialect/... ./internal/infrastructure/config/... ./internal/infrastructure/postgres/repositories/documentcontentrepository/...` — passes

## Deployment Notes

No migrations, config, or env changes. No behaviour change.

Two checks remain red on `master` and are **not** addressed here:

- **GraphQL Codegen** — `@graphql-codegen/client-preset` resolves to 6.1.1, whose generated `getFragmentData` places a `Partial<TType>` overload first. Committing the regenerated `fragment-masking.ts` makes TypeScript select that overload and breaks roughly eight call sites under `src/routes/reports/**`. Being handled separately by updating those call sites.
- **Workers Builds: trenova** — also failed on #536, completing in zero seconds. Appears environmental rather than code-related.

## Checklist

- [x] I kept the change focused and reviewable.
- [x] I followed `AGENTS.md`, `CLAUDE.md`, and existing repository patterns.
- [ ] I added or updated tests for behavior changes, or explained why tests are not applicable. — no behaviour change; the existing tests over these packages still pass.
- [x] I updated relevant documentation, examples, migrations, or configuration.
- [x] I did not include secrets, credentials, private customer data, unrelated refactors, or placeholder code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXYnxBszfwkNUeeAcVSSNf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved document search behavior for empty queries, full-text search databases, and wildcard matching.
  - Preserved existing search filtering and ordering for non-empty queries.

- **Refactor**
  - Simplified internal error creation without changing user-visible messages.
  - Applied formatting improvements to configuration definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->