### PR TITLE
style: realign struct tags flagged by golines

### DIFF
--- a/services/tms/internal/core/domain/distancecontrol/distancecontrol.go
+++ b/services/tms/internal/core/domain/distancecontrol/distancecontrol.go
@@ -35,25 +35,25 @@ const (
 type DistanceControl struct {
 	bun.BaseModel `bun:"table:distance_controls,alias:dc" json:"-"`
 
-	ID                                           pulid.ID `json:"id"                                          bun:"id,type:VARCHAR(100),pk,notnull"`
-	BusinessUnitID                               pulid.ID `json:"businessUnitId"                              bun:"business_unit_id,type:VARCHAR(100),pk,notnull"`
-	OrganizationID                               pulid.ID `json:"organizationId"                              bun:"organization_id,type:VARCHAR(100),pk,notnull"`
-	StoreMileage                                 bool     `json:"storeMileage"                                bun:"store_mileage,type:BOOLEAN,notnull"`
-	StoredDistanceUnits                          string   `json:"storedDistanceUnits"                         bun:"stored_distance_units,type:VARCHAR(50),notnull"`
-	PostalCodeFallbackToCity                     bool     `json:"postalCodeFallbackToCity"                    bun:"postal_code_fallback_to_city,type:BOOLEAN,notnull"`
-	AutoCreateStoredMileage                      bool     `json:"autoCreateStoredMileage"                     bun:"auto_create_stored_mileage,type:BOOLEAN,notnull"`
-	LoadedMoveDistanceProfileID                  pulid.ID `json:"loadedMoveDistanceProfileId"                 bun:"loaded_move_distance_profile_id,type:VARCHAR(100),notnull"`
-	EmptyMoveDistanceProfileID                   pulid.ID `json:"emptyMoveDistanceProfileId"                  bun:"empty_move_distance_profile_id,type:VARCHAR(100),notnull"`
-	PayDistanceProfileID                         pulid.ID `json:"payDistanceProfileId"                        bun:"pay_distance_profile_id,type:VARCHAR(100),notnull"`
-	BillingDistanceProfileID                     pulid.ID `json:"billingDistanceProfileId"                    bun:"billing_distance_profile_id,type:VARCHAR(100),notnull"`
-	FuelDistanceProfileID                        pulid.ID `json:"fuelDistanceProfileId"                       bun:"fuel_distance_profile_id,type:VARCHAR(100),notnull"`
-	EtaOutOfRouteDistanceProfileID               pulid.ID `json:"etaOutOfRouteDistanceProfileId"              bun:"eta_out_of_route_distance_profile_id,type:VARCHAR(100),notnull"`
-	DistanceCalculatorShortestDistanceProfileID  pulid.ID `json:"distanceCalculatorShortestDistanceProfileId" bun:"distance_calculator_shortest_distance_profile_id,type:VARCHAR(100),notnull"`
+	ID                                           pulid.ID `json:"id"                                           bun:"id,type:VARCHAR(100),pk,notnull"`
+	BusinessUnitID                               pulid.ID `json:"businessUnitId"                               bun:"business_unit_id,type:VARCHAR(100),pk,notnull"`
+	OrganizationID                               pulid.ID `json:"organizationId"                               bun:"organization_id,type:VARCHAR(100),pk,notnull"`
+	StoreMileage                                 bool     `json:"storeMileage"                                 bun:"store_mileage,type:BOOLEAN,notnull"`
+	StoredDistanceUnits                          string   `json:"storedDistanceUnits"                          bun:"stored_distance_units,type:VARCHAR(50),notnull"`
+	PostalCodeFallbackToCity                     bool     `json:"postalCodeFallbackToCity"                     bun:"postal_code_fallback_to_city,type:BOOLEAN,notnull"`
+	AutoCreateStoredMileage                      bool     `json:"autoCreateStoredMileage"                      bun:"auto_create_stored_mileage,type:BOOLEAN,notnull"`
+	LoadedMoveDistanceProfileID                  pulid.ID `json:"loadedMoveDistanceProfileId"                  bun:"loaded_move_distance_profile_id,type:VARCHAR(100),notnull"`
+	EmptyMoveDistanceProfileID                   pulid.ID `json:"emptyMoveDistanceProfileId"                   bun:"empty_move_distance_profile_id,type:VARCHAR(100),notnull"`
+	PayDistanceProfileID                         pulid.ID `json:"payDistanceProfileId"                         bun:"pay_distance_profile_id,type:VARCHAR(100),notnull"`
+	BillingDistanceProfileID                     pulid.ID `json:"billingDistanceProfileId"                     bun:"billing_distance_profile_id,type:VARCHAR(100),notnull"`
+	FuelDistanceProfileID                        pulid.ID `json:"fuelDistanceProfileId"                        bun:"fuel_distance_profile_id,type:VARCHAR(100),notnull"`
+	EtaOutOfRouteDistanceProfileID               pulid.ID `json:"etaOutOfRouteDistanceProfileId"               bun:"eta_out_of_route_distance_profile_id,type:VARCHAR(100),notnull"`
+	DistanceCalculatorShortestDistanceProfileID  pulid.ID `json:"distanceCalculatorShortestDistanceProfileId"  bun:"distance_calculator_shortest_distance_profile_id,type:VARCHAR(100),notnull"`
 	DistanceCalculatorPracticalDistanceProfileID pulid.ID `json:"distanceCalculatorPracticalDistanceProfileId" bun:"distance_calculator_practical_distance_profile_id,type:VARCHAR(100),notnull"`
-	Version                                      int64    `json:"version"                                     bun:"version,type:BIGINT,notnull"`
-	CreatedAt                                    int64    `json:"createdAt"                                   bun:"created_at,type:BIGINT,notnull,default:extract(epoch from current_timestamp)::bigint"`
-	UpdatedAt                                    int64    `json:"updatedAt"                                   bun:"updated_at,type:BIGINT,notnull,default:extract(epoch from current_timestamp)::bigint"`
-	SearchVector                                 string   `json:"-"                                           bun:"search_vector,type:TSVECTOR,scanonly"`
+	Version                                      int64    `json:"version"                                      bun:"version,type:BIGINT,notnull"`
+	CreatedAt                                    int64    `json:"createdAt"                                    bun:"created_at,type:BIGINT,notnull,default:extract(epoch from current_timestamp)::bigint"`
+	UpdatedAt                                    int64    `json:"updatedAt"                                    bun:"updated_at,type:BIGINT,notnull,default:extract(epoch from current_timestamp)::bigint"`
+	SearchVector                                 string   `json:"-"                                            bun:"search_vector,type:TSVECTOR,scanonly"`
 
 	BusinessUnit *tenant.BusinessUnit `json:"-" bun:"rel:belongs-to,join:business_unit_id=id"`
 	Organization *tenant.Organization `json:"-" bun:"rel:belongs-to,join:organization_id=id"`

--- a/services/tms/internal/core/domain/tenant/agentcontrol.go
+++ b/services/tms/internal/core/domain/tenant/agentcontrol.go
@@ -23,11 +23,11 @@ type AgentControl struct {
 	BusinessUnitID pulid.ID `json:"businessUnitId" bun:"business_unit_id,type:VARCHAR(100),pk,notnull"`
 	OrganizationID pulid.ID `json:"organizationId" bun:"organization_id,type:VARCHAR(100),pk,notnull"`
 
-	ShadowMode          bool `json:"shadowMode"             bun:"shadow_mode,type:BOOLEAN,notnull,default:true"`
-	BillingAgentEnabled bool `json:"billingAgentEnabled"    bun:"billing_agent_enabled,type:BOOLEAN,notnull"`
+	ShadowMode          bool `json:"shadowMode"          bun:"shadow_mode,type:BOOLEAN,notnull,default:true"`
+	BillingAgentEnabled bool `json:"billingAgentEnabled" bun:"billing_agent_enabled,type:BOOLEAN,notnull"`
 	// DispatchAgentEnabled gates the auto-assign agent separately from the billing agent,
 	// so enabling one never enables the other.
-	DispatchAgentEnabled bool `json:"dispatchAgentEnabled"   bun:"dispatch_agent_enabled,type:BOOLEAN,notnull"`
+	DispatchAgentEnabled bool `json:"dispatchAgentEnabled" bun:"dispatch_agent_enabled,type:BOOLEAN,notnull"`
 	// DispatchAutonomyTier is an agent.AutonomyTier. It is held as a string because the
 	// agent domain already depends on this package, and importing it back would cycle.
 	DispatchAutonomyTier   string `json:"dispatchAutonomyTier"   bun:"dispatch_autonomy_tier,type:agent_autonomy_tier_enum,notnull,default:'Propose'"`


### PR DESCRIPTION
# Description

#540 merged with the **Lint** check red. This fixes the two golines findings it reported, restoring that check on `master`.

Dropping the zero-value `default:` tags in #540 shortened the bun tags in these two structs, which moved the column golines aligns them to. The lines were already over the limit beforehand, but golangci-lint runs with `--new-from-rev`, so they were only linted once the sweep touched them.

## Related Issue or Discussion

Follow-up to #540. Failing job: https://github.com/emoss08/Trenova/actions/runs/31560662772/job/94002078090

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Tests
- [ ] Build, CI, or infrastructure

## Scope

**`internal/core/domain/distancecontrol/distancecontrol.go`** and **`internal/core/domain/tenant/agentcontrol.go`** — struct tag padding only, 21 lines across the two files. No declarations, types, tag contents or validation rules change.

Formatted with **`github.com/golangci/golines` v0.15.0**, which is the fork golangci-lint v2.12.2 embeds. Worth recording, because `segmentio/golines` formats these two files differently and reports them clean — that is what let the failure through on #540 when I checked locally.

Only the two files CI flagged are touched. Running the fork across all of `internal/core/domain/` wants to reformat 42 files and roughly 2500 lines of pre-existing drift, which `--new-from-rev` correctly leaves out of scope here.

## Validation

- [x] `cd services/tms && task test` — passes
- [ ] `cd services/tms && task lint` — **not run.** golangci-lint does not start in this environment: it is built against Go 1.25 while the module targets Go 1.26 and exits with `can't load config`. This change was instead produced by running the exact golines fork and version that golangci-lint embeds, so its output should match byte for byte. CI is the real check.
- [ ] `cd client && pnpm build` — no client changes
- [ ] `cd client && pnpm lint` — no client changes
- [x] Other: `go build ./internal/core/domain/...` — clean

## Deployment Notes

Formatting only. No behaviour, schema, config or migration changes.

`Workers Builds: trenova` is expected to stay red. It has failed identically across #536, #537, #539 and #540, including on PRs that change no client files at all, and its logs sit behind an authenticated Cloudflare dashboard. It needs someone with dashboard access.

## Checklist

- [x] I kept the change focused and reviewable.
- [x] I followed `AGENTS.md`, `CLAUDE.md`, and existing repository patterns.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable. — formatting only, no behaviour change.
- [x] I updated relevant documentation, examples, migrations, or configuration.
- [x] I did not include secrets, credentials, private customer data, unrelated refactors, or placeholder code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXYnxBszfwkNUeeAcVSSNf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting and alignment for distance and agent control fields.
  * No user-facing behavior, data, or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->