### PR TITLE
fix(client): narrow getFragmentData so codegen output can be committed

### DIFF
--- a/client/apps/web/src/hooks/use-reports.ts
+++ b/client/apps/web/src/hooks/use-reports.ts
@@ -1,4 +1,4 @@
-import { getFragmentData } from "@trenova/graphql/generated";
+import { getFragmentData } from "@trenova/graphql/fragment-data";
 import {
   ReportDashboardFieldsFragmentDoc,
   ReportDefinitionFieldsFragmentDoc,

--- a/client/apps/web/src/lib/graphql/agent-control.ts
+++ b/client/apps/web/src/lib/graphql/agent-control.ts
@@ -5,7 +5,7 @@ import {
   type AgentControlFieldsFragment,
   type AgentControlInput,
 } from "@trenova/graphql/generated/graphql";
-import { getFragmentData } from "@trenova/graphql/generated";
+import { getFragmentData } from "@trenova/graphql/fragment-data";
 import { requestGraphQL } from "@trenova/shared/lib/graphql";
 
 export type AgentControl = AgentControlFieldsFragment;

--- a/client/apps/web/src/lib/graphql/home-layout.ts
+++ b/client/apps/web/src/lib/graphql/home-layout.ts
@@ -16,7 +16,7 @@ import {
   type SaveHomeLayoutPresetInput,
   type UpdateHomeLayoutPresetInput,
 } from "@trenova/graphql/generated/graphql";
-import { getFragmentData, type FragmentType } from "@trenova/graphql/generated";
+import { getFragmentData, type FragmentType } from "@trenova/graphql/fragment-data";
 import { requestGraphQL } from "@trenova/shared/lib/graphql";
 
 export type HomeWidget = HomeWidgetFieldsFragment;

--- a/client/apps/web/src/lib/graphql/reports.ts
+++ b/client/apps/web/src/lib/graphql/reports.ts
@@ -46,7 +46,7 @@ import {
   type UpdateReportScheduleInput,
   type UpdateReportViewInput,
 } from "@trenova/graphql/generated/graphql";
-import { getFragmentData } from "@trenova/graphql/generated";
+import { getFragmentData } from "@trenova/graphql/fragment-data";
 import { withCsrfHeader } from "@trenova/shared/lib/api";
 import { API_BASE_URL } from "@trenova/shared/lib/constants";
 import { requestGraphQL } from "@trenova/shared/lib/graphql";

--- a/client/packages/graphql/package.json
+++ b/client/packages/graphql/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     "./generated": "./src/generated/index.ts",
+    "./fragment-data": "./src/fragment-data.ts",
     "./generated/operation-catalog.json": "./src/generated/operation-catalog.json",
     "./generated/graphql": "./src/generated/graphql.ts",
     "./generated/gql": "./src/generated/gql.ts",

--- a/client/packages/graphql/src/fragment-data.ts
+++ b/client/packages/graphql/src/fragment-data.ts
@@ -1,0 +1,73 @@
+/**
+ * A narrowed `getFragmentData`.
+ *
+ * The generated `fragment-masking.ts` declares a `Partial<TType>` overload first,
+ * to cover fragments made partial by `@include`/`@skip`. TypeScript picks the first
+ * overload whose parameter type matches, and a non-nullable fragment ref matches the
+ * partial one structurally — so every unmasked fragment widened to `Partial<T>` and
+ * every field became optional.
+ *
+ * Trenova does not use conditional directives on masked fragments, so that overload is
+ * unreachable in practice while poisoning inference everywhere else. This re-declares
+ * the remaining overloads and delegates to the generated implementation, which keeps
+ * `fragment-masking.ts` byte-identical to codegen output.
+ *
+ * Drop this module if the codegen preset stops emitting the partial overload first, or
+ * if masked fragments start using conditional directives — at which point the partial
+ * return type becomes correct and call sites need real null handling.
+ */
+import type { DocumentTypeDecoration } from "@graphql-typed-document-node/core";
+
+import {
+  type FragmentType,
+  getFragmentData as getGeneratedFragmentData,
+} from "./generated/fragment-masking";
+
+export type { FragmentType };
+
+export function getFragmentData<TType>(
+  documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>,
+): TType;
+export function getFragmentData<TType>(
+  documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | undefined,
+): TType | undefined;
+export function getFragmentData<TType>(
+  documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null,
+): TType | null;
+export function getFragmentData<TType>(
+  documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined,
+): TType | null | undefined;
+export function getFragmentData<TType>(
+  documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>>,
+): Array<TType>;
+export function getFragmentData<TType>(
+  documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined,
+): Array<TType> | null | undefined;
+export function getFragmentData<TType>(
+  documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>,
+): ReadonlyArray<TType>;
+export function getFragmentData<TType>(
+  documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType:
+    | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
+    | null
+    | undefined,
+): ReadonlyArray<TType> | null | undefined;
+export function getFragmentData<TType>(
+  documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: unknown,
+): unknown {
+  return (
+    getGeneratedFragmentData as (
+      node: DocumentTypeDecoration<TType, any>,
+      fragment: unknown,
+    ) => unknown
+  )(documentNode, fragmentType);
+}

--- a/client/packages/graphql/src/generated/fragment-masking.ts
+++ b/client/packages/graphql/src/generated/fragment-masking.ts
@@ -14,6 +14,11 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
     : never
   : never;
 
+// return partial if `fragmentType` is partial e.g. because of conditional directives
+export function getFragmentData<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>
+): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function getFragmentData<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,


