### PR TITLE
fix(db): remove hardcoded Postgres epoch expressions from query SQL

### DIFF
--- a/docs/databases.md
+++ b/docs/databases.md
@@ -43,7 +43,7 @@ another dialect means adding a profile to `scripts/dialect-convert/profiles.py`,
 not writing a second converter — `profiles.py` already carries a starting sketch
 for SQL Server.
 
-Current state: **1471 of 1471 translated statements apply cleanly, producing 273
+Current state: **1518 of 1518 translated statements apply cleanly, producing 273
 tables.**
 
 ### What the converter translates
@@ -55,7 +55,7 @@ tables.**
 | `jsonb` / `json` | `TEXT` |
 | `varchar(n)`, `uuid`, `timestamptz`, ranges | `TEXT` |
 | `bigint`, `smallint`, `boolean`, identity columns | `INTEGER` |
-| `numeric(p,s)` | `NUMERIC` |
+| `numeric(p,s)` | `REAL` (NUMERIC affinity demotes integers and breaks float64 scans) |
 | `bytea` | `BLOB` |
 | `EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::bigint` | `(unixepoch())` |
 | `now()` | `CURRENT_TIMESTAMP` |
@@ -83,7 +83,7 @@ Every dropped statement is reported by reason rather than silently discarded.
 | `EXCLUDE USING gist` constraints | no exclusion constraints |
 | `ALTER TABLE ... ADD CONSTRAINT` | SQLite cannot add constraints after creation |
 | `ALTER TABLE ... ALTER COLUMN` | SQLite cannot alter column definitions |
-| `ALTER TABLE ... DROP COLUMN` | rejected whenever an index or `CHECK` still references the column |
+| `ALTER TABLE ... DROP COLUMN` | only when an index or constraint still pins the column; otherwise it is emitted, dropping blocking indexes first |
 | `CREATE STATISTICS`, publications, RLS policies | no planner statistics or replication objects |
 
 The practical consequence: **a SQLite database has weaker integrity guarantees
@@ -127,6 +127,37 @@ correct, coverage is narrower. Stemming, ranking and multi-word queries are lost
 - **Advisory locks, `SELECT ... FOR UPDATE`, `SET LOCAL lock_timeout`.** The
   connection layer skips these on SQLite; concurrency is serialised by SQLite's
   single-writer model instead.
+
+## Postgres-only SQL in query code
+
+Migrations are not the only place Postgres dialect leaks in. Query code can hardcode
+it too, and that only fails when the code path runs — the RBAC role lookup broke login
+on SQLite this way, long after migrations and seeding both passed.
+
+The current-timestamp idiom is the common case and now has a helper:
+
+```go
+r.db.NowEpoch()                    // on a *postgres.Connection
+dbdialect.NowEpochFromBun(db)      // when you only have a bun.IDB or a tx
+```
+
+`TestNoHardcodedEpochExpression` in `pkg/dbdialect` fails the build if
+`extract(epoch ...)` reappears in query SQL. Model `default:` tags are exempt: bun
+only emits those for zero values, and `BeforeAppendModel` sets the fields first.
+
+A file that is deliberately Postgres-only opts out with a `dialect:postgres-only`
+marker near its package clause, and must gate itself on a capability instead.
+
+### Known gaps not yet addressed
+
+These still contain Postgres-only SQL and will fail at runtime on SQLite:
+
+| Construct | Extent | Note |
+|---|---|---|
+| `ILIKE` | 17 files | SQLite `LIKE` is already case-insensitive for ASCII, so this is a mechanical swap |
+| `::int`, `::float`, `::bigint`, `::numeric`, `::text`, `::jsonb` casts | ~109 occurrences | mostly in analytics and reporting aggregates |
+| `date_trunc` bucketing | reporting compiler, A/R analytics | marked `dialect:postgres-only`; needs a `strftime` equivalent |
+| `pg_stat_activity`, `pg_blocking_pids` | database session diagnostics | gated on `CapSessionDiagnostic`, returns 501 on SQLite |
 
 ## Error handling
 

--- a/services/tms/internal/core/services/ediservice/service.go
+++ b/services/tms/internal/core/services/ediservice/service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/emoss08/trenova/internal/core/services/internaledilifecycle"
 	"github.com/emoss08/trenova/internal/core/services/notificationservice"
 	"github.com/emoss08/trenova/internal/infrastructure/observability/metrics"
+	"github.com/emoss08/trenova/pkg/dbdialect"
 	"github.com/emoss08/trenova/pkg/dberror"
 	"github.com/emoss08/trenova/pkg/domaintypes"
 	"github.com/emoss08/trenova/pkg/errortypes"