### PR DESCRIPTION
# Description

The **GraphQL Codegen** check has been red on `master` because the repository was stuck: regenerating `fragment-masking.ts` satisfies the check but breaks the build, and not regenerating it leaves the check failing.

`@graphql-codegen/client-preset` resolves to 6.1.1, whose generated `getFragmentData` declares a `Partial<TType>` overload **first**, covering fragments made partial by `@include`/`@skip`. TypeScript selects the first overload whose parameter type matches, and a non-nullable fragment ref matches the partial one structurally. So every unmasked fragment widened to `Partial<T>`, every field became optional, and committing the regenerated file produced **45 type errors across 12 files**.

Trenova does not use conditional directives on masked fragments, so that overload is unreachable in practice while poisoning inference everywhere else. Rather than add null handling to 45 call sites for a case that cannot occur, this adds a narrowed wrapper.

## Related Issue or Discussion

Follow-up to #536 and #537. The drift was first surfaced by the GraphQL Codegen job on #536: https://github.com/emoss08/Trenova/actions/runs/31556051152/job/93988585852

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Tests
- [x] Build, CI, or infrastructure

## Scope

**`client/packages/graphql/src/fragment-data.ts`** (new) — re-declares the `getFragmentData` overloads minus the partial one and delegates to the generated implementation. Hand-written and outside `src/generated/`, so codegen never overwrites it. Its doc comment records when to delete it: if the preset stops emitting the partial overload first, or if masked fragments start using conditional directives, the partial return type becomes *correct* and call sites will need real null handling.

**`client/packages/graphql/package.json`** — exports the new module as `@trenova/graphql/fragment-data`.

**`client/packages/graphql/src/generated/fragment-masking.ts`** — regenerated, byte-identical to codegen output. This is what makes the check pass.

**Four importers** — `hooks/use-reports.ts`, `lib/graphql/agent-control.ts`, `lib/graphql/home-layout.ts`, `lib/graphql/reports.ts` now import `getFragmentData` from the narrowed module. These are the only files in the app that import it, which is why a central fix works.

No runtime behaviour changes: the generated implementation is still what executes.

## Validation

- [ ] `cd services/tms && task test`
- [ ] `cd services/tms && task lint`
- [x] `cd client && pnpm build` — passes (`@trenova/web` builds clean; 45 → 0 type errors)
- [x] `cd client && pnpm lint` — passes
- [x] Other: `pnpm --filter @trenova/graphql codegen:check` — passes, the check this PR fixes
- [x] Other: `cd client && pnpm typecheck` — passes

The Go suites were not run; this PR touches no Go code.

## Deployment Notes

No migrations, config, or env changes.

One check remains red on `master` and is **not** addressed here: **Workers Builds: trenova**. It also failed on #536, completing in zero seconds, which points at the Cloudflare deployment rather than the code. Its logs are behind an authenticated Cloudflare dashboard and were not readable from CI output, so it needs someone with dashboard access to diagnose.

## Checklist

- [x] I kept the change focused and reviewable.
- [x] I followed `AGENTS.md`, `CLAUDE.md`, and existing repository patterns.
- [ ] I added or updated tests for behavior changes, or explained why tests are not applicable. — no behaviour change; this is a type-level narrowing, and `codegen:check` plus `typecheck` in CI are the checks that guard it.
- [x] I updated relevant documentation, examples, migrations, or configuration.
- [x] I did not include secrets, credentials, private customer data, unrelated refactors, or placeholder code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXYnxBszfwkNUeeAcVSSNf)_