@@ -1812,12 +1813,14 @@ func (s *Service) setShipmentTenderStatus(
 	tenantInfo pagination.TenantInfo,
 	status shipment.TenderStatus,
 ) error {
-	results, err := s.db.DBForContext(ctx).
+	db := s.db.DBForContext(ctx)
+
+	results, err := db.
 		NewUpdate().
 		Model((*shipment.Shipment)(nil)).
 		Set("tender_status = ?", status).
 		Set("version = version + 1").
-		Set("updated_at = extract(epoch from current_timestamp)::bigint").
+		Set("updated_at = "+dbdialect.NowEpochFromBun(db)).
 		Where("id = ?", shipmentID).
 		Where("organization_id = ?", tenantInfo.OrgID).
 		Where("business_unit_id = ?", tenantInfo.BuID).

--- a/services/tms/internal/core/services/hosprojection/project_test.go
+++ b/services/tms/internal/core/services/hosprojection/project_test.go
@@ -34,8 +34,8 @@ func TestProject_PlentyOfHoursRunsOnCurrentClocks(t *testing.T) {
 	t.Parallel()
 
 	result := Project(Input{
-		Now:       baseTime,
-		Departure: baseTime,
+		Now:         baseTime,
+		Departure:   baseTime,
 		TripDriveMs: hoursMs(4),
 		Clocks: Clocks{
 			DriveMs: hoursMs(9),
@@ -295,10 +295,15 @@ func TestProject_CanadianJurisdictionSkipsSplitAndRestart(t *testing.T) {
 		BreakMs: 8 * hourMs,
 	}
 	result := Project(Input{
-		Now:          baseTime,
-		Departure:    baseTime + hoursSec(40),
-		TripDriveMs:  hoursMs(8),
-		Clocks:       Clocks{DriveMs: hoursMs(8), ShiftMs: hoursMs(10), CycleMs: hoursMs(1), BreakMs: hoursMs(8)},
+		Now:         baseTime,
+		Departure:   baseTime + hoursSec(40),
+		TripDriveMs: hoursMs(8),
+		Clocks: Clocks{
+			DriveMs: hoursMs(8),
+			ShiftMs: hoursMs(10),
+			CycleMs: hoursMs(1),
+			BreakMs: hoursMs(8),
+		},
 		ClocksAt:     baseTime,
 		DutyStatus:   telematics.DutyStatusOffDuty,
 		Limits:       limits,

--- a/services/tms/internal/core/services/reporting/compiler/outputs.go
+++ b/services/tms/internal/core/services/reporting/compiler/outputs.go
@@ -1,3 +1,4 @@
+// dialect:postgres-only — report date bucketing compiles to date_trunc.
 package compiler
 
 import (

--- a/services/tms/internal/infrastructure/database/seeds/development/12_driverpay_ledger.go
+++ b/services/tms/internal/infrastructure/database/seeds/development/12_driverpay_ledger.go
@@ -14,6 +14,7 @@ import (
 	"github.com/emoss08/trenova/internal/core/domain/worker"
 	"github.com/emoss08/trenova/internal/core/services/driversettlementservice"
 	"github.com/emoss08/trenova/internal/infrastructure/database/common"
+	"github.com/emoss08/trenova/pkg/dbdialect"
 	"github.com/emoss08/trenova/pkg/domaintypes"
 	"github.com/emoss08/trenova/pkg/seedhelpers"
 	"github.com/emoss08/trenova/shared/pulid"
@@ -73,7 +74,13 @@ func (s *DriverPayLedgerSeed) Run(ctx context.Context, tx bun.Tx) error {
 				return fmt.Errorf("ensure ledger accounts: %w", err)
 			}
 
-			if err = s.configureAccountingControl(ctx, tx, org.ID, org.BusinessUnitID, accounts); err != nil {
+			if err = s.configureAccountingControl(
+				ctx,
+				tx,
+				org.ID,
+				org.BusinessUnitID,
+				accounts,
+			); err != nil {
 				return fmt.Errorf("configure accounting control: %w", err)
 			}
 
@@ -81,11 +88,26 @@ func (s *DriverPayLedgerSeed) Run(ctx context.Context, tx bun.Tx) error {
 				return fmt.Errorf("configure cost categories: %w", err)
 			}
 
-			if err = s.ensureRecurringEarnings(ctx, tx, sc, org.ID, org.BusinessUnitID, admin.ID); err != nil {
+			if err = s.ensureRecurringEarnings(
+				ctx,
+				tx,
+				sc,
+				org.ID,
+				org.BusinessUnitID,
+				admin.ID,
+			); err != nil {
 				return fmt.Errorf("ensure recurring earnings: %w", err)
 			}
 
-			if err = s.postSeededSettlementJournals(ctx, tx, sc, org.ID, org.BusinessUnitID, admin.ID, accounts); err != nil {
+			if err = s.postSeededSettlementJournals(
+				ctx,
+				tx,
+				sc,
+				org.ID,
+				org.BusinessUnitID,
+				admin.ID,
+				accounts,
+			); err != nil {
 				return fmt.Errorf("post seeded settlement journals: %w", err)
 			}
 
@@ -322,14 +344,86 @@ func (s *DriverPayLedgerSeed) ensureRecurringEarnings(
 		capMinor    int64
 		paidMinor   int64
 	}{
-		{payWorkerJohn, "PERDIEM", driverpay.EarningStatusActive, driverpay.EarningFrequencyEverySettlement, "OTR per diem — IRS substantiated M&IE", 33250, 0, 299250},
-		{payWorkerRobert, "PERDIEM", driverpay.EarningStatusActive, driverpay.EarningFrequencyEverySettlement, "OTR per diem — IRS substantiated M&IE", 33250, 0, 199500},
-		{payWorkerEmily, "PERDIEM", driverpay.EarningStatusActive, driverpay.EarningFrequencyEverySettlement, "Regional per diem — partial-day M&IE", 19950, 0, 119700},
-		{payWorkerJane, "SAFETY", driverpay.EarningStatusActive, driverpay.EarningFrequencyMonthly, "Quarterly safety bonus accrual — clean CSA record", 12500, 0, 62500},
-		{payWorkerSarah, "STIPEND", driverpay.EarningStatusActive, driverpay.EarningFrequencyMonthly, "Cell phone and ELD data stipend", 5000, 0, 25000},
-		{payWorkerMike, "PERFORM", driverpay.EarningStatusActive, driverpay.EarningFrequencyEverySettlement, "On-time delivery bonus program", 7500, 195000, 97500},
-		{payWorkerCarlos, "EQUIPRENT", driverpay.EarningStatusActive, driverpay.EarningFrequencyEverySettlement, "APU rental — company use of driver-owned unit", 6000, 0, 78000},
-		{payWorkerDavid, "LONGEVITY", driverpay.EarningStatusPaused, driverpay.EarningFrequencyMonthly, "Longevity bonus — 3+ years of service", 10000, 0, 30000},
+		{
+			payWorkerJohn,
+			"PERDIEM",
+			driverpay.EarningStatusActive,
+			driverpay.EarningFrequencyEverySettlement,
+			"OTR per diem — IRS substantiated M&IE",
+			33250,
+			0,
+			299250,
+		},
+		{
+			payWorkerRobert,
+			"PERDIEM",
+			driverpay.EarningStatusActive,
+			driverpay.EarningFrequencyEverySettlement,
+			"OTR per diem — IRS substantiated M&IE",
+			33250,
+			0,
+			199500,
+		},
+		{
+			payWorkerEmily,
+			"PERDIEM",
+			driverpay.EarningStatusActive,
+			driverpay.EarningFrequencyEverySettlement,
+			"Regional per diem — partial-day M&IE",
+			19950,
+			0,
+			119700,
+		},
+		{
+			payWorkerJane,
+			"SAFETY",
+			driverpay.EarningStatusActive,
+			driverpay.EarningFrequencyMonthly,
+			"Quarterly safety bonus accrual — clean CSA record",
+			12500,
+			0,
+			62500,
+		},
+		{
+			payWorkerSarah,
+			"STIPEND",
+			driverpay.EarningStatusActive,
+			driverpay.EarningFrequencyMonthly,
+			"Cell phone and ELD data stipend",
+			5000,
+			0,
+			25000,
+		},
+		{
+			payWorkerMike,
+			"PERFORM",
+			driverpay.EarningStatusActive,
+			driverpay.EarningFrequencyEverySettlement,
+			"On-time delivery bonus program",
+			7500,
+			195000,
+			97500,
+		},
+		{
+			payWorkerCarlos,
+			"EQUIPRENT",
+			driverpay.EarningStatusActive,
+			driverpay.EarningFrequencyEverySettlement,
+			"APU rental — company use of driver-owned unit",
+			6000,
+			0,
+			78000,
+		},
+		{
+			payWorkerDavid,
+			"LONGEVITY",
+			driverpay.EarningStatusPaused,
+			driverpay.EarningFrequencyMonthly,
+			"Longevity bonus — 3+ years of service",
+			10000,
+			0,
+			30000,
+		},
 	}
 
 	rows := make([]*driverpay.RecurringEarning, 0, len(defs))
@@ -375,7 +469,10 @@ func (s *DriverPayLedgerSeed) ensureRecurringEarnings(
 
 	seedhelpers.LogSuccess(
 		"Created recurring earning fixtures",
-		fmt.Sprintf("- Created %d recurring earnings (per diem, bonuses, stipends, equipment rental)", len(rows)),
+		fmt.Sprintf(
+			"- Created %d recurring earnings (per diem, bonuses, stipends, equipment rental)",
+			len(rows),
+		),
 	)
 	return nil
 }
@@ -698,7 +795,10 @@ func (s *DriverPayLedgerSeed) postSeededSettlementJournals(
 	if posted > 0 {
 		seedhelpers.LogSuccess(
 			"Posted seeded settlements to the general ledger",
-			fmt.Sprintf("- Created %d balanced journal batches with period balances for cost control", posted),
+			fmt.Sprintf(
+				"- Created %d balanced journal batches with period balances for cost control",
+				posted,
+			),
 		)
 	}
 	return nil
@@ -728,7 +828,7 @@ func (s *DriverPayLedgerSeed) applyBalances(
 			period_credit_minor = gb.period_credit_minor + EXCLUDED.period_credit_minor,
 			net_change_minor = gb.net_change_minor + EXCLUDED.net_change_minor,
 			last_journal_entry_id = EXCLUDED.last_journal_entry_id,
-			updated_at = extract(epoch from current_timestamp)::bigint
+			updated_at = `+dbdialect.NowEpochFromBun(tx)+`
 	`,
 		orgID, buID, line.GLAccountID, fiscalYearID, fiscalPeriodID,
 		line.DebitAmount, line.CreditAmount, line.NetAmount, entryID,
@@ -740,7 +840,7 @@ func (s *DriverPayLedgerSeed) applyBalances(
 		Set("current_balance = current_balance + ?", line.NetAmount).
 		Set("debit_balance = debit_balance + ?", line.DebitAmount).
 		Set("credit_balance = credit_balance + ?", line.CreditAmount).
-		Set("updated_at = extract(epoch from current_timestamp)::bigint").
+		Set("updated_at = "+dbdialect.NowEpochFromBun(tx)).
 		Where("id = ?", line.GLAccountID).
 		Where("organization_id = ?", orgID).
 		Where("business_unit_id = ?", buID).

--- a/services/tms/internal/infrastructure/pdfrender/gotenberg/client_live_test.go
+++ b/services/tms/internal/infrastructure/pdfrender/gotenberg/client_live_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
-	fitz "github.com/gen2brain/go-fitz"
 	"github.com/emoss08/trenova/internal/core/domain/documenttemplate"
 	"github.com/emoss08/trenova/internal/core/ports/services"
 	"github.com/emoss08/trenova/internal/infrastructure/config"
+	fitz "github.com/gen2brain/go-fitz"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"

--- a/services/tms/internal/infrastructure/postgres/connection.go
+++ b/services/tms/internal/infrastructure/postgres/connection.go
@@ -112,9 +112,18 @@ func oltpSettings(cfg *config.Config) connectionSettings {
 		connMaxLifetime: cfg.Database.ConnMaxLifetime,
 		connMaxIdleTime: cfg.Database.ConnMaxIdleTime,
 		connParams: map[string]any{
-			"statement_timeout":                   fmt.Sprintf("%dms", max(cfg.Database.GetStatementTimeout().Milliseconds(), 1)),
-			"lock_timeout":                        fmt.Sprintf("%dms", max(cfg.Database.GetLockTimeout().Milliseconds(), 1)),
-			"idle_in_transaction_session_timeout": fmt.Sprintf("%dms", max(cfg.Database.GetIdleTxTimeout().Milliseconds(), 1)),
+			"statement_timeout": fmt.Sprintf(
+				"%dms",
+				max(cfg.Database.GetStatementTimeout().Milliseconds(), 1),
+			),
+			"lock_timeout": fmt.Sprintf(
+				"%dms",
+				max(cfg.Database.GetLockTimeout().Milliseconds(), 1),
+			),
+			"idle_in_transaction_session_timeout": fmt.Sprintf(
+				"%dms",
+				max(cfg.Database.GetIdleTxTimeout().Milliseconds(), 1),
+			),
 		},
 		registerStats: true,
 	}
@@ -130,10 +139,19 @@ func reportingSettings(cfg *config.Config) connectionSettings {
 		connMaxLifetime: cfg.Database.ConnMaxLifetime,
 		connMaxIdleTime: cfg.Database.ConnMaxIdleTime,
 		connParams: map[string]any{
-			"statement_timeout":                   fmt.Sprintf("%dms", max(reporting.GetStatementTimeout().Milliseconds(), 1)),
-			"lock_timeout":                        fmt.Sprintf("%dms", max(cfg.Database.GetLockTimeout().Milliseconds(), 1)),
-			"idle_in_transaction_session_timeout": fmt.Sprintf("%dms", max(cfg.Database.GetIdleTxTimeout().Milliseconds(), 1)),
-			"default_transaction_read_only":       "on",
+			"statement_timeout": fmt.Sprintf(
+				"%dms",
+				max(reporting.GetStatementTimeout().Milliseconds(), 1),
+			),
+			"lock_timeout": fmt.Sprintf(
+				"%dms",
+				max(cfg.Database.GetLockTimeout().Milliseconds(), 1),
+			),
+			"idle_in_transaction_session_timeout": fmt.Sprintf(
+				"%dms",
+				max(cfg.Database.GetIdleTxTimeout().Milliseconds(), 1),
+			),
+			"default_transaction_read_only": "on",
 		},
 		registerStats: false,
 	}
@@ -381,4 +399,13 @@ func (c *Connection) Close() error {
 		return c.db.Close()
 	}
 	return nil
+}
+
+// NowEpoch is the current-Unix-timestamp SQL for the connection's dialect.
+func (c *Connection) NowEpoch() string {
+	if c.cfg == nil {
+		return dbdialect.DefaultKind.NowEpoch()
+	}
+
+	return c.cfg.Database.GetDialect().NowEpoch()
 }

--- a/services/tms/internal/infrastructure/postgres/repositories/accountsreceivablerepository/analytics.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/accountsreceivablerepository/analytics.go
@@ -1,3 +1,4 @@
+// dialect:postgres-only — collections analytics bucket dates with date_trunc.
 package accountsreceivablerepository
 
 import (

--- a/services/tms/internal/infrastructure/postgres/repositories/databasesessionrepository/databasesession.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/databasesessionrepository/databasesession.go
@@ -1,3 +1,5 @@
+// dialect:postgres-only — reads pg_stat_activity and pg_blocking_pids, which
+// have no counterpart outside PostgreSQL. Callers gate on CapSessionDiagnostics.
 package databasesessionrepository
 
 import (
@@ -9,6 +11,7 @@ import (
 	"github.com/emoss08/trenova/internal/core/ports"
 	"github.com/emoss08/trenova/internal/core/ports/repositories"
 	"github.com/emoss08/trenova/internal/infrastructure/postgres"
+	"github.com/emoss08/trenova/pkg/dbdialect"
 	"github.com/emoss08/trenova/pkg/dberror"
 	"github.com/emoss08/trenova/pkg/errortypes"
 	"github.com/uptrace/bun"
@@ -38,6 +41,10 @@ func New(p Params) repositories.DatabaseSessionRepository {
 }
 
 func (r *repository) ListBlocked(ctx context.Context) ([]*system.DatabaseSessionChain, error) {
+	if err := dbdialect.RequireFromBun(r.db.DB(), dbdialect.CapSessionDiagnostic); err != nil {
+		return nil, err
+	}
+
 	var rows []*system.DatabaseSessionChain
 
 	err := r.db.DBForContext(ctx).NewRaw(`
@@ -76,6 +83,10 @@ func (r *repository) Terminate(
 	ctx context.Context,
 	pid int64,
 ) (*system.TerminateDatabaseSessionResult, error) {
+	if err := dbdialect.RequireFromBun(r.db.DB(), dbdialect.CapSessionDiagnostic); err != nil {
+		return nil, err
+	}
+
 	if pid <= 0 {
 		return nil, errortypes.NewValidationError(
 			"pid",

--- a/services/tms/internal/infrastructure/postgres/repositories/documentparsingrulerepository/documentparsingrule.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/documentparsingrulerepository/documentparsingrule.go
@@ -274,7 +274,7 @@ func (r *repository) ArchivePublishedVersions(
 		NewUpdate().
 		Model((*documentparsingrule.RuleVersion)(nil)).
 		Set(cols.Status.Set(), documentparsingrule.VersionStatusArchived).
-		Set(cols.UpdatedAt.SetExpr("extract(epoch from current_timestamp)::bigint")).
+		Set(cols.UpdatedAt.SetExpr(r.db.NowEpoch())).
 		Where(cols.RuleSetID.Eq(), ruleSetID).
 		Where(cols.OrganizationID.Eq(), orgID).
 		Where(cols.BusinessUnitID.Eq(), buID).
@@ -292,7 +292,7 @@ func (r *repository) SetPublishedVersion(
 		NewUpdate().
 		Model((*documentparsingrule.RuleSet)(nil)).
 		Set(cols.PublishedVersionID.Set(), versionID).
-		Set(cols.UpdatedAt.SetExpr("extract(epoch from current_timestamp)::bigint")).
+		Set(cols.UpdatedAt.SetExpr(r.db.NowEpoch())).
 		Where(cols.ID.Eq(), ruleSetID).
 		Where(cols.OrganizationID.Eq(), orgID).
 		Where(cols.BusinessUnitID.Eq(), buID).

--- a/services/tms/internal/infrastructure/postgres/repositories/driverpayrepository/assignment.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/driverpayrepository/assignment.go
@@ -110,7 +110,7 @@ func (r *workerPayAssignmentRepository) ListForProfile(
 		Where("wpa.business_unit_id = ?", tenantInfo.BuID).
 		Where("wpa.pay_profile_id = ?", profileID).
 		Where(
-			"wpa.effective_to IS NULL OR wpa.effective_to > extract(epoch from current_timestamp)::bigint",
+			"wpa.effective_to IS NULL OR wpa.effective_to > "+r.db.NowEpoch(),
 		).
 		Relation("Worker", func(q *bun.SelectQuery) *bun.SelectQuery { return q }).
 		Order("wpa.effective_from DESC").

--- a/services/tms/internal/infrastructure/postgres/repositories/driverpayrepository/payprofile.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/driverpayrepository/payprofile.go
@@ -248,7 +248,7 @@ func (r *payProfileRepository) CountActiveAssignments(
 		Where("wpa.organization_id = ?", tenantInfo.OrgID).
 		Where("wpa.business_unit_id = ?", tenantInfo.BuID).
 		Where("wpa.pay_profile_id = ?", profileID).
-		Where("wpa.effective_to IS NULL OR wpa.effective_to > extract(epoch from current_timestamp)::bigint").
+		Where("wpa.effective_to IS NULL OR wpa.effective_to > " + r.db.NowEpoch()).
 		Count(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("count active pay assignments: %w", err)

--- a/services/tms/internal/infrastructure/postgres/repositories/driversettlementrepository/batch.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/driversettlementrepository/batch.go
@@ -180,7 +180,7 @@ func (r *batchRepository) RecalculateAggregates(
 			exception_count = agg.exception_count,
 			total_gross_minor = agg.total_gross_minor,
 			total_net_minor = agg.total_net_minor,
-			updated_at = extract(epoch from current_timestamp)::bigint
+			updated_at = `+r.db.NowEpoch()+`
 		FROM (
 			SELECT
 				COUNT(*) FILTER (WHERE s.status != 'Voided') AS settlement_count,

--- a/services/tms/internal/infrastructure/postgres/repositories/edimappingprofilerepository/edimappingprofiler.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/edimappingprofilerepository/edimappingprofiler.go
@@ -269,7 +269,7 @@ func (r *repository) SaveMappingItems(
 		Set(itemCols.TargetLabel.SetExcluded()).
 		Set(itemCols.SourceLabel.SetExcluded()).
 		Set(itemCols.UpdatedByID.SetExcluded()).
-		Set(itemCols.UpdatedAt.SetExpr("extract(epoch FROM current_timestamp)::bigint")).
+		Set(itemCols.UpdatedAt.SetExpr(r.db.NowEpoch())).
 		Set(itemCols.Version.SetExpr(itemCols.Version.Qualified() + " + 1")).
 		Returning("*").
 		Exec(ctx)

--- a/services/tms/internal/infrastructure/postgres/repositories/edimessagerepository/edimessage.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/edimessagerepository/edimessage.go
@@ -290,7 +290,7 @@ func (r *repository) UpdateMessageDelivery(
 		Set("delivery_last_attempt_at = ?", req.DeliveryLastAttemptAt).
 		Set("delivery_sent_at = ?", req.DeliverySentAt).
 		Set("delivery_last_error = ?", req.DeliveryLastError).
-		Set("updated_at = extract(epoch from current_timestamp)::bigint").
+		Set("updated_at = "+r.db.NowEpoch()).
 		Where("id = ?", req.ID).
 		Where("organization_id = ?", req.TenantInfo.OrgID).
 		Where("business_unit_id = ?", req.TenantInfo.BuID).
@@ -627,7 +627,7 @@ func (r *repository) UpdateMessageAcknowledgment(
 		Set("ack_message_id = ?", req.AckMessageID).
 		Set("ack_received_at = ?", req.AckReceivedAt).
 		Set("ack_last_error = ?", req.AckLastError).
-		Set("updated_at = extract(epoch from current_timestamp)::bigint").
+		Set("updated_at = "+r.db.NowEpoch()).
 		Where("id = ?", req.ID).
 		Where("organization_id = ?", req.TenantInfo.OrgID).
 		Where("business_unit_id = ?", req.TenantInfo.BuID).

--- a/services/tms/internal/infrastructure/postgres/repositories/editenderchangerepository/editenderchange.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/editenderchangerepository/editenderchange.go
@@ -160,7 +160,7 @@ func (r *repository) SupersedeActionableTenderChanges(
 		NewUpdate().
 		Model((*edi.TenderChange)(nil)).
 		Set("status = ?", edi.TenderChangeStatusSuperseded).
-		Set("updated_at = extract(epoch from current_timestamp)::bigint").
+		Set("updated_at = "+r.db.NowEpoch()).
 		Where("recipient_id = ?", req.RecipientID).
 		Where("status IN (?)", bun.List(req.Statuses))
 	if req.ExcludeChangeID.IsNotNil() {

--- a/services/tms/internal/infrastructure/postgres/repositories/editenderrecipientrepository/editenderrecipient.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/editenderrecipientrepository/editenderrecipient.go
@@ -124,7 +124,7 @@ func (r *repository) UpsertTenderRecipient(
 		Set("partner_document_profile_id = COALESCE(NULLIF(EXCLUDED.partner_document_profile_id, ''), etr.partner_document_profile_id)").
 		Set("communication_profile_id = COALESCE(NULLIF(EXCLUDED.communication_profile_id, ''), etr.communication_profile_id)").
 		Set("status = ?", edi.TenderRecipientStatusActive).
-		Set("updated_at = extract(epoch from current_timestamp)::bigint").
+		Set("updated_at = " + r.db.NowEpoch()).
 		Returning("*").
 		Exec(ctx)
 	if err != nil {

--- a/services/tms/internal/infrastructure/postgres/repositories/editransferrepository/editransfer.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/editransferrepository/editransfer.go
@@ -339,7 +339,7 @@ func (r *repository) SetApprovalWorkflowRunID(
 		NewUpdate().
 		Model(entity).
 		Set(cols.ApprovalWorkflowRunID.Set(), req.RunID).
-		Set(cols.UpdatedAt.SetExpr("extract(epoch from current_timestamp)::bigint")).
+		Set(cols.UpdatedAt.SetExpr(r.db.NowEpoch())).
 		Where(cols.ID.Eq(), req.ID).
 		Where(cols.TargetOrganizationID.Eq(), req.TenantInfo.OrgID).
 		Where(cols.TargetBusinessUnitID.Eq(), req.TenantInfo.BuID).

--- a/services/tms/internal/infrastructure/postgres/repositories/emailrepository/email.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/emailrepository/email.go
@@ -210,12 +210,18 @@ func (r *repository) GetProfile(
 	return entity, dberror.HandleNotFoundError(err, "EmailProfile")
 }
 
-func (r *repository) CreateProfile(ctx context.Context, entity *email.Profile) (*email.Profile, error) {
+func (r *repository) CreateProfile(
+	ctx context.Context,
+	entity *email.Profile,
+) (*email.Profile, error) {
 	_, err := r.db.DB().NewInsert().Model(entity).Returning(profileReturningColumns).Exec(ctx)
 	return entity, err
 }
 
-func (r *repository) UpdateProfile(ctx context.Context, entity *email.Profile) (*email.Profile, error) {
+func (r *repository) UpdateProfile(
+	ctx context.Context,
+	entity *email.Profile,
+) (*email.Profile, error) {
 	previousVersion := entity.Version
 	entity.Version++
 	result, err := r.db.DB().NewUpdate().
@@ -234,7 +240,10 @@ func (r *repository) UpdateProfile(ctx context.Context, entity *email.Profile) (
 	return entity, nil
 }
 
-func (r *repository) DeleteProfile(ctx context.Context, req repositories.GetEmailEntityRequest) error {
+func (r *repository) DeleteProfile(
+	ctx context.Context,
+	req repositories.GetEmailEntityRequest,
+) error {
 	result, err := r.db.DB().NewDelete().
 		Model((*email.Profile)(nil)).
 		Where("id = ?", req.ID).
@@ -283,7 +292,7 @@ func (r *repository) UpsertAssignments(
 				Model(assignment).
 				On("CONFLICT (organization_id, business_unit_id, purpose) DO UPDATE").
 				Set("profile_id = EXCLUDED.profile_id").
-				Set("updated_at = EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::bigint").
+				Set("updated_at = " + r.db.NowEpoch()).
 				Returning("*").
 				Exec(ctx)
 			if err != nil {
@@ -336,12 +345,18 @@ func (r *repository) GetAssignedProfile(
 	return entity, dberror.HandleNotFoundError(err, "EmailProfile")
 }
 
-func (r *repository) CreateMessage(ctx context.Context, entity *email.Message) (*email.Message, error) {
+func (r *repository) CreateMessage(
+	ctx context.Context,
+	entity *email.Message,
+) (*email.Message, error) {
 	_, err := r.db.DB().NewInsert().Model(entity).Returning("*").Exec(ctx)
 	return entity, err
 }
 
-func (r *repository) UpdateMessage(ctx context.Context, entity *email.Message) (*email.Message, error) {
+func (r *repository) UpdateMessage(
+	ctx context.Context,
+	entity *email.Message,
+) (*email.Message, error) {
 	_, err := r.db.DB().
 		NewUpdate().
 		Model(entity).
@@ -526,7 +541,10 @@ func (r *repository) CreateSuppression(
 	return entity, err
 }
 
-func (r *repository) DeleteSuppression(ctx context.Context, req repositories.GetEmailEntityRequest) error {
+func (r *repository) DeleteSuppression(
+	ctx context.Context,
+	req repositories.GetEmailEntityRequest,
+) error {
 	result, err := r.db.DB().NewDelete().
 		Model((*email.Suppression)(nil)).
 		Where("id = ?", req.ID).

--- a/services/tms/internal/infrastructure/postgres/repositories/invoiceadjustmentrepository/invoiceadjustment.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/invoiceadjustmentrepository/invoiceadjustment.go
@@ -591,7 +591,7 @@ func (r *repository) UpdateBatchItem(
 		Set("error_message = ?", item.ErrorMessage).
 		Set("request_payload = ?", item.RequestPayload).
 		Set("result_payload = ?", item.ResultPayload).
-		Set("updated_at = extract(epoch from current_timestamp)::bigint").
+		Set("updated_at = " + r.db.NowEpoch()).
 		Exec(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("update batch item: %w", err)

--- a/services/tms/internal/infrastructure/postgres/repositories/journalpostingrepository/journalposting.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/journalpostingrepository/journalposting.go
@@ -316,7 +316,7 @@ func (r *repository) upsertPeriodBalance(
 			period_credit_minor = gb.period_credit_minor + EXCLUDED.period_credit_minor,
 			net_change_minor = gb.net_change_minor + EXCLUDED.net_change_minor,
 			last_journal_entry_id = EXCLUDED.last_journal_entry_id,
-			updated_at = extract(epoch from current_timestamp)::bigint
+			updated_at = `+r.db.NowEpoch()+`
 	`,
 		params.OrganizationID,
 		params.BusinessUnitID,
@@ -346,7 +346,7 @@ func (r *repository) updateGLAccountRunningBalance(
 		Set("current_balance = current_balance + ?", aggregate.net).
 		Set("debit_balance = debit_balance + ?", aggregate.debit).
 		Set("credit_balance = credit_balance + ?", aggregate.credit).
-		Set("updated_at = extract(epoch from current_timestamp)::bigint").
+		Set("updated_at = "+r.db.NowEpoch()).
 		Where("id = ?", aggregate.glAccountID).
 		Where("organization_id = ?", params.OrganizationID).
 		Where("business_unit_id = ?", params.BusinessUnitID).

--- a/services/tms/internal/infrastructure/postgres/repositories/rbacrepository/rbac.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/rbacrepository/rbac.go
@@ -167,7 +167,7 @@ func (r *repository) GetAuthorizedRoles(
 		Where("ura.organization_id = ?", orgID).
 		WhereGroup(" AND ", func(sq *bun.SelectQuery) *bun.SelectQuery {
 			return sq.Where("ura.expires_at IS NULL").
-				WhereOr("ura.expires_at > extract(epoch from current_timestamp)::bigint")
+				WhereOr("ura.expires_at > " + r.db.NowEpoch())
 		}).
 		Order("r.name ASC").
 		Scan(ctx)

--- a/services/tms/internal/infrastructure/postgres/repositories/shipmentimportchatrepository/shipmentimportchat.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/shipmentimportchatrepository/shipmentimportchat.go
@@ -155,7 +155,7 @@ func (r *repository) UpdateActiveConversationStatusByDocument(
 		Model((*shipmentimportchat.Conversation)(nil)).
 		Set("status = ?", status).
 		Set("status_reason = ?", reason).
-		Set("updated_at = extract(epoch from current_timestamp)::bigint").
+		Set("updated_at = "+r.db.NowEpoch()).
 		Where("document_id = ?", documentID).
 		Where("organization_id = ?", tenantInfo.OrgID).
 		Where("business_unit_id = ?", tenantInfo.BuID).

--- a/services/tms/internal/infrastructure/postgres/repositories/tableconfigurationrepository/tableconfiguration.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/tableconfigurationrepository/tableconfiguration.go
@@ -409,7 +409,7 @@ func (r *repository) ClearOrgDefaultForResource(
 		NewUpdate().
 		Model((*tableconfiguration.TableConfiguration)(nil)).
 		Set("is_org_default = ?", false).
-		Set("updated_at = extract(epoch from current_timestamp)::bigint").
+		Set("updated_at = "+r.db.NowEpoch()).
 		WhereGroup(" AND ", func(uq *bun.UpdateQuery) *bun.UpdateQuery {
 			return uq.Where("tc.resource = ?", resource).
 				Where("tc.is_org_default = ?", true).
@@ -441,7 +441,7 @@ func (r *repository) ClearDefaultForResource(
 		NewUpdate().
 		Model((*tableconfiguration.TableConfiguration)(nil)).
 		Set("is_default = ?", false).
-		Set("updated_at = extract(epoch from current_timestamp)::bigint").
+		Set("updated_at = "+r.db.NowEpoch()).
 		WhereGroup(" AND ", func(uq *bun.UpdateQuery) *bun.UpdateQuery {
 			return uq.Where("tc.user_id = ?", userID).
 				Where("tc.resource = ?", resource).

--- a/services/tms/internal/infrastructure/reporting/render/render_test.go
+++ b/services/tms/internal/infrastructure/reporting/render/render_test.go
@@ -435,4 +435,3 @@ func TestFormatCellEdgeCases(t *testing.T) {
 }
 
 func zapNop() *zap.Logger { return zap.NewNop() }
-

--- a/services/tms/pkg/dbdialect/bun.go
+++ b/services/tms/pkg/dbdialect/bun.go
@@ -20,3 +20,7 @@ func FromBun(db bun.IDB) Kind {
 func RequireFromBun(db bun.IDB, capability Capability) error {
 	return Require(FromBun(db), capability)
 }
+
+func NowEpochFromBun(db bun.IDB) string {
+	return FromBun(db).NowEpoch()
+}

--- a/services/tms/pkg/dbdialect/dbdialect.go
+++ b/services/tms/pkg/dbdialect/dbdialect.go
@@ -59,6 +59,7 @@ const (
 	CapTrigram           = Capability("trigram")
 	CapConcurrentIndex   = Capability("concurrent_index")
 	CapPartitionedTable  = Capability("partitioned_table")
+	CapSessionDiagnostic = Capability("session_diagnostics")
 )
 
 var postgresOnly = map[Capability]struct{}{
@@ -73,6 +74,7 @@ var postgresOnly = map[Capability]struct{}{
 	CapTrigram:           {},
 	CapConcurrentIndex:   {},
 	CapPartitionedTable:  {},
+	CapSessionDiagnostic: {},
 }
 
 func (k Kind) Supports(capability Capability) bool {
@@ -109,7 +111,20 @@ func (c Capability) DisplayName() string {
 		return "concurrent index creation"
 	case CapPartitionedTable:
 		return "declarative table partitioning"
+	case CapSessionDiagnostic:
+		return "database session diagnostics"
 	default:
 		return string(c)
 	}
+}
+
+// NowEpoch returns the SQL expression for the current Unix timestamp as an
+// integer. PostgreSQL has no portable spelling of this and SQLite has no
+// extract(), so query builders must ask for it rather than hardcoding either.
+func (k Kind) NowEpoch() string {
+	if k.IsSQLite() {
+		return "unixepoch()"
+	}
+
+	return "extract(epoch from current_timestamp)::bigint"
 }

--- a/services/tms/pkg/dbdialect/nowepoch_test.go
+++ b/services/tms/pkg/dbdialect/nowepoch_test.go
@@ -1,0 +1,112 @@
+package dbdialect_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/emoss08/trenova/pkg/dbdialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNowEpoch(t *testing.T) {
+	assert.Equal(t, "extract(epoch from current_timestamp)::bigint", dbdialect.Postgres.NowEpoch())
+	assert.Equal(t, "unixepoch()", dbdialect.SQLite.NowEpoch())
+}
+
+// TestNoHardcodedEpochExpression guards the class of bug that broke login on
+// SQLite: a Postgres-only epoch expression written straight into query SQL.
+// Model `default:` tags are exempt because bun only emits them for zero values,
+// and BeforeAppendModel sets those fields before every insert.
+const postgresOnlyMarker = "dialect:postgres-only"
+
+func TestNoHardcodedEpochExpression(t *testing.T) {
+	root := moduleRoot(t)
+
+	var offenders []string
+
+	// The helper itself is where the expression is allowed to live.
+	helper := filepath.Join(root, "pkg", "dbdialect", "dbdialect.go")
+
+	for _, dir := range []string{"internal", "pkg"} {
+		err := filepath.WalkDir(filepath.Join(root, dir), func(path string, entry os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			if path == helper {
+				return nil
+			}
+
+			contents, readErr := os.ReadFile(path) //nolint:gosec // walking our own source tree
+			if readErr != nil {
+				return readErr
+			}
+
+			// Files that are deliberately Postgres-only opt out with a marker.
+			// They must gate themselves on a capability instead.
+			if strings.Contains(string(contents), postgresOnlyMarker) {
+				return nil
+			}
+
+			for i, line := range strings.Split(string(contents), "\n") {
+				lower := strings.ToLower(line)
+				if !strings.Contains(lower, "extract(epoch") {
+					continue
+				}
+				if strings.Contains(lower, "default:extract(epoch") {
+					continue
+				}
+
+				rel, _ := filepath.Rel(root, path)
+				offenders = append(offenders, rel+":"+itoa(i+1))
+			}
+
+			return nil
+		})
+		require.NoError(t, err)
+	}
+
+	assert.Emptyf(
+		t,
+		offenders,
+		"use Kind.NowEpoch() or dbdialect.NowEpochFromBun() instead of a hardcoded epoch expression:\n%s",
+		strings.Join(offenders, "\n"),
+	)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+
+	digits := make([]byte, 0, 8)
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+
+	return string(digits)
+}
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	for range 10 {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		dir = filepath.Dir(dir)
+	}
+
+	t.Fatal("could not locate module root")
+
+	return ""
+}


### PR DESCRIPTION
# Description

Login failed on SQLite. The RBAC role lookup runs:

```sql
ura.expires_at > extract(epoch from current_timestamp)::bigint
```

which SQLite rejects with `near "from": syntax error`.

Migrations and seeding both passed beforehand, because this dialect leak lives in **query code** rather than in the schema. It only surfaces when that code path executes, which is a different failure class from everything fixed so far and the reason it appeared at login rather than at startup.

## Related Issue or Discussion

Follow-up to #540. Same SQLite development-support effort.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Refactor
- [x] Tests
- [ ] Build, CI, or infrastructure

## Scope

**`pkg/dbdialect`** — adds `Kind.NowEpoch()`, returning `extract(epoch from current_timestamp)::bigint` on PostgreSQL and `unixepoch()` on SQLite, plus `NowEpochFromBun()` for call sites holding only a `bun.IDB` or a transaction. `(*postgres.Connection).NowEpoch()` is the convenience for repositories.

**20 live call sites** across 16 repository, service and seed files now use those helpers instead of the literal expression.

The roughly 398 `default:` tags in domain models are deliberately **not** touched. bun only emits a default for a zero value, and `BeforeAppendModel` sets `created_at`/`updated_at` before every insert, so those never reach the database.

**`TestNoHardcodedEpochExpression`** fails the build if the expression reappears in query SQL. Worth noting that writing it immediately found **six occurrences a grep had already missed** — different casing and multi-line forms — which is the argument for having it rather than trusting a search.

**Three files are genuinely Postgres-only** rather than careless, and opt out with a `dialect:postgres-only` marker near the package clause:

- `databasesessionrepository` reads `pg_stat_activity` and `pg_blocking_pids`. It now gates on a new `CapSessionDiagnostic` capability and returns 501 on SQLite.
- The reporting compiler and A/R analytics bucket dates with `date_trunc`. Left as-is and recorded as an outstanding gap; a `strftime` equivalent is real work and did not belong in a login fix.

**`docs/databases.md`** gains a section on dialect leaks in query code, and a table of the remaining runtime surface — `ILIKE` in 17 files, roughly 109 numeric and jsonb casts, and the `date_trunc` bucketing — so the next contributor is not left discovering it one failing request at a time. Two stale figures are corrected while there: the converter now emits 1518 statements rather than 1471, and `numeric` maps to `REAL`, not `NUMERIC`.

## Validation

- [x] `cd services/tms && task test` — passes
- [ ] `cd services/tms && task lint` — **not run.** golangci-lint does not start here: built against Go 1.25 while the module targets 1.26. Changed files were formatted with `github.com/golangci/golines` v0.15.0, the fork golangci-lint v2.12.2 embeds, which is what CI checks.
- [ ] `cd client && pnpm build` — no client changes
- [ ] `cd client && pnpm lint` — no client changes
- [x] Other: `go build ./...` — clean
- [x] Other: `go test ./pkg/dbdialect/ ./pkg/dberror/ ./internal/infrastructure/database/seeder/` — passes, including the full SQLite seed run

## Deployment Notes

No migrations, config or env changes.

PostgreSQL generates identical SQL: `Kind.NowEpoch()` returns exactly the expression that was previously hardcoded. The only behavioural change on PostgreSQL is that database session diagnostics now pass through a capability check, which PostgreSQL always satisfies.

## Checklist

- [x] I kept the change focused and reviewable.
- [x] I followed `AGENTS.md`, `CLAUDE.md`, and existing repository patterns.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I updated relevant documentation, examples, migrations, or configuration.
- [x] I did not include secrets, credentials, private customer data, unrelated refactors, or placeholder code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXYnxBszfwkNUeeAcVSSNf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved SQLite compatibility, including support for more column conversions and `DROP COLUMN` operations.
  * Added database-aware timestamp handling across supported database systems.
  * Added capability checks for database session diagnostics.

* **Bug Fixes**
  * Corrected numeric type conversion to use SQLite `REAL` values where appropriate.
  * Improved reliability of timestamp updates across database operations.

* **Documentation**
  * Documented database-specific query behavior, timestamp helpers, compatibility markers, and remaining SQLite limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->