### PR TITLE
Brokerages cannot assign drivers: asset-side capability sweep

### DIFF
--- a/client/apps/web/src/components/command-palette/route-command-data.ts
+++ b/client/apps/web/src/components/command-palette/route-command-data.ts
@@ -1,7 +1,7 @@
 import { isNavGroup, type NavGroup, type NavItem, type NavModule } from "@/config/navigation.types";
 import type { SidebarLink } from "@/components/sidebar-nav";
 import type { QuickActionCommand } from "@/config/navigation.types";
-import { Operation, type OperationType } from "@trenova/shared/types/permission";
+import { canAccessQuickAction, type NavAccessContext } from "@/hooks/use-filtered-navigation";
 import { SettingsIcon } from "lucide-react";
 
 type PaletteIconComponent = React.ComponentType<{
@@ -184,14 +184,10 @@ export function buildRouteCommandGroups(
   });
 }
 
-function getRequiredOperation(action: QuickActionCommand): OperationType {
-  return action.requiredOperation ?? Operation.Create;
-}
-
 export function buildSuggestedCreateCommands(
   definitions: QuickActionCommand[],
   routeGroups: RouteCommandGroup[],
-  hasPermission: (resource: string, operation: OperationType) => boolean,
+  access: NavAccessContext,
 ): SuggestedCommandItem[] {
   const routeIconByPath = new Map<string, PaletteIconComponent>();
   for (const group of routeGroups) {
@@ -201,13 +197,7 @@ export function buildSuggestedCreateCommands(
   }
 
   return definitions
-    .filter((definition) => {
-      if (!definition.resource) {
-        return true;
-      }
-
-      return hasPermission(definition.resource, getRequiredOperation(definition));
-    })
+    .filter((definition) => canAccessQuickAction(definition, access))
     .map((definition) => ({
       id: definition.id,
       label: definition.label,

--- a/client/apps/web/src/components/command-palette/route-command-palette.tsx
+++ b/client/apps/web/src/components/command-palette/route-command-palette.tsx
@@ -11,6 +11,7 @@ import { navigationConfig } from "@/config/navigation.config";
 import { useAccessibleAdminLinks } from "@/hooks/use-accessible-admin-links";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useFilteredNavigation } from "@/hooks/use-filtered-navigation";
+import { useOrgCapabilities } from "@trenova/shared/hooks/use-org-capabilities";
 import { cn } from "@trenova/shared/lib/utils";
 import { apiService } from "@/services/api";
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
@@ -41,6 +42,7 @@ export function RouteCommandPalette() {
   const setOpen = useCommandPaletteStore((state) => state.setOpen);
   const toggleOpen = useCommandPaletteStore((state) => state.toggleOpen);
   const hasPermission = usePermissionStore((state) => state.hasPermission);
+  const capabilities = useOrgCapabilities();
   const [searchValue, setSearchValue] = useState("");
   const [recordEntityFilter, setRecordEntityFilter] = useState<SearchableEntityType | null>(null);
   const [mentionOpen, setMentionOpen] = useState(false);
@@ -55,12 +57,11 @@ export function RouteCommandPalette() {
   );
   const suggestedCommands = useMemo(
     () =>
-      buildSuggestedCreateCommands(
-        navigationConfig.quickActions ?? [],
-        routeGroups,
-        (resource, operation) => hasPermission(resource, operation),
-      ),
-    [hasPermission, routeGroups],
+      buildSuggestedCreateCommands(navigationConfig.quickActions ?? [], routeGroups, {
+        capabilities,
+        hasPermission,
+      }),
+    [capabilities, hasPermission, routeGroups],
   );
   const hasQuery = searchValue.trim().length > 0;
   const activeEntityOption = useMemo(

--- a/client/apps/web/src/components/navigation/quick-actions-section.tsx
+++ b/client/apps/web/src/components/navigation/quick-actions-section.tsx
@@ -3,9 +3,10 @@ import { SidebarSectionLabel } from "@/components/navigation/sidebar-primitives"
 import { navigationConfig } from "@/config/navigation.config";
 import type { QuickActionCommand } from "@/config/navigation.types";
 import { QUICK_ACTION_ICONS } from "@/config/quick-action-icons";
+import { canAccessQuickAction } from "@/hooks/use-filtered-navigation";
 import { useSidebarPreferences } from "@/hooks/use-sidebar-preferences";
+import { useOrgCapabilities } from "@trenova/shared/hooks/use-org-capabilities";
 import { usePermissionStore } from "@trenova/shared/stores/permission-store";
-import { Operation } from "@trenova/shared/types/permission";
 import type { LucideIcon } from "lucide-react";
 import { useMemo } from "react";
 import { Link } from "react-router";
@@ -18,6 +19,7 @@ interface SidebarQuickAction {
 
 export function QuickActionsSection() {
   const hasPermission = usePermissionStore((state) => state.hasPermission);
+  const capabilities = useOrgCapabilities();
   const { data: preferences } = useSidebarPreferences();
   const quickActionIds = preferences?.quickActionIds;
 
@@ -31,17 +33,14 @@ export function QuickActionsSection() {
         if (!definition || !QUICK_ACTION_ICONS[definition.id]) {
           return false;
         }
-        if (!definition.resource) {
-          return true;
-        }
-        return hasPermission(definition.resource, definition.requiredOperation ?? Operation.Create);
+        return canAccessQuickAction(definition, { capabilities, hasPermission });
       })
       .map((definition) => ({
         definition,
         icon: QUICK_ACTION_ICONS[definition.id],
         href: buildCommandHref(definition.path, definition.query),
       }));
-  }, [hasPermission, quickActionIds]);
+  }, [capabilities, hasPermission, quickActionIds]);
 
   if (actions.length === 0) {
     return null;

--- a/client/apps/web/src/components/work-modules/customer-mix.tsx
+++ b/client/apps/web/src/components/work-modules/customer-mix.tsx
@@ -26,7 +26,7 @@ const PICKUP_STATUS: Record<PickupStatus, { label: string; variant: BadgeVariant
   scheduled: { label: "Scheduled", variant: "outline" },
   confirmed: { label: "Confirmed", variant: "active" },
   tentative: { label: "Tentative", variant: "warning" },
-  unassigned: { label: "Needs driver", variant: "warning" },
+  unassigned: { label: "Needs coverage", variant: "warning" },
 };
 
 const SHARE_BAR_COLORS = [

--- a/client/apps/web/src/config/__tests__/asset-capability-navigation.test.tsx
+++ b/client/apps/web/src/config/__tests__/asset-capability-navigation.test.tsx
@@ -1,0 +1,250 @@
+import { adminLinks, navigationConfig } from "@/config/navigation.config";
+import { isNavGroup, type NavGroup, type NavItem } from "@/config/navigation.types";
+import { useAccessibleAdminLinks } from "@/hooks/use-accessible-admin-links";
+import {
+  canAccessNavEntry,
+  canAccessQuickAction,
+  filterNavModules,
+  type NavAccessContext,
+} from "@/hooks/use-filtered-navigation";
+import { renderHook } from "@testing-library/react";
+import { useAuthStore } from "@trenova/shared/stores/auth-store";
+import { usePermissionStore } from "@trenova/shared/stores/permission-store";
+import type { OrganizationCapabilities } from "@trenova/shared/types/organization-capability";
+import { Resource, type PermissionManifest } from "@trenova/shared/types/permission";
+import type { User } from "@trenova/shared/types/user";
+import { afterEach, describe, expect, it } from "vitest";
+
+const ALL_OPERATIONS = 0xffff;
+
+const hybrid: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: true,
+};
+const brokerageOnly: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: false,
+};
+
+/**
+ * Every permission is granted in both directions, so the only thing that can
+ * move an entry in or out of these expectations is the capability itself.
+ */
+function context(capabilities: OrganizationCapabilities): NavAccessContext {
+  return { capabilities, hasPermission: () => true };
+}
+
+function collectEntryIds(entries: (NavItem | NavGroup)[]): string[] {
+  return entries.flatMap((entry) =>
+    isNavGroup(entry) ? [entry.id, ...entry.items.map((item) => item.id)] : [entry.id],
+  );
+}
+
+function visibleIds(capabilities: OrganizationCapabilities): Set<string> {
+  const modules = filterNavModules(navigationConfig.modules, context(capabilities));
+  return new Set(modules.flatMap((module) => [module.id, ...collectEntryIds(module.navigation)]));
+}
+
+/** Nav entries an organization without its own trucks has no use for. */
+const ASSET_ONLY_NAV_IDS = [
+  "workers",
+  "tractors",
+  "trailers",
+  "fleet-codes",
+  "payroll",
+  "settlement-workspace",
+  "driver-settlements",
+  "settlement-disputes",
+  "driver-expenses",
+  "settlement-batches",
+  "pay-events",
+  "payroll-config-group",
+  "pay-profiles",
+  "recurring-deductions",
+  "recurring-earnings",
+  "pay-codes",
+  "pay-advances",
+  "escrow-accounts",
+];
+
+/**
+ * Equipment types and manufacturers describe what a load requires, not what the
+ * organization owns — a brokerage still has to say "this needs a 53' reefer".
+ */
+const NEVER_GATED_NAV_IDS = [
+  "equipment-types",
+  "equipment-manufacturers",
+  "dispatch-console",
+  "locations",
+  "location-categories",
+  "carriers",
+];
+
+describe("asset-only navigation", () => {
+  it("shows every asset entry to an organization that runs its own trucks", () => {
+    const ids = visibleIds(hybrid);
+
+    for (const id of [...ASSET_ONLY_NAV_IDS, ...NEVER_GATED_NAV_IDS]) {
+      expect(ids.has(id), `${id} should be visible to an asset organization`).toBe(true);
+    }
+  });
+
+  it("hides every asset entry from a brokerage", () => {
+    const ids = visibleIds(brokerageOnly);
+
+    for (const id of ASSET_ONLY_NAV_IDS) {
+      expect(ids.has(id), `${id} should be hidden from a brokerage`).toBe(false);
+    }
+  });
+
+  it("keeps freight-requirement configuration reachable for a brokerage", () => {
+    const ids = visibleIds(brokerageOnly);
+
+    for (const id of NEVER_GATED_NAV_IDS) {
+      expect(ids.has(id), `${id} should stay visible to a brokerage`).toBe(true);
+    }
+  });
+
+  it("drops the payroll module itself rather than emptying it out", () => {
+    const modules = filterNavModules(navigationConfig.modules, context(brokerageOnly));
+
+    expect(modules.some((module) => module.id === "payroll")).toBe(false);
+  });
+
+  it("gates the payroll module at the module level, as carrier settlements is", () => {
+    const payroll = navigationConfig.modules.find((module) => module.id === "payroll");
+    if (!payroll) {
+      throw new Error("payroll module missing from navigation config");
+    }
+
+    expect(canAccessNavEntry(payroll, context(brokerageOnly))).toBe(false);
+    expect(canAccessNavEntry(payroll, context(hybrid))).toBe(true);
+  });
+});
+
+const ASSET_ONLY_QUICK_ACTION_IDS = [
+  "create-worker",
+  "create-tractor",
+  "create-trailer",
+  "create-fleet-code",
+];
+
+const NEVER_GATED_QUICK_ACTION_IDS = [
+  "create-equipment-type",
+  "create-equipment-manufacturer",
+  "create-location",
+];
+
+describe("asset-only quick actions", () => {
+  function quickAction(id: string) {
+    const action = (navigationConfig.quickActions ?? []).find((entry) => entry.id === id);
+    if (!action) {
+      throw new Error(`quick action ${id} missing from navigation config`);
+    }
+    return action;
+  }
+
+  it("offers every create action to an asset organization", () => {
+    for (const id of [...ASSET_ONLY_QUICK_ACTION_IDS, ...NEVER_GATED_QUICK_ACTION_IDS]) {
+      expect(canAccessQuickAction(quickAction(id), context(hybrid)), id).toBe(true);
+    }
+  });
+
+  it("withholds the asset create actions from a brokerage", () => {
+    for (const id of ASSET_ONLY_QUICK_ACTION_IDS) {
+      expect(canAccessQuickAction(quickAction(id), context(brokerageOnly)), id).toBe(false);
+    }
+  });
+
+  it("keeps freight-requirement create actions available to a brokerage", () => {
+    for (const id of NEVER_GATED_QUICK_ACTION_IDS) {
+      expect(canAccessQuickAction(quickAction(id), context(brokerageOnly)), id).toBe(true);
+    }
+  });
+
+  it("still refuses a quick action the user lacks the permission for", () => {
+    expect(
+      canAccessQuickAction(quickAction("create-worker"), {
+        capabilities: hybrid,
+        hasPermission: () => false,
+      }),
+    ).toBe(false);
+  });
+});
+
+function manifest(): PermissionManifest {
+  return {
+    version: "1.0",
+    userId: "usr_01",
+    organizationId: "org_01",
+    activeRoleIds: [],
+    authorizedRoleIds: [],
+    activeRoles: [],
+    authorizedRoles: [],
+    requiresRoleActivation: false,
+    maxSensitivity: "internal",
+    permissions: Object.fromEntries(
+      Object.values(Resource).map((resource) => [resource, ALL_OPERATIONS]),
+    ),
+    routeAccess: {},
+    availableOrgs: [],
+    checksum: "abc123",
+    expiresAt: 1_782_403_304,
+  } as unknown as PermissionManifest;
+}
+
+function signIn(capabilities: OrganizationCapabilities) {
+  useAuthStore.setState({
+    user: {
+      currentOrganizationId: "org_01",
+      memberships: [
+        {
+          userId: "usr_01",
+          organizationId: "org_01",
+          isDefault: true,
+          organization: { id: "org_01", name: "Brokerage Co", ...capabilities },
+        },
+      ],
+    } as unknown as User,
+    isAuthenticated: true,
+  });
+
+  usePermissionStore.setState({ manifest: manifest(), lastFetched: Date.now(), isLoading: false });
+}
+
+describe("asset-only admin links", () => {
+  afterEach(() => {
+    usePermissionStore.getState().clearPermissions();
+    useAuthStore.setState({ user: null, isAuthenticated: false });
+  });
+
+  it("lists the driver settlement and driver portal controls for an asset organization", () => {
+    signIn(hybrid);
+
+    const { result } = renderHook(() => useAccessibleAdminLinks());
+    const hrefs = result.current.map((link) => link.href);
+
+    expect(hrefs).toContain("/admin/settlement-control");
+    expect(hrefs).toContain("/admin/dash-control");
+  });
+
+  it("withholds them from a brokerage while keeping the neutral controls", () => {
+    signIn(brokerageOnly);
+
+    const { result } = renderHook(() => useAccessibleAdminLinks());
+    const hrefs = result.current.map((link) => link.href);
+
+    expect(hrefs).not.toContain("/admin/settlement-control");
+    expect(hrefs).not.toContain("/admin/dash-control");
+    expect(hrefs).toContain("/admin/accounting-control");
+    expect(hrefs).toContain("/admin/organization-settings");
+  });
+
+  it("keeps every admin link declared in the config reachable when both halves run", () => {
+    signIn(hybrid);
+
+    const { result } = renderHook(() => useAccessibleAdminLinks());
+
+    expect(result.current).toHaveLength(adminLinks.filter((link) => !link.disabled).length);
+  });
+});

--- a/client/apps/web/src/config/navigation.config.ts
+++ b/client/apps/web/src/config/navigation.config.ts
@@ -134,6 +134,7 @@ const dispatchModule: NavModule = {
       label: "Workers",
       path: "/dispatch/workers",
       resource: Resource.Worker,
+      capability: OrganizationCapability.AssetOperations,
     },
     {
       id: "carriers",
@@ -165,6 +166,7 @@ const dispatchModule: NavModule = {
           label: "Fleet Codes",
           path: "/dispatch/configuration-files/fleet-codes",
           resource: Resource.FleetCode,
+          capability: OrganizationCapability.AssetOperations,
         },
       ],
     },
@@ -183,12 +185,14 @@ const equipmentModule: NavModule = {
       label: "Tractors",
       path: "/equipment/tractors",
       resource: Resource.Tractor,
+      capability: OrganizationCapability.AssetOperations,
     },
     {
       id: "trailers",
       label: "Trailers",
       path: "/equipment/trailers",
       resource: Resource.Trailer,
+      capability: OrganizationCapability.AssetOperations,
     },
     {
       id: "equipment-config-group",
@@ -350,6 +354,7 @@ const payrollModule: NavModule = {
   icon: WalletIcon,
   description: "Driver and owner-operator pay",
   basePath: "/payroll",
+  capability: OrganizationCapability.AssetOperations,
   navigation: [
     {
       id: "settlement-workspace",
@@ -868,6 +873,7 @@ export const navigationConfig: NavigationConfig = {
       requiredOperation: Operation.Create,
       query: { panelType: "create" },
       keywords: ["tractor", "equipment"],
+      capability: OrganizationCapability.AssetOperations,
     },
     {
       id: "create-trailer",
@@ -878,6 +884,7 @@ export const navigationConfig: NavigationConfig = {
       requiredOperation: Operation.Create,
       query: { panelType: "create" },
       keywords: ["trailer", "equipment"],
+      capability: OrganizationCapability.AssetOperations,
     },
     {
       id: "create-equipment-type",
@@ -918,6 +925,7 @@ export const navigationConfig: NavigationConfig = {
       requiredOperation: Operation.Create,
       query: { pageTab: "workers", panelType: "create" },
       keywords: ["worker", "driver", "employee"],
+      capability: OrganizationCapability.AssetOperations,
     },
     {
       id: "create-location-category",
@@ -938,6 +946,7 @@ export const navigationConfig: NavigationConfig = {
       requiredOperation: Operation.Create,
       query: { panelType: "create" },
       keywords: ["fleet", "code"],
+      capability: OrganizationCapability.AssetOperations,
     },
     {
       id: "create-hold-reason",
@@ -1094,6 +1103,7 @@ export const adminLinks: SidebarLink[] = [
     group: "Organization",
     resource: Resource.SettlementControl,
     requiredOperation: Operation.Read,
+    capability: OrganizationCapability.AssetOperations,
   },
   {
     href: "/admin/carrier-settlement-control",
@@ -1109,6 +1119,7 @@ export const adminLinks: SidebarLink[] = [
     group: "Organization",
     resource: Resource.DashControl,
     requiredOperation: Operation.Read,
+    capability: OrganizationCapability.AssetOperations,
   },
   {
     href: "/admin/agent-control",

--- a/client/apps/web/src/config/navigation.types.ts
+++ b/client/apps/web/src/config/navigation.types.ts
@@ -81,6 +81,11 @@ export interface QuickActionCommand {
   path: string;
   resource?: string;
   requiredOperation?: OperationType;
+  /**
+   * Mirrors `NavItem.capability`: a create shortcut for a half of the product
+   * the organization does not run would only lead to a route that refuses it.
+   */
+  capability?: OrganizationCapabilityType;
   query?: Record<string, string>;
   keywords?: string[];
 }

--- a/client/apps/web/src/hooks/use-filtered-navigation.ts
+++ b/client/apps/web/src/hooks/use-filtered-navigation.ts
@@ -4,6 +4,7 @@ import {
   type NavGroup,
   type NavItem,
   type NavModule,
+  type QuickActionCommand,
 } from "@/config/navigation.types";
 import { useOrgCapabilities } from "@trenova/shared/hooks/use-org-capabilities";
 import { usePermissionStore } from "@trenova/shared/stores/permission-store";
@@ -34,6 +35,25 @@ export function canAccessNavEntry(
 
   if (entry.resource) {
     return context.hasPermission(entry.resource, Operation.Read);
+  }
+
+  return true;
+}
+
+/**
+ * The quick-action twin of `canAccessNavEntry`. Quick actions create records
+ * rather than read them, so the permission they need defaults to Create.
+ */
+export function canAccessQuickAction(
+  action: QuickActionCommand,
+  context: NavAccessContext,
+): boolean {
+  if (action.capability && !hasOrganizationCapability(context.capabilities, action.capability)) {
+    return false;
+  }
+
+  if (action.resource) {
+    return context.hasPermission(action.resource, action.requiredOperation ?? Operation.Create);
   }
 
   return true;

--- a/client/apps/web/src/lib/__tests__/asset-capability-routes.test.ts
+++ b/client/apps/web/src/lib/__tests__/asset-capability-routes.test.ts
@@ -1,0 +1,203 @@
+import { routes } from "@/router";
+import { useAuthStore } from "@trenova/shared/stores/auth-store";
+import { usePermissionStore } from "@trenova/shared/stores/permission-store";
+import type { OrganizationCapabilities } from "@trenova/shared/types/organization-capability";
+import { Resource, type PermissionManifest } from "@trenova/shared/types/permission";
+import type { User } from "@trenova/shared/types/user";
+import type { LoaderFunctionArgs, RouteObject } from "react-router";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const ALL_OPERATIONS = 0xffff;
+const CAPABILITY_STATUS_TEXT = "Asset Operations not enabled";
+
+const hybrid: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: true,
+};
+const brokerageOnly: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: false,
+};
+
+function manifest(): PermissionManifest {
+  return {
+    version: "1.0",
+    userId: "usr_01",
+    organizationId: "org_01",
+    activeRoleIds: [],
+    authorizedRoleIds: [],
+    activeRoles: [],
+    authorizedRoles: [],
+    requiresRoleActivation: false,
+    maxSensitivity: "internal",
+    permissions: Object.fromEntries(
+      Object.values(Resource).map((resource) => [resource, ALL_OPERATIONS]),
+    ),
+    routeAccess: {},
+    availableOrgs: [],
+    checksum: "abc123",
+    expiresAt: 1_782_403_304,
+  } as unknown as PermissionManifest;
+}
+
+function signIn(capabilities: OrganizationCapabilities) {
+  useAuthStore.setState({
+    user: {
+      currentOrganizationId: "org_01",
+      memberships: [
+        {
+          userId: "usr_01",
+          organizationId: "org_01",
+          isDefault: true,
+          organization: { id: "org_01", name: "Brokerage Co", ...capabilities },
+        },
+      ],
+    } as unknown as User,
+    isAuthenticated: true,
+    // protectedLoader asks the store, not the network.
+    checkAuth: async () => true,
+  } as unknown as Parameters<typeof useAuthStore.setState>[0]);
+
+  usePermissionStore.setState({ manifest: manifest(), lastFetched: Date.now(), isLoading: false });
+}
+
+function joinPath(parent: string, child: string): string {
+  if (child.startsWith("/")) {
+    return child;
+  }
+  return `${parent.replace(/\/$/, "")}/${child}`;
+}
+
+function collectLoaders(
+  entries: RouteObject[],
+  parent = "",
+  found = new Map<string, RouteObject>(),
+): Map<string, RouteObject> {
+  for (const entry of entries) {
+    const path = entry.path === undefined ? parent : joinPath(parent, entry.path);
+    if (entry.path !== undefined) {
+      found.set(path, entry);
+    }
+    if (entry.children) {
+      collectLoaders(entry.children, path, found);
+    }
+  }
+  return found;
+}
+
+const routesByPath = collectLoaders(routes);
+
+async function runLoader(path: string): Promise<unknown> {
+  const route = routesByPath.get(path);
+  if (!route) {
+    throw new Error(`route ${path} is not registered`);
+  }
+  if (typeof route.loader !== "function") {
+    throw new Error(`route ${path} has no loader`);
+  }
+
+  return await route.loader({
+    request: new Request(`http://localhost${path}`),
+    params: {},
+    context: undefined,
+  } as unknown as LoaderFunctionArgs);
+}
+
+async function capabilityRefusal(path: string): Promise<Response | null> {
+  const thrown: unknown = await runLoader(path)
+    .then(() => null)
+    .catch((error: unknown) => error);
+
+  if (thrown instanceof Response && thrown.statusText === CAPABILITY_STATUS_TEXT) {
+    return thrown;
+  }
+  return null;
+}
+
+/** Routes that only make sense for an organization that owns trucks and employs drivers. */
+const ASSET_ONLY_ROUTES = [
+  "/dispatch/workers",
+  "/equipment/tractors",
+  "/equipment/trailers",
+  "/dispatch/configuration-files/fleet-codes",
+  "/payroll/workspace",
+  "/payroll/settlements",
+  "/payroll/disputes",
+  "/payroll/expenses",
+  "/payroll/settlement-batches",
+  "/payroll/pay-events",
+  "/payroll/pay-profiles",
+  "/payroll/deductions",
+  "/payroll/earnings",
+  "/payroll/pay-codes",
+  "/payroll/advances",
+  "/payroll/escrow-accounts",
+  "/admin/settlement-control",
+  "/admin/dash-control",
+];
+
+/**
+ * Equipment types describe the trailer a load needs, not one the organization
+ * owns, and dispatch controls keeps its page so the neutral settings on it stay
+ * editable — the driver-compliance fields are hidden inside the form instead.
+ */
+const NEVER_GATED_ROUTES = [
+  "/equipment/configuration-files/equipment-types",
+  "/equipment/configuration-files/equipment-manufacturers",
+  "/dispatch/configuration-files/location-categories",
+  "/admin/dispatch-controls",
+  "/dispatch/console",
+];
+
+describe("asset-only routes", () => {
+  beforeEach(() => {
+    usePermissionStore.getState().clearPermissions();
+    useAuthStore.setState({ user: null, isAuthenticated: false });
+  });
+
+  afterEach(() => {
+    usePermissionStore.getState().clearPermissions();
+    useAuthStore.setState({ user: null, isAuthenticated: false });
+  });
+
+  it("refuses every asset-only route for a brokerage", async () => {
+    signIn(brokerageOnly);
+
+    for (const path of ASSET_ONLY_ROUTES) {
+      const refusal = await capabilityRefusal(path);
+      expect(refusal, `${path} should be refused`).not.toBeNull();
+      expect(refusal?.status).toBe(403);
+      await expect(refusal?.text()).resolves.toBe(
+        "Asset Operations is not enabled for this organization",
+      );
+    }
+  });
+
+  it("lets an asset organization through every one of them", async () => {
+    signIn(hybrid);
+
+    for (const path of ASSET_ONLY_ROUTES) {
+      await expect(runLoader(path), `${path} should load`).resolves.toBeNull();
+    }
+  });
+
+  it("leaves freight-requirement and neutral routes open to a brokerage", async () => {
+    signIn(brokerageOnly);
+
+    for (const path of NEVER_GATED_ROUTES) {
+      await expect(runLoader(path), `${path} should stay open`).resolves.toBeNull();
+    }
+  });
+
+  it("checks the capability before the permission, so a refusal names the capability", async () => {
+    signIn(brokerageOnly);
+    usePermissionStore.setState({ manifest: null, lastFetched: null, isLoading: false });
+
+    const thrown: unknown = await runLoader("/payroll/workspace")
+      .then(() => null)
+      .catch((error: unknown) => error);
+
+    expect(thrown).toBeInstanceOf(Response);
+    expect((thrown as Response).statusText).toBe(CAPABILITY_STATUS_TEXT);
+  });
+});

--- a/client/apps/web/src/router.tsx
+++ b/client/apps/web/src/router.tsx
@@ -35,7 +35,7 @@ const guestLoader: LoaderFunction = async () => {
   return null;
 };
 
-const routes: RouteObject[] = [
+export const routes: RouteObject[] = [
   {
     element: <RootLayout />,
     errorElement: <RouteErrorBoundary />,
@@ -254,6 +254,7 @@ const routes: RouteObject[] = [
             path: "/payroll/workspace",
             loader: combineLoaders(
               protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
               createPermissionLoader(Resource.DriverSettlement),
             ),
             async lazy() {
@@ -266,6 +267,7 @@ const routes: RouteObject[] = [
             path: "/payroll/settlements",
             loader: combineLoaders(
               protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
               createPermissionLoader(Resource.DriverSettlement),
             ),
             async lazy() {
@@ -277,6 +279,7 @@ const routes: RouteObject[] = [
             path: "/payroll/disputes",
             loader: combineLoaders(
               protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
               createPermissionLoader(Resource.SettlementDispute),
             ),
             async lazy() {
@@ -286,7 +289,11 @@ const routes: RouteObject[] = [
           },
           {
             path: "/payroll/expenses",
-            loader: combineLoaders(protectedLoader, createPermissionLoader(Resource.DriverExpense)),
+            loader: combineLoaders(
+              protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
+              createPermissionLoader(Resource.DriverExpense),
+            ),
             async lazy() {
               const { DriverExpensesPage } = await import("@/routes/driver-expense/page");
               return { Component: DriverExpensesPage };
@@ -296,6 +303,7 @@ const routes: RouteObject[] = [
             path: "/payroll/settlement-batches",
             loader: combineLoaders(
               protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
               createPermissionLoader(Resource.DriverSettlement),
             ),
             async lazy() {
@@ -307,6 +315,7 @@ const routes: RouteObject[] = [
             path: "/payroll/pay-events",
             loader: combineLoaders(
               protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
               createPermissionLoader(Resource.DriverSettlement),
             ),
             async lazy() {
@@ -318,6 +327,7 @@ const routes: RouteObject[] = [
             path: "/payroll/pay-profiles",
             loader: combineLoaders(
               protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
               createPermissionLoader(Resource.DriverPayProfile),
             ),
             async lazy() {
@@ -329,6 +339,7 @@ const routes: RouteObject[] = [
             path: "/payroll/deductions",
             loader: combineLoaders(
               protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
               createPermissionLoader(Resource.RecurringDeduction),
             ),
             async lazy() {
@@ -340,6 +351,7 @@ const routes: RouteObject[] = [
             path: "/payroll/earnings",
             loader: combineLoaders(
               protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
               createPermissionLoader(Resource.RecurringEarning),
             ),
             async lazy() {
@@ -349,7 +361,11 @@ const routes: RouteObject[] = [
           },
           {
             path: "/payroll/pay-codes",
-            loader: combineLoaders(protectedLoader, createPermissionLoader(Resource.PayCode)),
+            loader: combineLoaders(
+              protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
+              createPermissionLoader(Resource.PayCode),
+            ),
             async lazy() {
               const { PayCodesPage } = await import("@/routes/pay-code/page");
               return { Component: PayCodesPage };
@@ -357,7 +373,11 @@ const routes: RouteObject[] = [
           },
           {
             path: "/payroll/advances",
-            loader: combineLoaders(protectedLoader, createPermissionLoader(Resource.PayAdvance)),
+            loader: combineLoaders(
+              protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
+              createPermissionLoader(Resource.PayAdvance),
+            ),
             async lazy() {
               const { PayAdvancesPage } = await import("@/routes/pay-advance/page");
               return { Component: PayAdvancesPage };
@@ -365,7 +385,11 @@ const routes: RouteObject[] = [
           },
           {
             path: "/payroll/escrow-accounts",
-            loader: combineLoaders(protectedLoader, createPermissionLoader(Resource.EscrowAccount)),
+            loader: combineLoaders(
+              protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
+              createPermissionLoader(Resource.EscrowAccount),
+            ),
             async lazy() {
               const { EscrowAccountsPage } = await import("@/routes/escrow-account/page");
               return { Component: EscrowAccountsPage };
@@ -769,7 +793,11 @@ const routes: RouteObject[] = [
           },
           {
             path: "/equipment/tractors",
-            loader: combineLoaders(protectedLoader, createPermissionLoader(Resource.Tractor)),
+            loader: combineLoaders(
+              protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
+              createPermissionLoader(Resource.Tractor),
+            ),
             async lazy() {
               const { TractorsPage } = await import("@/routes/tractor/page");
               return { Component: TractorsPage };
@@ -777,7 +805,11 @@ const routes: RouteObject[] = [
           },
           {
             path: "/equipment/trailers",
-            loader: combineLoaders(protectedLoader, createPermissionLoader(Resource.Trailer)),
+            loader: combineLoaders(
+              protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
+              createPermissionLoader(Resource.Trailer),
+            ),
             async lazy() {
               const { TrailersPage } = await import("@/routes/trailer/page");
               return { Component: TrailersPage };
@@ -819,6 +851,7 @@ const routes: RouteObject[] = [
             path: "/dispatch/configuration-files/fleet-codes",
             loader: combineLoaders(
               protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
               createPermissionLoader(Resource.FleetCode, Operation.Read),
             ),
             async lazy() {
@@ -921,7 +954,11 @@ const routes: RouteObject[] = [
           },
           {
             path: "/dispatch/workers",
-            loader: combineLoaders(protectedLoader, createPermissionLoader(Resource.Worker)),
+            loader: combineLoaders(
+              protectedLoader,
+              createCapabilityLoader(OrganizationCapability.AssetOperations),
+              createPermissionLoader(Resource.Worker),
+            ),
             async lazy() {
               const { WorkersPage } = await import("@/routes/worker/page");
               return { Component: WorkersPage };
@@ -1035,7 +1072,10 @@ const routes: RouteObject[] = [
               },
               {
                 path: "settlement-control",
-                loader: createPermissionLoader(Resource.SettlementControl, Operation.Read),
+                loader: combineLoaders(
+                  createCapabilityLoader(OrganizationCapability.AssetOperations),
+                  createPermissionLoader(Resource.SettlementControl, Operation.Read),
+                ),
                 async lazy() {
                   const { SettlementControlPage } =
                     await import("@/routes/settlement-control/page");
@@ -1056,7 +1096,10 @@ const routes: RouteObject[] = [
               },
               {
                 path: "dash-control",
-                loader: createPermissionLoader(Resource.DashControl, Operation.Read),
+                loader: combineLoaders(
+                  createCapabilityLoader(OrganizationCapability.AssetOperations),
+                  createPermissionLoader(Resource.DashControl, Operation.Read),
+                ),
                 async lazy() {
                   const { DashControlPage } = await import("@/routes/dash-control/page");
                   return { Component: DashControlPage };

--- a/client/apps/web/src/routes/dispatch-console/_components/__tests__/capacity-rail-capability.test.tsx
+++ b/client/apps/web/src/routes/dispatch-console/_components/__tests__/capacity-rail-capability.test.tsx
@@ -1,0 +1,138 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { useAuthStore } from "@trenova/shared/stores/auth-store";
+import type { OrganizationCapabilities } from "@trenova/shared/types/organization-capability";
+import type { User } from "@trenova/shared/types/user";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DispatchConsoleContent } from "../page-content";
+
+vi.mock("../capacity-rail", () => ({
+  CapacityRail: () => <div data-testid="capacity-rail" />,
+}));
+vi.mock("../console-center-pane", () => ({
+  ConsoleCenterPane: () => <div data-testid="console-center-pane" />,
+}));
+vi.mock("../inspector", () => ({
+  Inspector: () => <div data-testid="console-inspector" />,
+}));
+vi.mock("../console-overlays", () => ({
+  ConsoleOverlays: () => null,
+}));
+vi.mock("../summary-strip", () => ({
+  SummaryStrip: () => null,
+}));
+vi.mock("../console-toolbar", () => ({
+  ConsoleToolbar: () => null,
+}));
+vi.mock("../use-dispatch-actions", () => ({
+  useDispatchActions: () => ({
+    assign: vi.fn(),
+    undo: vi.fn(),
+    planAutoAssign: vi.fn(),
+    canUndo: false,
+    isAssigning: false,
+    isPlanning: false,
+    plan: null,
+  }),
+}));
+vi.mock("../use-dispatch-hotkeys", () => ({
+  useDispatchHotkeys: () => undefined,
+}));
+vi.mock("@/lib/queries/dispatch-console", () => ({
+  dispatchConsoleQueries: {
+    board: (input: unknown) => ({
+      queryKey: ["test-dispatch-board", input] as const,
+      queryFn: async () => ({ moves: [], drivers: [], summary: null }),
+    }),
+  },
+}));
+
+const hybrid: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: true,
+};
+const brokerageOnly: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: false,
+};
+
+function signIn(capabilities: OrganizationCapabilities) {
+  useAuthStore.setState({
+    user: {
+      currentOrganizationId: "org_01",
+      memberships: [
+        {
+          userId: "usr_01",
+          organizationId: "org_01",
+          isDefault: true,
+          organization: { id: "org_01", name: "Brokerage Co", ...capabilities },
+        },
+      ],
+    } as unknown as User,
+    isAuthenticated: true,
+  });
+}
+
+function renderConsole() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <NuqsTestingAdapter searchParams="">
+      <QueryClientProvider client={queryClient}>
+        <DispatchConsoleContent />
+      </QueryClientProvider>
+    </NuqsTestingAdapter>,
+  );
+}
+
+function boardGrid(): HTMLElement {
+  const pane = screen.getByTestId("console-center-pane");
+  const grid = pane.parentElement;
+  if (!grid) {
+    throw new Error("center pane is not inside a grid");
+  }
+  return grid;
+}
+
+describe("dispatch console capacity rail", () => {
+  afterEach(() => {
+    cleanup();
+    useAuthStore.setState({ user: null, isAuthenticated: false });
+  });
+
+  it("rails driver capacity for an organization that employs drivers", () => {
+    signIn(hybrid);
+
+    renderConsole();
+
+    expect(screen.getByTestId("capacity-rail")).toBeInTheDocument();
+    expect(boardGrid().className).toContain("lg:grid-cols-[300px_minmax(0,1fr)_320px]");
+  });
+
+  it("leaves the rail unmounted for a brokerage", () => {
+    signIn(brokerageOnly);
+
+    renderConsole();
+
+    expect(screen.queryByTestId("capacity-rail")).toBeNull();
+  });
+
+  it("closes the gap the rail leaves behind instead of holding its column open", () => {
+    signIn(brokerageOnly);
+
+    renderConsole();
+
+    expect(boardGrid().className).toContain("lg:grid-cols-[minmax(0,1fr)_320px]");
+    expect(boardGrid().className).not.toContain("300px");
+  });
+
+  it("keeps the board and inspector a brokerage still works from", () => {
+    signIn(brokerageOnly);
+
+    renderConsole();
+
+    expect(screen.getByTestId("console-center-pane")).toBeInTheDocument();
+    expect(screen.getByTestId("console-inspector")).toBeInTheDocument();
+  });
+});

--- a/client/apps/web/src/routes/dispatch-console/_components/__tests__/center-mode-capability.test.tsx
+++ b/client/apps/web/src/routes/dispatch-console/_components/__tests__/center-mode-capability.test.tsx
@@ -1,0 +1,133 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { useAuthStore } from "@trenova/shared/stores/auth-store";
+import type { OrganizationCapabilities } from "@trenova/shared/types/organization-capability";
+import type { User } from "@trenova/shared/types/user";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ConsoleCenterPane } from "../console-center-pane";
+import { ConsoleToolbar } from "../console-toolbar";
+import { resolveCenterMode } from "../url-state";
+
+vi.mock("../dispatch-timeline", () => ({
+  DispatchTimeline: () => <div data-testid="dispatch-timeline" />,
+}));
+vi.mock("../coverage-kanban", () => ({
+  CoverageKanban: () => <div data-testid="coverage-kanban" />,
+}));
+
+const hybrid: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: true,
+};
+const brokerageOnly: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: false,
+};
+
+function signIn(capabilities: OrganizationCapabilities) {
+  useAuthStore.setState({
+    user: {
+      currentOrganizationId: "org_01",
+      memberships: [
+        {
+          userId: "usr_01",
+          organizationId: "org_01",
+          isDefault: true,
+          organization: { id: "org_01", name: "Brokerage Co", ...capabilities },
+        },
+      ],
+    } as unknown as User,
+    isAuthenticated: true,
+  });
+}
+
+function renderPane(searchParams: string) {
+  return render(
+    <NuqsTestingAdapter searchParams={searchParams}>
+      <ConsoleCenterPane
+        moves={[]}
+        drivers={[]}
+        isLoading={false}
+        range={{ start: 0, end: 86_400 }}
+        zoom={1}
+        selectedMoveId={null}
+        selectedWorkerId={null}
+        onSelectMove={vi.fn()}
+        onSelectDriver={vi.fn()}
+      />
+    </NuqsTestingAdapter>,
+  );
+}
+
+function renderToolbar() {
+  return render(
+    <NuqsTestingAdapter searchParams="">
+      <ConsoleToolbar
+        canUndo={false}
+        isAssigning={false}
+        isPlanning={false}
+        onUndo={vi.fn()}
+        onPlan={vi.fn()}
+      />
+    </NuqsTestingAdapter>,
+  );
+}
+
+describe("resolveCenterMode", () => {
+  it("keeps the driver timeline for an organization that employs drivers", () => {
+    expect(resolveCenterMode("timeline", hybrid)).toBe("timeline");
+    expect(resolveCenterMode("board", hybrid)).toBe("board");
+  });
+
+  it("falls back to the coverage board for a brokerage", () => {
+    expect(resolveCenterMode("timeline", brokerageOnly)).toBe("board");
+    expect(resolveCenterMode("board", brokerageOnly)).toBe("board");
+  });
+});
+
+describe("dispatch console center view", () => {
+  afterEach(() => {
+    cleanup();
+    useAuthStore.setState({ user: null, isAuthenticated: false });
+  });
+
+  it("mounts the driver timeline for an organization that employs drivers", async () => {
+    signIn(hybrid);
+
+    renderPane("?mode=timeline");
+
+    expect(await screen.findByTestId("dispatch-timeline")).toBeInTheDocument();
+  });
+
+  it("leaves the driver timeline unmounted for a brokerage", async () => {
+    signIn(brokerageOnly);
+
+    renderPane("?mode=timeline");
+
+    expect(await screen.findByTestId("coverage-kanban")).toBeInTheDocument();
+    expect(screen.queryByTestId("dispatch-timeline")).toBeNull();
+  });
+});
+
+describe("dispatch console centre view toggle", () => {
+  afterEach(() => {
+    cleanup();
+    useAuthStore.setState({ user: null, isAuthenticated: false });
+  });
+
+  it("offers the choice of centre views to an organization that employs drivers", () => {
+    signIn(hybrid);
+
+    renderToolbar();
+
+    expect(screen.getByRole("group", { name: "Center view" })).toBeInTheDocument();
+  });
+
+  it("withdraws the toggle from a brokerage rather than offering one option", () => {
+    signIn(brokerageOnly);
+
+    renderToolbar();
+
+    expect(screen.queryByRole("group", { name: "Center view" })).toBeNull();
+  });
+});

--- a/client/apps/web/src/routes/dispatch-console/_components/__tests__/center-mode-capability.test.tsx
+++ b/client/apps/web/src/routes/dispatch-console/_components/__tests__/center-mode-capability.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { useAuthStore } from "@trenova/shared/stores/auth-store";
 import type { OrganizationCapabilities } from "@trenova/shared/types/organization-capability";
 import type { User } from "@trenova/shared/types/user";
@@ -129,5 +130,51 @@ describe("dispatch console centre view toggle", () => {
     renderToolbar();
 
     expect(screen.queryByRole("group", { name: "Center view" })).toBeNull();
+  });
+});
+
+describe("dispatch console auto-assign", () => {
+  afterEach(() => {
+    cleanup();
+    useAuthStore.setState({ user: null, isAuthenticated: false });
+  });
+
+  it("offers auto-assign to an organization that employs drivers", () => {
+    signIn(hybrid);
+
+    renderToolbar();
+
+    expect(screen.getByRole("button", { name: /auto-assign/i })).toBeInTheDocument();
+  });
+
+  it("withholds auto-assign from a brokerage, whose proposals could never execute", () => {
+    signIn(brokerageOnly);
+
+    renderToolbar();
+
+    expect(screen.queryByRole("button", { name: /auto-assign/i })).toBeNull();
+  });
+
+  it("leaves a brokerage no control at all that reaches the plan mutation", async () => {
+    signIn(brokerageOnly);
+    const onPlan = vi.fn();
+
+    render(
+      <NuqsTestingAdapter searchParams="">
+        <ConsoleToolbar
+          canUndo
+          isAssigning={false}
+          isPlanning={false}
+          onUndo={vi.fn()}
+          onPlan={onPlan}
+        />
+      </NuqsTestingAdapter>,
+    );
+
+    for (const control of screen.getAllByRole("button")) {
+      await userEvent.click(control);
+    }
+
+    expect(onPlan).not.toHaveBeenCalled();
   });
 });

--- a/client/apps/web/src/routes/dispatch-console/_components/__tests__/inspector-asset-capability.test.tsx
+++ b/client/apps/web/src/routes/dispatch-console/_components/__tests__/inspector-asset-capability.test.tsx
@@ -1,0 +1,183 @@
+import type { DispatchBoardMove } from "@/lib/graphql/dispatch-console";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { useAuthStore } from "@trenova/shared/stores/auth-store";
+import { usePermissionStore } from "@trenova/shared/stores/permission-store";
+import type { OrganizationCapabilities } from "@trenova/shared/types/organization-capability";
+import { Operation, Resource, type PermissionManifest } from "@trenova/shared/types/permission";
+import type { User } from "@trenova/shared/types/user";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Inspector } from "../inspector";
+import type { DispatchActions } from "../use-dispatch-actions";
+
+const candidatesQueryFn = vi.hoisted(() => vi.fn(async () => []));
+
+vi.mock("@/lib/queries/dispatch-console", () => ({
+  dispatchConsoleQueries: {
+    moveCandidates: (input: { moveId: string; includeBlocked: boolean }) => ({
+      queryKey: ["test-move-candidates", input] as const,
+      queryFn: candidatesQueryFn,
+    }),
+    shipmentTenders: (shipmentId: string) => ({
+      queryKey: ["test-shipment-tenders", shipmentId] as const,
+      queryFn: async () => [],
+    }),
+    driverMoves: (input: unknown) => ({
+      queryKey: ["test-driver-moves", input] as const,
+      queryFn: async () => [],
+    }),
+  },
+}));
+
+const hybrid: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: true,
+};
+const brokerageOnly: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: false,
+};
+
+function manifest(permissions: Record<string, number>): PermissionManifest {
+  return {
+    version: "1.0",
+    userId: "usr_01",
+    organizationId: "org_01",
+    activeRoleIds: [],
+    authorizedRoleIds: [],
+    activeRoles: [],
+    authorizedRoles: [],
+    requiresRoleActivation: false,
+    maxSensitivity: "internal",
+    permissions,
+    routeAccess: {},
+    availableOrgs: [],
+    checksum: "abc123",
+    expiresAt: 1_782_403_304,
+  } as PermissionManifest;
+}
+
+function signIn(capabilities: OrganizationCapabilities) {
+  useAuthStore.setState({
+    user: {
+      currentOrganizationId: "org_01",
+      memberships: [
+        {
+          userId: "usr_01",
+          organizationId: "org_01",
+          isDefault: true,
+          organization: { id: "org_01", name: "Brokerage Co", ...capabilities },
+        },
+      ],
+    } as unknown as User,
+    isAuthenticated: true,
+  });
+
+  // The dispatcher holds every assignment permission there is: only the
+  // capability separates these cases.
+  usePermissionStore.setState({
+    manifest: manifest({
+      [Resource.ShipmentMove]: Operation.Read | Operation.Assign,
+      [Resource.Tender]: Operation.Read | Operation.Create,
+    }),
+    lastFetched: Date.now(),
+    isLoading: false,
+  });
+}
+
+const move = {
+  moveId: "smv_1",
+  shipmentId: "shp_1",
+  proNumber: "PRO-1",
+  originCity: "Dallas",
+  originState: "TX",
+  destinationCity: "Tulsa",
+  destinationState: "OK",
+  originWindowStart: 1_720_000_000,
+  originLocationId: null,
+  destinationLocationId: null,
+  coverageType: "unassigned",
+  isCovered: false,
+  carrierAssignmentId: null,
+  liveTender: null,
+} as unknown as DispatchBoardMove;
+
+const actions = {
+  sendSpotTender: vi.fn(),
+  startWaterfallTender: vi.fn(),
+  cancelTender: vi.fn(),
+  recordOfferResponse: vi.fn(),
+  isTendering: false,
+} as unknown as DispatchActions;
+
+function renderInspector() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <Inspector
+          selectedMove={move}
+          selectedDriver={null}
+          onAssign={vi.fn()}
+          onSelectMove={vi.fn()}
+          isAssigning={false}
+          hotkeysEnabled={false}
+          actions={actions}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("Inspector driver ranking is hidden when the organization owns no trucks", () => {
+  beforeEach(() => {
+    candidatesQueryFn.mockClear();
+    usePermissionStore.getState().clearPermissions();
+    useAuthStore.setState({ user: null, isAuthenticated: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+    usePermissionStore.getState().clearPermissions();
+    useAuthStore.setState({ user: null, isAuthenticated: false });
+  });
+
+  it("ranks drivers for an organization that employs them", async () => {
+    signIn(hybrid);
+
+    renderInspector();
+
+    expect(await screen.findByText("0 candidates")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show ineligible" })).toBeInTheDocument();
+    expect(await screen.findByText(/No eligible driver for this move/)).toBeInTheDocument();
+  });
+
+  it("hides the candidate list and its controls from a brokerage", () => {
+    signIn(brokerageOnly);
+
+    renderInspector();
+
+    expect(screen.queryByText("0 candidates")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Show ineligible" })).toBeNull();
+    expect(screen.queryByText(/No eligible driver for this move/)).toBeNull();
+  });
+
+  it("does not ask the server to rank drivers it will never show", async () => {
+    signIn(brokerageOnly);
+
+    renderInspector();
+
+    await screen.findByText("PRO-1");
+    expect(candidatesQueryFn).not.toHaveBeenCalled();
+  });
+
+  it("keeps the carrier coverage paths a brokerage actually uses", () => {
+    signIn(brokerageOnly);
+
+    renderInspector();
+
+    expect(screen.getByRole("button", { name: "Assign to carrier" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Tender to carriers" })).toBeInTheDocument();
+  });
+});

--- a/client/apps/web/src/routes/dispatch-console/_components/console-toolbar.tsx
+++ b/client/apps/web/src/routes/dispatch-console/_components/console-toolbar.tsx
@@ -52,7 +52,7 @@ export function ConsoleToolbar({
     setZoom,
     setIncludeCovered,
   } = useDispatchWindow();
-  const { mode, setMode } = useDispatchView();
+  const { mode, setMode, timelineAvailable } = useDispatchView();
 
   return (
     <div className="flex flex-wrap items-center gap-2">
@@ -131,33 +131,37 @@ export function ConsoleToolbar({
         ))}
       </div>
 
-      <div
-        role="group"
-        aria-label="Center view"
-        className="inline-flex overflow-hidden rounded-md border border-border"
-      >
-        {CENTER_MODE_OPTIONS.map((option, index) => (
-          <button
-            key={option.id}
-            type="button"
-            onClick={() => setMode(option.id)}
-            // Reaching for the toggle is enough warning to fetch the view behind it.
-            onPointerEnter={() => preloadCenterView(option.id)}
-            onFocus={() => preloadCenterView(option.id)}
-            aria-pressed={mode === option.id}
-            className={cn(
-              "flex items-center gap-1 px-2 py-1 text-[11px] transition-colors",
-              index > 0 && "border-l border-border",
-              mode === option.id
-                ? "bg-muted text-foreground"
-                : "bg-background text-muted-foreground hover:text-foreground",
-            )}
-          >
-            <option.Icon className="size-3" aria-hidden />
-            {option.label}
-          </button>
-        ))}
-      </div>
+      {/* With the driver timeline withheld the board is the only centre there is,
+          so the toggle goes rather than offering a choice of one. */}
+      {timelineAvailable && (
+        <div
+          role="group"
+          aria-label="Center view"
+          className="inline-flex overflow-hidden rounded-md border border-border"
+        >
+          {CENTER_MODE_OPTIONS.map((option, index) => (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => setMode(option.id)}
+              // Reaching for the toggle is enough warning to fetch the view behind it.
+              onPointerEnter={() => preloadCenterView(option.id)}
+              onFocus={() => preloadCenterView(option.id)}
+              aria-pressed={mode === option.id}
+              className={cn(
+                "flex items-center gap-1 px-2 py-1 text-[11px] transition-colors",
+                index > 0 && "border-l border-border",
+                mode === option.id
+                  ? "bg-muted text-foreground"
+                  : "bg-background text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <option.Icon className="size-3" aria-hidden />
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
 
       <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
         <Switch checked={includeCovered} onCheckedChange={setIncludeCovered} />

--- a/client/apps/web/src/routes/dispatch-console/_components/console-toolbar.tsx
+++ b/client/apps/web/src/routes/dispatch-console/_components/console-toolbar.tsx
@@ -1,3 +1,4 @@
+import { CapabilityGate } from "@/components/capability-gate";
 import { formatRangeLabelForDays, isTodayAnchor } from "@/lib/timeline/time-scale";
 import { Button } from "@trenova/shared/components/ui/button";
 import { Calendar } from "@trenova/shared/components/ui/calendar";
@@ -5,6 +6,7 @@ import { Kbd } from "@trenova/shared/components/ui/kbd";
 import { Popover, PopoverContent, PopoverTrigger } from "@trenova/shared/components/ui/popover";
 import { Switch } from "@trenova/shared/components/ui/switch";
 import { cn } from "@trenova/shared/lib/utils";
+import { OrganizationCapability } from "@trenova/shared/types/organization-capability";
 import {
   CalendarIcon,
   ChevronLeftIcon,
@@ -180,16 +182,21 @@ export function ConsoleToolbar({
           Undo
           <Kbd className="h-4 min-w-4 text-[9px]">u</Kbd>
         </Button>
-        <Button
-          size="sm"
-          className="h-7 gap-1 px-2 text-[11px]"
-          disabled={isPlanning}
-          isLoading={isPlanning}
-          onClick={onPlan}
-        >
-          <SparklesIcon className="size-3" aria-hidden />
-          Auto-assign
-        </Button>
+        {/* Auto-assign plans driver/tractor pairings, which the API refuses for an
+            organization without asset operations. Withholding the button is the whole
+            trigger — there is no hotkey and the plan mutation fires from nowhere else. */}
+        <CapabilityGate capability={OrganizationCapability.AssetOperations}>
+          <Button
+            size="sm"
+            className="h-7 gap-1 px-2 text-[11px]"
+            disabled={isPlanning}
+            isLoading={isPlanning}
+            onClick={onPlan}
+          >
+            <SparklesIcon className="size-3" aria-hidden />
+            Auto-assign
+          </Button>
+        </CapabilityGate>
       </div>
     </div>
   );

--- a/client/apps/web/src/routes/dispatch-console/_components/inspector.tsx
+++ b/client/apps/web/src/routes/dispatch-console/_components/inspector.tsx
@@ -15,9 +15,13 @@ import { Button } from "@trenova/shared/components/ui/button";
 import { Kbd } from "@trenova/shared/components/ui/kbd";
 import { ScrollArea } from "@trenova/shared/components/ui/scroll-area";
 import { Skeleton } from "@trenova/shared/components/ui/skeleton";
+import { useOrgCapabilities } from "@trenova/shared/hooks/use-org-capabilities";
 import { formatClockDurationMs, formatUnixDateTime } from "@trenova/shared/lib/date";
 import { cn, formatCurrency } from "@trenova/shared/lib/utils";
-import { OrganizationCapability } from "@trenova/shared/types/organization-capability";
+import {
+  hasOrganizationCapability,
+  OrganizationCapability,
+} from "@trenova/shared/types/organization-capability";
 import { Operation, Resource } from "@trenova/shared/types/permission";
 import { useQuery } from "@tanstack/react-query";
 import { Building2Icon, SendIcon } from "lucide-react";
@@ -216,6 +220,14 @@ function MoveInspector({
   const [includeBlocked, setIncludeBlocked] = useState(false);
   const openCarrierAssign = useDispatchConsoleStore.use.openCarrierAssign();
   const openTender = useDispatchConsoleStore.use.openTender();
+  const capabilities = useOrgCapabilities();
+  // Ranking drivers is the whole point of this pane, and an organization that
+  // employs none has nothing to rank — the ranking is withheld rather than shown
+  // permanently empty, and the query behind it is never issued.
+  const canRankDrivers = hasOrganizationCapability(
+    capabilities,
+    OrganizationCapability.AssetOperations,
+  );
   const isCarrierCovered = move.coverageType === "carrier";
   // A carrier-covered move cannot take a driver on top; the carrier assignment has to be
   // canceled first, so driver assignment is held off rather than allowed to fail.
@@ -224,6 +236,7 @@ function MoveInspector({
   const { data, isLoading } = useQuery({
     ...dispatchConsoleQueries.moveCandidates({ moveId: move.moveId, includeBlocked }),
     staleTime: CANDIDATE_STALE_MS,
+    enabled: canRankDrivers,
   });
 
   const candidates = useMemo(() => data ?? [], [data]);
@@ -231,7 +244,7 @@ function MoveInspector({
   // The rank shown next to each candidate doubles as its keyboard shortcut: pressing the
   // digit assigns without touching the mouse.
   useEffect(() => {
-    if (!hotkeysEnabled || assignLocked) return;
+    if (!hotkeysEnabled || assignLocked || !canRankDrivers) return;
 
     function onKeyDown(event: KeyboardEvent) {
       if (event.metaKey || event.ctrlKey || event.altKey) return;
@@ -246,7 +259,7 @@ function MoveInspector({
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [candidates, hotkeysEnabled, assignLocked, onAssign]);
+  }, [candidates, hotkeysEnabled, assignLocked, canRankDrivers, onAssign]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -270,10 +283,12 @@ function MoveInspector({
       )}
 
       <div className="flex items-center justify-between gap-2 border-b px-2.5 py-1.5">
-        <span className="text-[10px] tracking-wide text-muted-foreground uppercase">
-          {candidates.length} candidates
-        </span>
-        <div className="flex items-center gap-1.5">
+        {canRankDrivers && (
+          <span className="text-[10px] tracking-wide text-muted-foreground uppercase">
+            {candidates.length} candidates
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-1.5">
           <CapabilityGate capability={OrganizationCapability.Brokerage}>
             {!move.isCovered && (
               <PermissionGate resource={Resource.ShipmentMove} operation={Operation.Assign}>
@@ -304,14 +319,16 @@ function MoveInspector({
               </PermissionGate>
             )}
           </CapabilityGate>
-          <Button
-            size="sm"
-            variant="outline"
-            className="h-6 px-2 text-[10px]"
-            onClick={() => setIncludeBlocked((value) => !value)}
-          >
-            {includeBlocked ? "Hide ineligible" : "Show ineligible"}
-          </Button>
+          {canRankDrivers && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-6 px-2 text-[10px]"
+              onClick={() => setIncludeBlocked((value) => !value)}
+            >
+              {includeBlocked ? "Hide ineligible" : "Show ineligible"}
+            </Button>
+          )}
         </div>
       </div>
 
@@ -322,24 +339,28 @@ function MoveInspector({
         maskHeight={18}
       >
         <div className="flex flex-col gap-1.5 p-2">
-          {isLoading
-            ? Array.from({ length: 5 }, (_, index) => (
-                <Skeleton key={index} className="h-24 rounded-md" />
-              ))
-            : candidates.map((candidate, index) => (
-                <CandidateRow
-                  key={candidate.workerId}
-                  candidate={candidate}
-                  rank={index + 1}
-                  onAssign={onAssign}
-                  isAssigning={assignLocked}
-                />
-              ))}
-          {!isLoading && candidates.length === 0 && (
-            <p className="px-1 py-6 text-center text-xs text-muted-foreground">
-              No eligible driver for this move.
-              {!includeBlocked ? " Show ineligible drivers to see why." : ""}
-            </p>
+          {canRankDrivers && (
+            <>
+              {isLoading
+                ? Array.from({ length: 5 }, (_, index) => (
+                    <Skeleton key={index} className="h-24 rounded-md" />
+                  ))
+                : candidates.map((candidate, index) => (
+                    <CandidateRow
+                      key={candidate.workerId}
+                      candidate={candidate}
+                      rank={index + 1}
+                      onAssign={onAssign}
+                      isAssigning={assignLocked}
+                    />
+                  ))}
+              {!isLoading && candidates.length === 0 && (
+                <p className="px-1 py-6 text-center text-xs text-muted-foreground">
+                  No eligible driver for this move.
+                  {!includeBlocked ? " Show ineligible drivers to see why." : ""}
+                </p>
+              )}
+            </>
           )}
 
           <CapabilityGate capability={OrganizationCapability.Brokerage}>
@@ -489,11 +510,23 @@ export function Inspector({
   hotkeysEnabled: boolean;
   actions: DispatchActions;
 }) {
+  const capabilities = useOrgCapabilities();
+  const canRankDrivers = hasOrganizationCapability(
+    capabilities,
+    OrganizationCapability.AssetOperations,
+  );
+
   return (
     <section className="flex min-h-0 flex-col overflow-hidden rounded-lg border bg-card">
       <header className="flex items-center justify-between border-b px-2.5 py-1.5">
         <h2 className="text-[10.5px] font-semibold tracking-wide text-muted-foreground uppercase">
-          {selectedMove ? "Rank drivers" : selectedDriver ? "Find work" : "Inspector"}
+          {selectedMove
+            ? canRankDrivers
+              ? "Rank drivers"
+              : "Cover move"
+            : selectedDriver
+              ? "Find work"
+              : "Inspector"}
         </h2>
       </header>
 
@@ -511,7 +544,9 @@ export function Inspector({
         <div className="flex flex-1 flex-col items-center justify-center gap-1 p-6 text-center">
           <p className="text-xs font-medium">Nothing selected</p>
           <p className="text-[11px] text-muted-foreground">
-            Select a move to rank drivers for it, or a driver to find them work.
+            {canRankDrivers
+              ? "Select a move to rank drivers for it, or a driver to find them work."
+              : "Select a move to see how it can be covered."}
           </p>
         </div>
       )}

--- a/client/apps/web/src/routes/dispatch-console/_components/page-content.tsx
+++ b/client/apps/web/src/routes/dispatch-console/_components/page-content.tsx
@@ -8,6 +8,12 @@ import { useDispatchConsoleStore, type PreflightTarget } from "@/stores/dispatch
 import { DndContext, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
 import { useQuery } from "@tanstack/react-query";
+import { useOrgCapabilities } from "@trenova/shared/hooks/use-org-capabilities";
+import { cn } from "@trenova/shared/lib/utils";
+import {
+  hasOrganizationCapability,
+  OrganizationCapability,
+} from "@trenova/shared/types/organization-capability";
 import { Suspense, lazy, useCallback, useEffect, useMemo } from "react";
 import { CapacityRail } from "./capacity-rail";
 import { ConsoleCenterPane } from "./console-center-pane";
@@ -42,6 +48,14 @@ export function DispatchConsoleContent() {
     useDispatchSelection();
   const { urgencyFocus, setUrgencyFocus } = useDispatchView();
   const { setCapacityFilter } = useDispatchRail();
+  const capabilities = useOrgCapabilities();
+  // The rail is a column of driver rows with HOS gauges and drag handles. With no
+  // drivers to put in it there is nothing to rail, so the column is removed
+  // rather than left standing empty beside the board.
+  const showsCapacityRail = hasOrganizationCapability(
+    capabilities,
+    OrganizationCapability.AssetOperations,
+  );
 
   const setDragPreview = useDispatchConsoleStore.use.setDragPreview();
   const openPreflight = useDispatchConsoleStore.use.openPreflight();
@@ -206,13 +220,22 @@ export function DispatchConsoleContent() {
           onPlan={planForWindow}
         />
 
-        <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 lg:grid-cols-[300px_minmax(0,1fr)_320px]">
-          <CapacityRail
-            drivers={drivers}
-            isLoading={isLoading}
-            selectedWorkerId={selectedWorkerId}
-            onSelectDriver={selectDriver}
-          />
+        <div
+          className={cn(
+            "grid min-h-0 flex-1 grid-cols-1 gap-3",
+            showsCapacityRail
+              ? "lg:grid-cols-[300px_minmax(0,1fr)_320px]"
+              : "lg:grid-cols-[minmax(0,1fr)_320px]",
+          )}
+        >
+          {showsCapacityRail && (
+            <CapacityRail
+              drivers={drivers}
+              isLoading={isLoading}
+              selectedWorkerId={selectedWorkerId}
+              onSelectDriver={selectDriver}
+            />
+          )}
 
           <ConsoleCenterPane
             moves={moves}

--- a/client/apps/web/src/routes/dispatch-console/_components/url-state.ts
+++ b/client/apps/web/src/routes/dispatch-console/_components/url-state.ts
@@ -4,6 +4,12 @@ import {
   serializeAnchorDate,
   shiftAnchorByDays,
 } from "@/lib/timeline/time-scale";
+import { useOrgCapabilities } from "@trenova/shared/hooks/use-org-capabilities";
+import {
+  hasOrganizationCapability,
+  OrganizationCapability,
+  type OrganizationCapabilities,
+} from "@trenova/shared/types/organization-capability";
 import { startOfDay } from "date-fns";
 import {
   debounce,
@@ -32,6 +38,29 @@ import { TIMELINE_ZOOM_OPTIONS, type TimelineZoomDays } from "./timeline-metrics
 
 const CENTER_MODES = ["board", "timeline"] as const;
 export type CenterMode = (typeof CENTER_MODES)[number];
+
+/**
+ * The console's timeline is a grid of driver lanes with loads dropped onto them —
+ * the same shape as the capacity rail, laid out horizontally. An organization
+ * without its own drivers has no lanes, so the view is withheld and the board is
+ * the only centre.
+ */
+export function isDispatchTimelineAvailable(capabilities: OrganizationCapabilities): boolean {
+  return hasOrganizationCapability(capabilities, OrganizationCapability.AssetOperations);
+}
+
+/**
+ * Resolves the requested centre view against what the organization can use. The
+ * console's whole state is shareable through the URL, so `?mode=timeline` can
+ * outlive the capability behind it and must degrade rather than render lanes
+ * that cannot exist.
+ */
+export function resolveCenterMode(
+  mode: CenterMode,
+  capabilities: OrganizationCapabilities,
+): CenterMode {
+  return mode === "timeline" && !isDispatchTimelineAvailable(capabilities) ? "board" : mode;
+}
 
 const ZOOM_VALUES: readonly TimelineZoomDays[] = TIMELINE_ZOOM_OPTIONS.map((option) => option.id);
 const CAPACITY_FILTER_IDS: readonly CapacityFilter[] = CAPACITY_FILTERS.map((filter) => filter.id);
@@ -127,6 +156,7 @@ export function useDispatchSelection() {
 
 export function useDispatchView() {
   const [{ mode, urgency }, setView] = useQueryStates(dispatchViewParsers, URL_OPTIONS);
+  const capabilities = useOrgCapabilities();
 
   const setMode = useCallback((next: CenterMode) => void setView({ mode: next }), [setView]);
   const setUrgencyFocus = useCallback(
@@ -134,7 +164,13 @@ export function useDispatchView() {
     [setView],
   );
 
-  return { mode, urgencyFocus: urgency, setMode, setUrgencyFocus };
+  return {
+    mode: resolveCenterMode(mode, capabilities),
+    timelineAvailable: isDispatchTimelineAvailable(capabilities),
+    urgencyFocus: urgency,
+    setMode,
+    setUrgencyFocus,
+  };
 }
 
 export function useDispatchRail() {

--- a/client/apps/web/src/routes/dispatch-control/__tests__/dispatch-control-capability.test.tsx
+++ b/client/apps/web/src/routes/dispatch-control/__tests__/dispatch-control-capability.test.tsx
@@ -1,0 +1,135 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { useAuthStore } from "@trenova/shared/stores/auth-store";
+import type { OrganizationCapabilities } from "@trenova/shared/types/organization-capability";
+import type { User } from "@trenova/shared/types/user";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DispatchControl } from "@/types/dispatch-control";
+import DispatchControlForm from "../_components/dispatch-control-form";
+
+const control: DispatchControl = {
+  id: "dc_1",
+  version: 0,
+  organizationId: "org_01",
+  businessUnitId: "bu_01",
+  enableAutoAssignment: true,
+  autoAssignmentStrategy: "Proximity",
+  scoringWeights: {},
+  enforceWorkerAssign: true,
+  enforceTrailerContinuity: true,
+  enforceHosCompliance: true,
+  enforceWorkerPtaRestrictions: true,
+  enforceWorkerTractorFleetContinuity: true,
+  enforceDriverQualificationCompliance: true,
+  enforceMedicalCertCompliance: true,
+  enforceHazmatCompliance: true,
+  enforceDrugAndAlcoholCompliance: true,
+  complianceEnforcementLevel: "Warning",
+  recordServiceFailures: "Never",
+} as unknown as DispatchControl;
+
+vi.mock("@/lib/queries", () => ({
+  queries: {
+    dispatchControl: {
+      get: () => ({ queryKey: ["dispatch-control"], queryFn: async () => control }),
+    },
+  },
+}));
+
+vi.mock("@/hooks/use-optimistic-mutation", () => ({
+  useOptimisticMutation: () => ({ mutateAsync: vi.fn() }),
+}));
+
+/** Every driver-compliance control the plan calls for hiding. */
+const DRIVER_COMPLIANCE_LABELS = [
+  "Enable Automated Assignment",
+  "Assignment Optimization Strategy",
+  "Candidate Scoring Weights",
+  "Enable DOT Compliance Enforcement",
+  "Medical Certification Validation",
+  "Driver Qualification Verification",
+  "Drug and Alcohol Testing Compliance",
+  "Require Worker Assignment",
+  "Require Trailer Continuity",
+  "Enforce Worker PTA Restrictions",
+  "Enforce Worker Tractor Fleet Continuity",
+];
+
+/** Neutral settings that describe the freight, not the driver moving it. */
+const NEUTRAL_LABELS = ["Record Service Failures"];
+
+const hybrid: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: true,
+};
+const brokerageOnly: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: false,
+};
+
+function signIn(capabilities: OrganizationCapabilities) {
+  useAuthStore.setState({
+    user: {
+      currentOrganizationId: "org_01",
+      memberships: [
+        {
+          userId: "usr_01",
+          organizationId: "org_01",
+          isDefault: true,
+          organization: { id: "org_01", name: "Brokerage Co", ...capabilities },
+        },
+      ],
+    } as unknown as User,
+    isAuthenticated: true,
+  });
+}
+
+function renderForm() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DispatchControlForm />
+    </QueryClientProvider>,
+  );
+}
+
+describe("dispatch control field visibility", () => {
+  afterEach(() => {
+    cleanup();
+    useAuthStore.setState({ user: null, isAuthenticated: false });
+  });
+
+  it("shows every driver-compliance control to an organization that employs drivers", async () => {
+    signIn(hybrid);
+
+    renderForm();
+
+    for (const label of DRIVER_COMPLIANCE_LABELS) {
+      expect(await screen.findByText(label), label).toBeInTheDocument();
+    }
+  });
+
+  it("hides every driver-compliance control from a brokerage", async () => {
+    signIn(brokerageOnly);
+
+    renderForm();
+
+    await screen.findByText("Record Service Failures");
+
+    for (const label of DRIVER_COMPLIANCE_LABELS) {
+      expect(screen.queryByText(label), label).toBeNull();
+    }
+  });
+
+  it("keeps the page and its neutral settings reachable for a brokerage", async () => {
+    signIn(brokerageOnly);
+
+    renderForm();
+
+    for (const label of NEUTRAL_LABELS) {
+      expect(await screen.findByText(label), label).toBeInTheDocument();
+    }
+    expect(screen.getByText("Service Failure Monitoring")).toBeInTheDocument();
+  });
+});

--- a/client/apps/web/src/routes/dispatch-control/_components/dispatch-control-form.tsx
+++ b/client/apps/web/src/routes/dispatch-control/_components/dispatch-control-form.tsx
@@ -1,3 +1,4 @@
+import { CapabilityGate } from "@/components/capability-gate";
 import { NumberField } from "@/components/fields/number-field";
 import { SelectField } from "@/components/fields/select-field";
 import { ScoringWeightForm } from "./scoring-weight-form";
@@ -25,6 +26,7 @@ import {
   serviceIncidentTypeSchema,
 } from "@/types/dispatch-control";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { OrganizationCapability } from "@trenova/shared/types/organization-capability";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useCallback, useEffect } from "react";
 import {
@@ -68,10 +70,20 @@ export default function DispatchControlForm() {
     <FormProvider {...form}>
       <Form onSubmit={handleSubmit(onSubmit)}>
         <div className="flex flex-col gap-4 pb-14">
-          <AutoAssignmentForm />
-          <ScoringWeightForm />
+          {/* Auto-assignment, its scoring weights and every DOT check on this
+              page act on employed drivers. An organization that brokers all of
+              its freight keeps the page — service failure monitoring is about
+              the load, not the driver — with the driver-side cards withheld.
+              The values behind them are still submitted untouched, so nothing
+              is reset by passing through here. */}
+          <CapabilityGate capability={OrganizationCapability.AssetOperations}>
+            <AutoAssignmentForm />
+            <ScoringWeightForm />
+          </CapabilityGate>
           <ServiceFailureForm />
-          <ComplianceForm />
+          <CapabilityGate capability={OrganizationCapability.AssetOperations}>
+            <ComplianceForm />
+          </CapabilityGate>
           <FormSaveDock saveButtonContent="Save Changes" />
         </div>
       </Form>

--- a/client/apps/web/src/routes/shipment/_components/__tests__/assignment-dialog-capability.test.tsx
+++ b/client/apps/web/src/routes/shipment/_components/__tests__/assignment-dialog-capability.test.tsx
@@ -1,0 +1,142 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { useAuthStore } from "@trenova/shared/stores/auth-store";
+import type { OrganizationCapabilities } from "@trenova/shared/types/organization-capability";
+import type { Assignment, CarrierAssignment } from "@trenova/shared/types/shipment";
+import type { User } from "@trenova/shared/types/user";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AssignmentDialog } from "../assignment-dialog";
+
+vi.mock("../assignment-hos-feasibility", () => ({
+  AssignmentHosFeasibility: () => null,
+}));
+
+const hybrid: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: true,
+};
+const brokerageOnly: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: false,
+};
+
+function signIn(capabilities: OrganizationCapabilities) {
+  useAuthStore.setState({
+    user: {
+      currentOrganizationId: "org_01",
+      memberships: [
+        {
+          userId: "usr_01",
+          organizationId: "org_01",
+          isDefault: true,
+          organization: { id: "org_01", name: "Brokerage Co", ...capabilities },
+        },
+      ],
+    } as unknown as User,
+    isAuthenticated: true,
+  });
+}
+
+const existingAssignment = {
+  id: "asn_1",
+  status: "New",
+  shipmentMoveId: "mov_1",
+  primaryWorkerId: "wrk_1",
+  tractorId: "trc_1",
+  trailerId: null,
+  secondaryWorkerId: null,
+} as unknown as Assignment;
+
+function renderDialog(options: { existingAssignment?: Assignment | null } = {}) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <AssignmentDialog
+          open
+          onOpenChange={vi.fn()}
+          moveId="mov_1"
+          existingAssignment={options.existingAssignment ?? null}
+          existingCarrierAssignment={null as CarrierAssignment | null}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AssignmentDialog coverage modes", () => {
+  afterEach(() => {
+    cleanup();
+    useAuthStore.setState({ user: null, isAuthenticated: false });
+  });
+
+  it("offers both coverage modes to an organization that runs drivers and brokers", () => {
+    signIn(hybrid);
+
+    renderDialog();
+
+    expect(screen.getByRole("radio", { name: "Driver" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Carrier" })).toBeInTheDocument();
+  });
+
+  it("drops the driver tab for an organization that employs no drivers", () => {
+    signIn(brokerageOnly);
+
+    renderDialog();
+
+    expect(screen.queryByRole("radio", { name: "Driver" })).toBeNull();
+    // One remaining mode is not a choice, so the whole control goes with it.
+    expect(screen.queryByRole("radiogroup", { name: "Coverage type" })).toBeNull();
+  });
+
+  it("opens straight into carrier coverage when the driver mode is unavailable", () => {
+    signIn(brokerageOnly);
+
+    renderDialog();
+
+    expect(screen.getByText("Assign Move to Carrier")).toBeInTheDocument();
+  });
+
+  it("still opens in driver mode for an organization that employs drivers", () => {
+    signIn(hybrid);
+
+    renderDialog();
+
+    expect(screen.getByText("Assign Move")).toBeInTheDocument();
+  });
+
+  /**
+   * The server refuses to create or change a driver assignment for an
+   * organization without asset operations. Reaching that refusal through a
+   * submit would surface a raw API error, so the dialog says it up front in the
+   * same panel shape it already uses for the driver/carrier cross-refusals.
+   */
+  it("pre-empts the server refusal instead of offering a reassignment that will fail", () => {
+    signIn(brokerageOnly);
+
+    renderDialog({ existingAssignment });
+
+    expect(screen.getByText("Driver assignment is not enabled")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reassign" })).toBeNull();
+    expect(screen.queryByLabelText("Tractor")).toBeNull();
+  });
+
+  it("says how the move can still be freed up", () => {
+    signIn(brokerageOnly);
+
+    renderDialog({ existingAssignment });
+
+    expect(screen.getByText(/Unassign the driver/)).toBeInTheDocument();
+  });
+
+  it("leaves reassignment alone for an organization that employs drivers", () => {
+    signIn(hybrid);
+
+    renderDialog({ existingAssignment });
+
+    expect(screen.queryByText("Driver assignment is not enabled")).toBeNull();
+    expect(screen.getByText("Reassign Move")).toBeInTheDocument();
+  });
+});

--- a/client/apps/web/src/routes/shipment/_components/__tests__/shipment-columns-coverage.test.ts
+++ b/client/apps/web/src/routes/shipment/_components/__tests__/shipment-columns-coverage.test.ts
@@ -1,0 +1,21 @@
+import { getColumns } from "@/routes/shipment/_components/shipment-columns";
+import { describe, expect, it } from "vitest";
+
+describe("shipment coverage column", () => {
+  const column = getColumns([]).find((entry) => entry.id === "driver");
+
+  it("is registered", () => {
+    expect(column).toBeDefined();
+  });
+
+  /**
+   * The cell under this header renders a driver, an external carrier, or
+   * nothing at all, so naming it after one of the three was already wrong for a
+   * brokered move and is wrong for every move at an organization without
+   * drivers.
+   */
+  it("names what the column actually holds rather than assuming a driver", () => {
+    expect(column?.header).toBe("Coverage");
+    expect(column?.meta?.label).toBe("Coverage");
+  });
+});

--- a/client/apps/web/src/routes/shipment/_components/assignment-dialog.tsx
+++ b/client/apps/web/src/routes/shipment/_components/assignment-dialog.tsx
@@ -27,7 +27,12 @@ import { Form, FormControl, FormGroup } from "@trenova/shared/components/ui/form
 import { ScrollArea } from "@trenova/shared/components/ui/scroll-area";
 import { SegmentedControl } from "@trenova/shared/components/ui/segmented-control";
 import { handleMutationError } from "@/hooks/use-api-mutation";
+import { useOrgCapabilities } from "@trenova/shared/hooks/use-org-capabilities";
 import { ApiRequestError } from "@trenova/shared/lib/api";
+import {
+  hasOrganizationCapability,
+  OrganizationCapability,
+} from "@trenova/shared/types/organization-capability";
 import type { SelectOption } from "@/lib/graphql/select-options";
 import { LocateTrailerDialog } from "@/routes/trailer/_components/locate-trailer-dialog";
 import { apiService } from "@/services/api";
@@ -90,7 +95,19 @@ export function AssignmentDialog({
   const queryClient = useQueryClient();
   const isEditing = !!existingAssignment?.id;
   const hasCarrierCoverage = isActiveCarrierAssignment(existingCarrierAssignment);
-  const [mode, setMode] = useState<CoverageMode>(hasCarrierCoverage ? "carrier" : "driver");
+  // Driver coverage is refused by the API for an organization without asset
+  // operations, so the mode is not offered rather than offered and rejected.
+  const capabilities = useOrgCapabilities();
+  const canAssignDrivers = hasOrganizationCapability(
+    capabilities,
+    OrganizationCapability.AssetOperations,
+  );
+  const [mode, setMode] = useState<CoverageMode>(
+    hasCarrierCoverage || !canAssignDrivers ? "carrier" : "driver",
+  );
+  // A move that already carries a driver at an organization that cannot assign
+  // one: neither mode can act on it, so the dialog explains rather than offers.
+  const driverAssignmentBlocked = !canAssignDrivers && isEditing;
 
   const [continuityError, setContinuityError] = useState<{
     message: string;
@@ -132,8 +149,8 @@ export function AssignmentDialog({
 
   useEffect(() => {
     if (!open) return;
-    setMode(hasCarrierCoverage ? "carrier" : "driver");
-  }, [open, hasCarrierCoverage]);
+    setMode(hasCarrierCoverage || !canAssignDrivers ? "carrier" : "driver");
+  }, [open, hasCarrierCoverage, canAssignDrivers]);
 
   const watchedTrailerId = useWatch({ control, name: "trailerId" });
   useEffect(() => {
@@ -224,30 +241,53 @@ export function AssignmentDialog({
       <DialogContent className="sm:max-w-[600px]">
         <DialogHeader>
           <DialogTitle>
-            {mode === "carrier"
-              ? hasCarrierCoverage
-                ? "Replace Carrier Assignment"
-                : "Assign Move to Carrier"
-              : isEditing
-                ? "Reassign Move"
-                : "Assign Move"}
+            {driverAssignmentBlocked
+              ? "Move Coverage"
+              : mode === "carrier"
+                ? hasCarrierCoverage
+                  ? "Replace Carrier Assignment"
+                  : "Assign Move to Carrier"
+                : isEditing
+                  ? "Reassign Move"
+                  : "Assign Move"}
           </DialogTitle>
           <DialogDescription>
-            {mode === "carrier"
-              ? "Broker this move to an external carrier with its rate and reference details."
-              : isEditing
-                ? "Update the tractor, trailer, and worker assignments for this move."
-                : "Assign a tractor, trailer, and workers to this move."}
+            {driverAssignmentBlocked
+              ? "This move is covered by a driver, which this organization cannot reassign."
+              : mode === "carrier"
+                ? "Broker this move to an external carrier with its rate and reference details."
+                : isEditing
+                  ? "Update the tractor, trailer, and worker assignments for this move."
+                  : "Assign a tractor, trailer, and workers to this move."}
           </DialogDescription>
         </DialogHeader>
-        <SegmentedControl
-          items={COVERAGE_MODE_ITEMS}
-          value={mode}
-          onValueChange={setMode}
-          fullWidth
-          aria-label="Coverage type"
-        />
-        {mode === "carrier" ? (
+        {canAssignDrivers && (
+          <SegmentedControl
+            items={COVERAGE_MODE_ITEMS}
+            value={mode}
+            onValueChange={setMode}
+            fullWidth
+            aria-label="Coverage type"
+          />
+        )}
+        {driverAssignmentBlocked ? (
+          <>
+            <Alert variant="default">
+              <TriangleAlertIcon />
+              <AlertTitle>Driver assignment is not enabled</AlertTitle>
+              <AlertDescription>
+                This organization does not run its own drivers, so an existing driver assignment
+                cannot be changed here. Unassign the driver to release the move, then cover it with
+                a carrier.
+              </AlertDescription>
+            </Alert>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={handleClose}>
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        ) : mode === "carrier" ? (
           isEditing ? (
             <>
               <Alert variant="default">

--- a/client/apps/web/src/routes/shipment/_components/command-center/__tests__/timeline-capability.test.tsx
+++ b/client/apps/web/src/routes/shipment/_components/command-center/__tests__/timeline-capability.test.tsx
@@ -1,0 +1,135 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { useAuthStore } from "@trenova/shared/stores/auth-store";
+import type { ColumnDef } from "@trenova/shared/types/data-table";
+import type { OrganizationCapabilities } from "@trenova/shared/types/organization-capability";
+import type { Shipment } from "@trenova/shared/types/shipment";
+import type { User } from "@trenova/shared/types/user";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CommandCenterTable } from "../command-center-table";
+import { resolveCommandCenterViewMode } from "../url-state";
+
+vi.mock("../timeline", () => ({
+  default: () => <div data-testid="command-center-timeline" />,
+}));
+
+vi.mock("@/lib/graphql/shipment", () => ({
+  listShipmentsGraphQL: async () => ({
+    results: [],
+    count: 0,
+    pageInfo: { endCursor: null, hasNextPage: false },
+  }),
+}));
+
+vi.mock("../use-view-counts", () => ({
+  useSavedViewCounts: () => ({}),
+}));
+
+vi.mock("@/lib/queries", () => ({
+  queries: {
+    tableConfiguration: {
+      default: () => ({ queryKey: ["table-config-default"], queryFn: async () => null }),
+    },
+  },
+}));
+
+const hybrid: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: true,
+};
+const brokerageOnly: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: false,
+};
+
+function signIn(capabilities: OrganizationCapabilities) {
+  useAuthStore.setState({
+    user: {
+      currentOrganizationId: "org_01",
+      memberships: [
+        {
+          userId: "usr_01",
+          organizationId: "org_01",
+          isDefault: true,
+          organization: { id: "org_01", name: "Brokerage Co", ...capabilities },
+        },
+      ],
+    } as unknown as User,
+    isAuthenticated: true,
+  });
+}
+
+const columns: ColumnDef<Shipment>[] = [
+  {
+    id: "proNumber",
+    header: "Pro Number",
+    accessorFn: () => null,
+    cell: () => null,
+  } as unknown as ColumnDef<Shipment>,
+];
+
+function renderTable(searchParams: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <NuqsTestingAdapter searchParams={searchParams}>
+      <QueryClientProvider client={queryClient}>
+        <CommandCenterTable
+          columns={columns}
+          rowActions={[]}
+          mandatoryFieldFilters={[]}
+          onUploadDocument={vi.fn()}
+        />
+      </QueryClientProvider>
+    </NuqsTestingAdapter>,
+  );
+}
+
+describe("resolveCommandCenterViewMode", () => {
+  it("keeps the timeline for an organization that employs drivers", () => {
+    expect(resolveCommandCenterViewMode("timeline", hybrid)).toBe("timeline");
+    expect(resolveCommandCenterViewMode("table", hybrid)).toBe("table");
+  });
+
+  it("resolves a bookmarked timeline back to the table for a brokerage", () => {
+    expect(resolveCommandCenterViewMode("timeline", brokerageOnly)).toBe("table");
+    expect(resolveCommandCenterViewMode("table", brokerageOnly)).toBe("table");
+  });
+});
+
+describe("command center timeline visibility", () => {
+  afterEach(() => {
+    cleanup();
+    useAuthStore.setState({ user: null, isAuthenticated: false });
+  });
+
+  it("offers the timeline view to an organization that employs drivers", async () => {
+    signIn(hybrid);
+
+    renderTable("?mode=timeline");
+
+    expect(screen.getByRole("button", { name: "Timeline" })).toBeInTheDocument();
+    expect(await screen.findByTestId("command-center-timeline")).toBeInTheDocument();
+  });
+
+  it("removes the option entirely for a brokerage rather than leaving an empty tab", () => {
+    signIn(brokerageOnly);
+
+    renderTable("?mode=table");
+
+    expect(screen.queryByRole("button", { name: "Timeline" })).toBeNull();
+    expect(screen.queryByRole("group", { name: "View mode" })).toBeNull();
+  });
+
+  it("leaves the timeline unmounted on a bookmarked timeline URL", async () => {
+    signIn(brokerageOnly);
+
+    renderTable("?mode=timeline");
+
+    // The table is what a lazy timeline chunk would have replaced; waiting for it
+    // proves the timeline is never mounted rather than merely not mounted yet.
+    expect(await screen.findByRole("table")).toBeInTheDocument();
+    expect(screen.queryByTestId("command-center-timeline")).toBeNull();
+  });
+});

--- a/client/apps/web/src/routes/shipment/_components/command-center/cells/driver-cell.test.tsx
+++ b/client/apps/web/src/routes/shipment/_components/command-center/cells/driver-cell.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { Shipment, ShipmentMove } from "@trenova/shared/types/shipment";
+import { afterEach, describe, expect, it } from "vitest";
+import { DriverCell } from "./driver-cell";
+
+function makeShipment(move: Partial<ShipmentMove>): Shipment {
+  return {
+    id: "shp_1",
+    status: "New",
+    moves: [
+      {
+        id: "mov_1",
+        status: "New",
+        sequence: 0,
+        loaded: true,
+        stops: [],
+        ...move,
+      },
+    ],
+  } as unknown as Shipment;
+}
+
+const carrierAssignment = {
+  id: "casn_1",
+  shipmentMoveId: "mov_1",
+  carrierId: "car_1",
+  status: "Confirmed",
+  rateMethod: "Flat",
+  carrier: { id: "car_1", name: "Acme Freight", scac: "ACME" },
+} as unknown as ShipmentMove["carrierAssignment"];
+
+describe("DriverCell", () => {
+  afterEach(cleanup);
+
+  it("never asks a brokerage for a driver it does not employ", () => {
+    render(<DriverCell shipment={makeShipment({ coverageType: "unassigned" })} />);
+
+    expect(screen.queryByText("Needs driver")).toBeNull();
+  });
+
+  it("renders an uncovered move as needing coverage rather than a driver", () => {
+    render(<DriverCell shipment={makeShipment({ coverageType: "unassigned" })} />);
+
+    expect(screen.getByText("Needs coverage")).toBeTruthy();
+  });
+
+  it("keeps an uncovered move uncovered even with a lingering carrier record", () => {
+    render(
+      <DriverCell shipment={makeShipment({ coverageType: "unassigned", carrierAssignment })} />,
+    );
+
+    expect(screen.getByText("Needs coverage")).toBeTruthy();
+    expect(screen.queryByText("Acme Freight")).toBeNull();
+  });
+
+  it("renders the carrier only when the move is carrier covered", () => {
+    render(<DriverCell shipment={makeShipment({ coverageType: "carrier", carrierAssignment })} />);
+
+    expect(screen.getByText("Acme Freight")).toBeTruthy();
+    expect(screen.queryByText("Needs coverage")).toBeNull();
+  });
+
+  it("renders the driver when the move is driver covered", () => {
+    render(
+      <DriverCell
+        shipment={makeShipment({
+          coverageType: "driver",
+          assignment: {
+            id: "asn_1",
+            status: "New",
+            primaryWorkerId: "wrk_1",
+            primaryWorker: { id: "wrk_1", firstName: "Dana", lastName: "Reyes" },
+            tractor: { id: "trc_1", code: "T-100" },
+          },
+        } as Partial<ShipmentMove>)}
+      />,
+    );
+
+    expect(screen.getByText("D. Reyes")).toBeTruthy();
+    expect(screen.queryByText("Needs coverage")).toBeNull();
+  });
+});

--- a/client/apps/web/src/routes/shipment/_components/command-center/cells/driver-cell.tsx
+++ b/client/apps/web/src/routes/shipment/_components/command-center/cells/driver-cell.tsx
@@ -41,11 +41,14 @@ export function DriverCell({ shipment }: { shipment: Shipment }) {
     );
   }
 
+  // A move can be covered by a driver or by an external carrier, so an empty one
+  // is short of coverage rather than short of a driver — an organization that
+  // brokers every load never wanted the driver it was being asked for.
   if (!driver) {
     return (
       <div className={cn("inline-flex items-center gap-1 text-[11px] font-medium text-warning")}>
         <TriangleAlertIcon className="size-3" />
-        <span>Needs driver</span>
+        <span>Needs coverage</span>
       </div>
     );
   }

--- a/client/apps/web/src/routes/shipment/_components/command-center/command-center-table.tsx
+++ b/client/apps/web/src/routes/shipment/_components/command-center/command-center-table.tsx
@@ -20,6 +20,7 @@ import {
   TableRow,
 } from "@trenova/shared/components/ui/table";
 import { useDebounce } from "@/hooks/use-debounce";
+import { useOrgCapabilities } from "@trenova/shared/hooks/use-org-capabilities";
 import {
   convertFilterItemsToFieldFilters,
   convertFilterItemsToFilterGroups,
@@ -50,7 +51,9 @@ import { FilterChipRow } from "./filter-chip-row";
 import { SavedViewsBar } from "./saved-views-bar";
 import { useCommandCenterStore } from "./store";
 import {
+  isTimelineViewAvailable,
   PAGE_SIZE_OPTIONS,
+  resolveCommandCenterViewMode,
   useCommandCenterUrl,
   type CommandCenterPageSize,
   type CommandCenterViewMode,
@@ -124,8 +127,13 @@ export function CommandCenterTable({
   onUploadDocument,
   onSummaryChange,
 }: CommandCenterTableProps) {
-  const [{ mode: viewMode, expanded: expandedId, page, size: pageSize, q: query }, setUrl] =
-    useCommandCenterUrl();
+  const [
+    { mode: requestedViewMode, expanded: expandedId, page, size: pageSize, q: query },
+    setUrl,
+  ] = useCommandCenterUrl();
+  const capabilities = useOrgCapabilities();
+  const timelineAvailable = isTimelineViewAvailable(capabilities);
+  const viewMode = resolveCommandCenterViewMode(requestedViewMode, capabilities);
   const pageIndex = Math.max(0, page - 1);
   const setQuery = (next: string) => void setUrl({ q: next.length === 0 ? null : next, page: 1 });
   const setPageIndex = (next: number) => void setUrl({ page: next + 1 });
@@ -321,7 +329,7 @@ export function CommandCenterTable({
 
   const rightSlot = (
     <>
-      <ViewModeToggle viewMode={viewMode} setViewMode={setViewMode} />
+      {timelineAvailable && <ViewModeToggle viewMode={viewMode} setViewMode={setViewMode} />}
       <Suspense fallback={<ToolbarButtonSkeleton />}>
         <DataTableConfigManager
           resource={RESOURCE_NAME}

--- a/client/apps/web/src/routes/shipment/_components/command-center/right-stack/__tests__/right-stack-capability.test.tsx
+++ b/client/apps/web/src/routes/shipment/_components/command-center/right-stack/__tests__/right-stack-capability.test.tsx
@@ -1,0 +1,151 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { useAuthStore } from "@trenova/shared/stores/auth-store";
+import type { OrganizationCapabilities } from "@trenova/shared/types/organization-capability";
+import type { User } from "@trenova/shared/types/user";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import RightStack from "../index";
+import {
+  ALL_MODULES,
+  availableRightStackModules,
+  useRightStackStore,
+  type RightStackModuleId,
+} from "../right-stack-store";
+
+vi.mock("../unassigned-queue", () => ({
+  UnassignedQueue: () => <div data-testid="panel-unassigned" />,
+}));
+vi.mock("../exceptions-inbox", () => ({
+  ExceptionsInbox: () => <div data-testid="panel-exceptions" />,
+}));
+vi.mock("../hos-watch", () => ({
+  HosWatch: () => <div data-testid="panel-hos" />,
+}));
+vi.mock("../certification-watch", () => ({
+  CertificationWatch: () => <div data-testid="panel-certification" />,
+}));
+
+const hybrid: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: true,
+};
+const brokerageOnly: OrganizationCapabilities = {
+  brokerageEnabled: true,
+  assetOperationsEnabled: false,
+};
+
+function signIn(capabilities: OrganizationCapabilities) {
+  useAuthStore.setState({
+    user: {
+      currentOrganizationId: "org_01",
+      memberships: [
+        {
+          userId: "usr_01",
+          organizationId: "org_01",
+          isDefault: true,
+          organization: { id: "org_01", name: "Brokerage Co", ...capabilities },
+        },
+      ],
+    } as unknown as User,
+    isAuthenticated: true,
+  });
+}
+
+function setPreference(order: RightStackModuleId[], hidden: RightStackModuleId[] = []) {
+  useRightStackStore.setState({ order, hidden });
+}
+
+describe("availableRightStackModules", () => {
+  it("keeps every module for an organization that employs drivers", () => {
+    expect(availableRightStackModules(ALL_MODULES, hybrid)).toEqual([...ALL_MODULES]);
+  });
+
+  it("drops the driver-watching modules for a brokerage", () => {
+    expect(availableRightStackModules(ALL_MODULES, brokerageOnly)).toEqual([
+      "unassigned",
+      "exceptions",
+    ]);
+  });
+
+  it("preserves the stored order of the modules it keeps", () => {
+    const stored: RightStackModuleId[] = ["hos", "exceptions", "certification", "unassigned"];
+
+    expect(availableRightStackModules(stored, brokerageOnly)).toEqual(["exceptions", "unassigned"]);
+  });
+
+  it("returns an empty list rather than throwing when nothing survives", () => {
+    expect(availableRightStackModules(["hos", "certification"], brokerageOnly)).toEqual([]);
+  });
+});
+
+describe("RightStack under a stored preference that names a hidden module", () => {
+  beforeEach(() => {
+    setPreference([...ALL_MODULES], []);
+  });
+
+  afterEach(() => {
+    cleanup();
+    setPreference([...ALL_MODULES], []);
+    useAuthStore.setState({ user: null, isAuthenticated: false });
+  });
+
+  it("mounts all four panels for an organization that employs drivers", () => {
+    signIn(hybrid);
+
+    render(<RightStack />);
+
+    expect(screen.getByTestId("panel-unassigned")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-exceptions")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-hos")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-certification")).toBeInTheDocument();
+  });
+
+  it("leaves the driver panels unmounted for a brokerage", () => {
+    signIn(brokerageOnly);
+
+    render(<RightStack />);
+
+    expect(screen.getByTestId("panel-unassigned")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-exceptions")).toBeInTheDocument();
+    expect(screen.queryByTestId("panel-hos")).toBeNull();
+    expect(screen.queryByTestId("panel-certification")).toBeNull();
+  });
+
+  it("honours a stored order that leads with a module the brokerage cannot use", () => {
+    signIn(brokerageOnly);
+    setPreference(["hos", "unassigned", "certification", "exceptions"]);
+
+    render(<RightStack />);
+
+    const panels = screen.getAllByTestId(/^panel-/).map((node) => node.dataset.testid);
+    expect(panels).toEqual(["panel-unassigned", "panel-exceptions"]);
+  });
+
+  it("does not offer a hidden driver module back through the add-panel menu", () => {
+    signIn(brokerageOnly);
+    setPreference([...ALL_MODULES], ["hos", "certification"]);
+
+    render(<RightStack />);
+
+    expect(screen.queryByRole("button", { name: /Add panel/ })).toBeNull();
+  });
+
+  it("counts only the modules the organization can actually restore", () => {
+    signIn(brokerageOnly);
+    setPreference([...ALL_MODULES], ["exceptions", "hos", "certification"]);
+
+    render(<RightStack />);
+
+    expect(screen.getByRole("button", { name: "Add panel (1)" })).toBeInTheDocument();
+  });
+
+  it("falls back to the empty state when the only visible modules are gated away", () => {
+    signIn(brokerageOnly);
+    setPreference([...ALL_MODULES], ["unassigned", "exceptions"]);
+
+    render(<RightStack />);
+
+    expect(screen.getByText("All panels hidden")).toBeInTheDocument();
+    expect(screen.queryByTestId("panel-hos")).toBeNull();
+    expect(screen.queryByTestId("panel-certification")).toBeNull();
+  });
+});

--- a/client/apps/web/src/routes/shipment/_components/command-center/right-stack/index.tsx
+++ b/client/apps/web/src/routes/shipment/_components/command-center/right-stack/index.tsx
@@ -21,11 +21,18 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
+import { useOrgCapabilities } from "@trenova/shared/hooks/use-org-capabilities";
 import { PlusIcon } from "lucide-react";
+import { useMemo } from "react";
 import { CertificationWatch } from "./certification-watch";
 import { ExceptionsInbox } from "./exceptions-inbox";
 import { HosWatch } from "./hos-watch";
-import { ALL_MODULES, useRightStackStore, type RightStackModuleId } from "./right-stack-store";
+import {
+  ALL_MODULES,
+  availableRightStackModules,
+  useRightStackStore,
+  type RightStackModuleId,
+} from "./right-stack-store";
 import { UnassignedQueue } from "./unassigned-queue";
 
 const MODULE_LABEL: Record<RightStackModuleId, string> = {
@@ -51,8 +58,23 @@ export default function RightStack({ backgroundEnabled = true }: { backgroundEna
   const hidden = useRightStackStore.use.hidden();
   const show = useRightStackStore.use.show();
   const reorder = useRightStackStore.use.reorder();
+  const capabilities = useOrgCapabilities();
 
-  const visible = order.filter((id) => !hidden.includes(id));
+  // A saved arrangement can name a module this organization no longer has any
+  // data for. Filtering here — rather than trusting the stored list — is what
+  // keeps that preference from rendering an empty card or a hole in the stack.
+  const visible = useMemo(
+    () => availableRightStackModules(order, capabilities).filter((id) => !hidden.includes(id)),
+    [order, hidden, capabilities],
+  );
+  const restorable = useMemo(
+    () => availableRightStackModules(hidden, capabilities),
+    [hidden, capabilities],
+  );
+  const addable = useMemo(
+    () => availableRightStackModules(ALL_MODULES, capabilities),
+    [capabilities],
+  );
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -82,7 +104,7 @@ export default function RightStack({ backgroundEnabled = true }: { backgroundEna
             }
           />
           <DropdownMenuContent align="center" className="min-w-45">
-            {ALL_MODULES.map((id) => (
+            {addable.map((id) => (
               <DropdownMenuItem key={id} title={MODULE_LABEL[id]} onClick={() => show(id)} />
             ))}
           </DropdownMenuContent>
@@ -93,19 +115,19 @@ export default function RightStack({ backgroundEnabled = true }: { backgroundEna
 
   return (
     <aside className="relative flex h-full min-h-0 flex-col gap-2">
-      {hidden.length > 0 && (
+      {restorable.length > 0 && (
         <div className="absolute -top-7 right-0 z-10">
           <DropdownMenu>
             <DropdownMenuTrigger
               render={
                 <Button variant="outline" size="xxs">
                   <PlusIcon className="size-2.5" />
-                  Add panel ({hidden.length})
+                  Add panel ({restorable.length})
                 </Button>
               }
             />
             <DropdownMenuContent align="end" className="min-w-40">
-              {hidden.map((id) => (
+              {restorable.map((id) => (
                 <DropdownMenuItem key={id} title={MODULE_LABEL[id]} onClick={() => show(id)} />
               ))}
             </DropdownMenuContent>

--- a/client/apps/web/src/routes/shipment/_components/command-center/right-stack/right-stack-store.ts
+++ b/client/apps/web/src/routes/shipment/_components/command-center/right-stack/right-stack-store.ts
@@ -1,4 +1,10 @@
 import { createSelectors } from "@trenova/shared/lib/utils";
+import {
+  hasOrganizationCapability,
+  OrganizationCapability,
+  type OrganizationCapabilities,
+  type OrganizationCapabilityType,
+} from "@trenova/shared/types/organization-capability";
 import { create } from "zustand";
 import { createJSONStorage, devtools, persist } from "zustand/middleware";
 
@@ -10,6 +16,31 @@ export const ALL_MODULES: readonly RightStackModuleId[] = [
   "hos",
   "certification",
 ] as const;
+
+const MODULE_CAPABILITY: Partial<Record<RightStackModuleId, OrganizationCapabilityType>> = {
+  hos: OrganizationCapability.AssetOperations,
+  certification: OrganizationCapability.AssetOperations,
+};
+
+/**
+ * Narrows a stack order — or a hidden list — to the modules the organization can
+ * actually use. HOS clocks and unsigned-log counts are readings off employed
+ * drivers, so a brokerage has nothing to put in them.
+ *
+ * The filter is applied where the stack renders rather than written back into
+ * the store: a layout preference outlives a capability change, and an
+ * organization that switches its own trucks back on should find its arrangement
+ * intact rather than silently rewritten.
+ */
+export function availableRightStackModules(
+  ids: readonly RightStackModuleId[],
+  capabilities: OrganizationCapabilities,
+): RightStackModuleId[] {
+  return ids.filter((id) => {
+    const capability = MODULE_CAPABILITY[id];
+    return !capability || hasOrganizationCapability(capabilities, capability);
+  });
+}
 
 interface RightStackState {
   order: RightStackModuleId[];

--- a/client/apps/web/src/routes/shipment/_components/command-center/timeline/use-timeline-data.test.ts
+++ b/client/apps/web/src/routes/shipment/_components/command-center/timeline/use-timeline-data.test.ts
@@ -73,7 +73,8 @@ function makeShipment(id: string, status: string, moves: MoveSeed[]): Shipment {
             tractor: move.tractorCode ? { id: "trk_1", code: move.tractorCode } : null,
           }
         : null,
-      coverageType: move.coverageType ?? (move.carrierId ? "carrier" : "driver"),
+      coverageType:
+        move.coverageType ?? (move.carrierId ? "carrier" : move.workerId ? "driver" : "unassigned"),
       carrierAssignment: move.carrierId
         ? {
             id: `casn-${move.id}`,
@@ -433,15 +434,35 @@ describe("buildTimelineData", () => {
     expect(barMatchesFocus(data.unassignedRow!.bars[0], "unassigned")).toBe(true);
   });
 
-  it("keeps a lingering active carrier assignment out of coverage when the move is driver-typed", () => {
-    // The server flips coverageType back to driver when coverage is removed; a stale
+  it("keeps a lingering active carrier assignment out of coverage when the move is not carrier-typed", () => {
+    // The server returns coverageType to unassigned when coverage is removed; a stale
     // active record must not resurrect a carrier row on its own.
+    for (const coverageType of ["driver", "unassigned"]) {
+      const shipments = [
+        makeShipment("shp_1", "New", [
+          {
+            id: "mov_1",
+            carrierId: "car_1",
+            coverageType,
+            stops: [{ start: RANGE.start + 1000, end: RANGE.start + 5000 }],
+          },
+        ]),
+      ];
+
+      const data = buildTimelineData(shipments, 1, RANGE, NOW);
+
+      expect(data.rows).toHaveLength(0);
+      expect(data.unassignedRow?.bars).toHaveLength(1);
+    }
+  });
+
+  it("lands a genuinely uncovered move in the unassigned lane", () => {
     const shipments = [
       makeShipment("shp_1", "New", [
         {
           id: "mov_1",
-          carrierId: "car_1",
-          coverageType: "driver",
+          status: "New",
+          coverageType: "unassigned",
           stops: [{ start: RANGE.start + 1000, end: RANGE.start + 5000 }],
         },
       ]),
@@ -451,6 +472,9 @@ describe("buildTimelineData", () => {
 
     expect(data.rows).toHaveLength(0);
     expect(data.unassignedRow?.bars).toHaveLength(1);
+    expect(data.unassignedRow?.bars[0].assignment).toBeNull();
+    expect(data.unassignedRow?.bars[0].carrierAssignment).toBeNull();
+    expect(data.exceptions.unassigned).toBe(1);
   });
 
   it("never flags overlapping moves on a carrier row", () => {

--- a/client/apps/web/src/routes/shipment/_components/command-center/url-state.ts
+++ b/client/apps/web/src/routes/shipment/_components/command-center/url-state.ts
@@ -1,4 +1,9 @@
 import {
+  hasOrganizationCapability,
+  OrganizationCapability,
+  type OrganizationCapabilities,
+} from "@trenova/shared/types/organization-capability";
+import {
   parseAsArrayOf,
   parseAsInteger,
   parseAsString,
@@ -21,6 +26,29 @@ const TIMELINE_ZOOMS = ["day", "3day", "week"] as const;
 export type TimelineZoom = (typeof TIMELINE_ZOOMS)[number];
 const TIMELINE_SORTS = ["name", "exceptions", "loads"] as const;
 export type TimelineSort = (typeof TIMELINE_SORTS)[number];
+
+/**
+ * The timeline lays shipments out on rows that *are* employed drivers, and its
+ * only real interaction is dragging a load onto one of them. An organization
+ * without its own drivers has no rows to draw and no legal drop target, so the
+ * view is withheld rather than shown empty.
+ */
+export function isTimelineViewAvailable(capabilities: OrganizationCapabilities): boolean {
+  return hasOrganizationCapability(capabilities, OrganizationCapability.AssetOperations);
+}
+
+/**
+ * Resolves the requested view against what the organization can actually use.
+ * The URL is shareable and bookmarkable, so `?mode=timeline` can outlive the
+ * capability that justified it; it degrades to the table instead of mounting a
+ * view with nothing to show.
+ */
+export function resolveCommandCenterViewMode(
+  mode: CommandCenterViewMode,
+  capabilities: OrganizationCapabilities,
+): CommandCenterViewMode {
+  return mode === "timeline" && !isTimelineViewAvailable(capabilities) ? "table" : mode;
+}
 
 /**
  * URL state for the Shipments Command Center. Backing every cross-cutting bit

--- a/client/apps/web/src/routes/shipment/_components/move/move-card.tsx
+++ b/client/apps/web/src/routes/shipment/_components/move/move-card.tsx
@@ -112,6 +112,7 @@ export function MoveCard({
     mutationFn: () => apiService.assignmentService.unassign(move.id!),
     onSuccess: () => {
       setValue(`moves.${moveIndex}.assignment`, null);
+      setValue(`moves.${moveIndex}.coverageType`, "unassigned");
       setValue(`moves.${moveIndex}.status`, "New");
       void queryClient.invalidateQueries({ queryKey: ["shipment-list"] });
       toast.success("Move unassigned", {
@@ -127,7 +128,7 @@ export function MoveCard({
     mutationFn: (reason: string) => apiService.carrierAssignmentService.cancel(move.id!, reason),
     onSuccess: () => {
       setValue(`moves.${moveIndex}.carrierAssignment`, null);
-      setValue(`moves.${moveIndex}.coverageType`, "driver");
+      setValue(`moves.${moveIndex}.coverageType`, "unassigned");
       setValue(`moves.${moveIndex}.status`, "New");
       setCancelCarrierOpen(false);
       void queryClient.invalidateQueries({ queryKey: ["shipment-list"] });
@@ -349,6 +350,7 @@ export function MoveCard({
             existingCarrierAssignment={carrierAssignment}
             onAssigned={(assignment) => {
               setValue(`moves.${moveIndex}.assignment`, assignment);
+              setValue(`moves.${moveIndex}.coverageType`, "driver");
               setValue(`moves.${moveIndex}.status`, "Assigned");
               void queryClient.invalidateQueries({
                 queryKey: ["assignment", assignment.id],

--- a/client/apps/web/src/routes/shipment/_components/shipment-columns.tsx
+++ b/client/apps/web/src/routes/shipment/_components/shipment-columns.tsx
@@ -190,13 +190,13 @@ export function getColumns(rowActions: RowAction<Shipment>[]): ColumnDef<Shipmen
     },
     {
       id: "driver",
-      header: "Driver / Equip",
+      header: "Coverage",
       accessorFn: () => null,
       cell: ({ row }) => <DriverCell shipment={row.original} />,
       size: 200,
       minSize: 160,
       maxSize: 260,
-      meta: { label: "Driver / Equip", sortable: false, filterable: false },
+      meta: { label: "Coverage", sortable: false, filterable: false },
     },
     {
       id: "eta",

--- a/client/packages/graphql/src/generated/graphql.ts
+++ b/client/packages/graphql/src/generated/graphql.ts
@@ -1487,7 +1487,8 @@ export type MatchRoutingGuideInput = {
 
 export type MoveCoverageType =
   | 'carrier'
-  | 'driver';
+  | 'driver'
+  | 'unassigned';
 
 export type MoveStatus =
   | 'Assigned'

--- a/client/packages/graphql/src/schema.graphql
+++ b/client/packages/graphql/src/schema.graphql
@@ -5665,6 +5665,7 @@ input MatchRoutingGuideInput {
 enum MoveCoverageType {
   carrier
   driver
+  unassigned
 }
 
 enum MoveStatus {

--- a/client/packages/shared/src/types/organization-capability.ts
+++ b/client/packages/shared/src/types/organization-capability.ts
@@ -2,9 +2,19 @@
  * Organization capabilities describe which halves of the product an
  * organization actually operates: brokered freight, its own assets, or both.
  *
- * They gate navigation and route *visibility* only. Permissions remain the real
- * access control and the API stays open regardless of these flags — turning a
- * capability off declutters the UI, it does not restrict anyone.
+ * Permissions remain the real access control: a capability says whether the
+ * organization uses that half of the product at all, never whether this user
+ * may act on it. What a capability does beyond hiding UI is deliberately
+ * asymmetric between the two:
+ *
+ * - `Brokerage` is hide-only. Every carrier-facing surface disappears, but the
+ *   API stays open — turning it off declutters, it does not restrict anyone.
+ * - `AssetOperations` is enforced. Driver assignment is refused server-side when
+ *   it is off, because assigning a driver you do not employ corrupts data rather
+ *   than merely cluttering a screen. Unassigning stays allowed, so an
+ *   organization that inherits driver assignments can still unwind them. The
+ *   client gating below therefore pre-empts a refusal the server will make
+ *   anyway, instead of being the only thing standing in the way.
  */
 export const OrganizationCapability = {
   Brokerage: "brokerage",
@@ -21,8 +31,10 @@ export interface OrganizationCapabilities {
 
 /**
  * The fail-open baseline. Every unknown state — no session, no membership, a
- * projection that predates the flags — resolves to this, so a cosmetic gate can
- * never be the reason a feature disappears.
+ * projection that predates the flags — resolves to this, so a gate can never be
+ * the reason a feature disappears for an organization whose capabilities simply
+ * are not known yet. The server enforces the asset half on its own record, so
+ * failing open here never widens what an organization can actually do.
  */
 export const ORGANIZATION_CAPABILITIES_ENABLED: OrganizationCapabilities = {
   brokerageEnabled: true,

--- a/client/packages/shared/src/types/shipment.test.ts
+++ b/client/packages/shared/src/types/shipment.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { carrierAssignmentPayloadSchema, emptyCarrierAssignmentPayload } from "./shipment";
+import {
+  carrierAssignmentPayloadSchema,
+  emptyCarrierAssignmentPayload,
+  moveCoverageTypeSchema,
+} from "./shipment";
 
 function makePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -65,5 +69,18 @@ describe("carrierAssignmentPayloadSchema", () => {
     expect(() =>
       carrierAssignmentPayloadSchema.parse(makePayload({ baseRate: "abc" })),
     ).toThrowError(/Base rate is required/);
+  });
+});
+
+describe("moveCoverageTypeSchema", () => {
+  it("accepts every coverage a move can carry, uncovered included", () => {
+    for (const coverage of ["unassigned", "driver", "carrier"]) {
+      expect(moveCoverageTypeSchema.parse(coverage)).toBe(coverage);
+    }
+  });
+
+  it("rejects a coverage the server never writes", () => {
+    expect(() => moveCoverageTypeSchema.parse("broker")).toThrow();
+    expect(() => moveCoverageTypeSchema.parse("")).toThrow();
   });
 });

--- a/client/packages/shared/src/types/shipment.ts
+++ b/client/packages/shared/src/types/shipment.ts
@@ -196,7 +196,7 @@ export const assignmentSchema = z.object({
 });
 export type Assignment = z.infer<typeof assignmentSchema>;
 
-export const moveCoverageTypeSchema = z.enum(["driver", "carrier"]);
+export const moveCoverageTypeSchema = z.enum(["unassigned", "driver", "carrier"]);
 export type MoveCoverageType = z.infer<typeof moveCoverageTypeSchema>;
 
 export const carrierAssignmentStatusSchema = z.enum(["Pending", "Confirmed", "Canceled"]);

--- a/services/tms/docs/docs.go
+++ b/services/tms/docs/docs.go
@@ -37220,10 +37220,12 @@ const docTemplate = `{
         "github_com_emoss08_trenova_internal_core_domain_shipment.MoveCoverageType": {
             "type": "string",
             "enum": [
+                "unassigned",
                 "driver",
                 "carrier"
             ],
             "x-enum-varnames": [
+                "MoveCoverageTypeUnassigned",
                 "MoveCoverageTypeDriver",
                 "MoveCoverageTypeCarrier"
             ]

--- a/services/tms/docs/openapi-3.json
+++ b/services/tms/docs/openapi-3.json
@@ -8759,11 +8759,13 @@
             },
             "github_com_emoss08_trenova_internal_core_domain_shipment.MoveCoverageType": {
                 "enum": [
+                    "unassigned",
                     "driver",
                     "carrier"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
+                    "MoveCoverageTypeUnassigned",
                     "MoveCoverageTypeDriver",
                     "MoveCoverageTypeCarrier"
                 ]

--- a/services/tms/docs/openapi-3.yaml
+++ b/services/tms/docs/openapi-3.yaml
@@ -6221,10 +6221,12 @@ components:
                 - HoldSourceEDI
         github_com_emoss08_trenova_internal_core_domain_shipment.MoveCoverageType:
             enum:
+                - unassigned
                 - driver
                 - carrier
             type: string
             x-enum-varnames:
+                - MoveCoverageTypeUnassigned
                 - MoveCoverageTypeDriver
                 - MoveCoverageTypeCarrier
         github_com_emoss08_trenova_internal_core_domain_shipment.MoveStatus:

--- a/services/tms/docs/swagger.json
+++ b/services/tms/docs/swagger.json
@@ -8759,11 +8759,13 @@
         },
         "github_com_emoss08_trenova_internal_core_domain_shipment.MoveCoverageType": {
             "enum": [
+                "unassigned",
                 "driver",
                 "carrier"
             ],
             "type": "string",
             "x-enum-varnames": [
+                "MoveCoverageTypeUnassigned",
                 "MoveCoverageTypeDriver",
                 "MoveCoverageTypeCarrier"
             ]

--- a/services/tms/docs/swagger.yaml
+++ b/services/tms/docs/swagger.yaml
@@ -6221,10 +6221,12 @@ definitions:
             - HoldSourceEDI
     github_com_emoss08_trenova_internal_core_domain_shipment.MoveCoverageType:
         enum:
+            - unassigned
             - driver
             - carrier
         type: string
         x-enum-varnames:
+            - MoveCoverageTypeUnassigned
             - MoveCoverageTypeDriver
             - MoveCoverageTypeCarrier
     github_com_emoss08_trenova_internal_core_domain_shipment.MoveStatus:

--- a/services/tms/internal/api/graphql/generated/generated.go
+++ b/services/tms/internal/api/graphql/generated/generated.go
@@ -51010,6 +51010,7 @@ type ShipmentFormulaVariableDefinition {
 }
 
 enum MoveCoverageType {
+  unassigned
   driver
   carrier
 }

--- a/services/tms/internal/api/graphql/resolver/shipmentmapping.go
+++ b/services/tms/internal/api/graphql/resolver/shipmentmapping.go
@@ -504,7 +504,7 @@ func shipmentMovesToModel(
 		}
 		coverageType := entity.CoverageType
 		if coverageType == "" {
-			coverageType = shipmentdomain.MoveCoverageTypeDriver
+			coverageType = shipmentdomain.MoveCoverageTypeUnassigned
 		}
 		moves = append(moves, &gqlmodel.ShipmentMove{
 			ID:                     idPtr(entity.ID),

--- a/services/tms/internal/api/graphql/schema/shipment.graphqls
+++ b/services/tms/internal/api/graphql/schema/shipment.graphqls
@@ -257,6 +257,7 @@ type ShipmentFormulaVariableDefinition {
 }
 
 enum MoveCoverageType {
+  unassigned
   driver
   carrier
 }

--- a/services/tms/internal/core/domain/shipment/shipmentmove.go
+++ b/services/tms/internal/core/domain/shipment/shipmentmove.go
@@ -14,8 +14,9 @@ import (
 type MoveCoverageType string
 
 const (
-	MoveCoverageTypeDriver  = MoveCoverageType("driver")
-	MoveCoverageTypeCarrier = MoveCoverageType("carrier")
+	MoveCoverageTypeUnassigned = MoveCoverageType("unassigned")
+	MoveCoverageTypeDriver     = MoveCoverageType("driver")
+	MoveCoverageTypeCarrier    = MoveCoverageType("carrier")
 )
 
 func (c MoveCoverageType) String() string {
@@ -24,7 +25,7 @@ func (c MoveCoverageType) String() string {
 
 func (c MoveCoverageType) IsValid() bool {
 	switch c {
-	case MoveCoverageTypeDriver, MoveCoverageTypeCarrier:
+	case MoveCoverageTypeUnassigned, MoveCoverageTypeDriver, MoveCoverageTypeCarrier:
 		return true
 	}
 	return false
@@ -38,7 +39,7 @@ type ShipmentMove struct {
 	OrganizationID         pulid.ID           `json:"organizationId"       bun:"organization_id,type:VARCHAR(100),pk,notnull"`
 	ShipmentID             pulid.ID           `json:"shipmentId"           bun:"shipment_id,type:VARCHAR(100),notnull"`
 	Status                 MoveStatus         `json:"status"               bun:"status,type:move_status_enum,notnull,default:'New'"`
-	CoverageType           MoveCoverageType   `json:"coverageType"         bun:"coverage_type,type:VARCHAR(20),notnull,default:'driver'"`
+	CoverageType           MoveCoverageType   `json:"coverageType"         bun:"coverage_type,type:VARCHAR(20),notnull,default:'unassigned'"`
 	Loaded                 bool               `json:"loaded"               bun:"loaded,type:BOOLEAN,notnull,default:true"`
 	Sequence               int64              `json:"sequence"             bun:"sequence,type:INTEGER,notnull"`
 	Distance               *float64           `json:"distance"             bun:"distance,type:FLOAT,nullzero"`
@@ -63,7 +64,7 @@ func (m *ShipmentMove) BeforeAppendModel(_ context.Context, query bun.Query) err
 	now := timeutils.NowUnix()
 
 	if m.CoverageType == "" {
-		m.CoverageType = MoveCoverageTypeDriver
+		m.CoverageType = MoveCoverageTypeUnassigned
 	}
 
 	switch query.(type) {

--- a/services/tms/internal/core/domain/shipment/shipmentmove_test.go
+++ b/services/tms/internal/core/domain/shipment/shipmentmove_test.go
@@ -1,0 +1,162 @@
+package shipment
+
+import (
+	"testing"
+
+	"github.com/emoss08/trenova/pkg/errortypes"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func TestMoveCoverageType_IsValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value MoveCoverageType
+		want  bool
+	}{
+		{name: "unassigned", value: MoveCoverageTypeUnassigned, want: true},
+		{name: "driver", value: MoveCoverageTypeDriver, want: true},
+		{name: "carrier", value: MoveCoverageTypeCarrier, want: true},
+		{name: "empty", value: MoveCoverageType(""), want: false},
+		{name: "unknown", value: MoveCoverageType("broker"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, tt.value.IsValid())
+		})
+	}
+}
+
+func TestShipmentMove_BeforeAppendModelDefaultsCoverageToUnassigned(t *testing.T) {
+	t.Parallel()
+
+	t.Run("insert without coverage is born uncovered", func(t *testing.T) {
+		t.Parallel()
+
+		move := &ShipmentMove{}
+		require.NoError(t, move.BeforeAppendModel(t.Context(), (*bun.InsertQuery)(nil)))
+
+		assert.Equal(t, MoveCoverageTypeUnassigned, move.CoverageType)
+		assert.False(t, move.ID.IsNil())
+		assert.NotZero(t, move.CreatedAt)
+	})
+
+	t.Run("insert keeps an explicit coverage", func(t *testing.T) {
+		t.Parallel()
+
+		move := &ShipmentMove{CoverageType: MoveCoverageTypeCarrier}
+		require.NoError(t, move.BeforeAppendModel(t.Context(), (*bun.InsertQuery)(nil)))
+
+		assert.Equal(t, MoveCoverageTypeCarrier, move.CoverageType)
+	})
+
+	t.Run("update without coverage is born uncovered", func(t *testing.T) {
+		t.Parallel()
+
+		move := &ShipmentMove{ID: pulid.MustNew("sm_")}
+		require.NoError(t, move.BeforeAppendModel(t.Context(), (*bun.UpdateQuery)(nil)))
+
+		assert.Equal(t, MoveCoverageTypeUnassigned, move.CoverageType)
+		assert.NotZero(t, move.UpdatedAt)
+	})
+}
+
+func TestShipmentMove_CoveragePredicatesAreCoverageTypeAgnostic(t *testing.T) {
+	t.Parallel()
+
+	driverAssignment := &Assignment{ID: pulid.MustNew("asn_")}
+	activeCarrier := &CarrierAssignment{
+		ID:     pulid.MustNew("ca_"),
+		Status: CarrierAssignmentStatusConfirmed,
+	}
+	canceledCarrier := &CarrierAssignment{
+		ID:     pulid.MustNew("ca_"),
+		Status: CarrierAssignmentStatusCanceled,
+	}
+
+	tests := []struct {
+		name            string
+		move            *ShipmentMove
+		hasCoverage     bool
+		carrierCovered  bool
+		hasAssignment   bool
+		hasCarrierAssig bool
+	}{
+		{
+			name: "unassigned move with nothing attached",
+			move: &ShipmentMove{CoverageType: MoveCoverageTypeUnassigned},
+		},
+		{
+			name:          "driver covered move",
+			move:          &ShipmentMove{CoverageType: MoveCoverageTypeDriver, Assignment: driverAssignment},
+			hasCoverage:   true,
+			hasAssignment: true,
+		},
+		{
+			name:            "carrier covered move",
+			move:            &ShipmentMove{CoverageType: MoveCoverageTypeCarrier, CarrierAssignment: activeCarrier},
+			hasCoverage:     true,
+			carrierCovered:  true,
+			hasCarrierAssig: true,
+		},
+		{
+			name:           "carrier label with a canceled carrier assignment is uncovered",
+			move:           &ShipmentMove{CoverageType: MoveCoverageTypeCarrier, CarrierAssignment: canceledCarrier},
+			carrierCovered: true,
+		},
+		{
+			name:          "unassigned label still reports the driver assignment it carries",
+			move:          &ShipmentMove{CoverageType: MoveCoverageTypeUnassigned, Assignment: driverAssignment},
+			hasCoverage:   true,
+			hasAssignment: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.hasCoverage, tt.move.HasCoverage())
+			assert.Equal(t, tt.carrierCovered, tt.move.IsCarrierCovered())
+			assert.Equal(t, tt.hasAssignment, tt.move.HasAssignment())
+			assert.Equal(t, tt.hasCarrierAssig, tt.move.HasCarrierAssignment())
+		})
+	}
+}
+
+func TestShipmentMove_ValidateAcceptsEveryCoverageType(t *testing.T) {
+	t.Parallel()
+
+	for _, coverage := range []MoveCoverageType{
+		MoveCoverageTypeUnassigned,
+		MoveCoverageTypeDriver,
+		MoveCoverageTypeCarrier,
+	} {
+		t.Run(coverage.String(), func(t *testing.T) {
+			t.Parallel()
+
+			move := &ShipmentMove{Status: MoveStatusNew, CoverageType: coverage}
+			multiErr := errortypes.NewMultiError()
+			move.Validate(multiErr)
+
+			assert.False(t, multiErr.HasErrors(), "%v", multiErr)
+		})
+	}
+
+	t.Run("unknown coverage is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		move := &ShipmentMove{Status: MoveStatusNew, CoverageType: MoveCoverageType("broker")}
+		multiErr := errortypes.NewMultiError()
+		move.Validate(multiErr)
+
+		assert.True(t, multiErr.HasErrors())
+	})
+}

--- a/services/tms/internal/core/ports/repositories/organization.go
+++ b/services/tms/internal/core/ports/repositories/organization.go
@@ -46,9 +46,6 @@ func (c BrokerageDependencyCounts) HasOutstandingWork() bool {
 		c.ActiveCarrierAssignments > 0
 }
 
-// AssetDependencyCounts reports outstanding asset-side work for an
-// organization. It backs the guard that refuses to turn asset operations off
-// while any of these remain open.
 type AssetDependencyCounts struct {
 	ActiveDriverAssignments int `json:"activeDriverAssignments"`
 	UnpaidDriverSettlements int `json:"unpaidDriverSettlements"`

--- a/services/tms/internal/core/ports/repositories/organization.go
+++ b/services/tms/internal/core/ports/repositories/organization.go
@@ -46,6 +46,21 @@ func (c BrokerageDependencyCounts) HasOutstandingWork() bool {
 		c.ActiveCarrierAssignments > 0
 }
 
+// AssetDependencyCounts reports outstanding asset-side work for an
+// organization. It backs the guard that refuses to turn asset operations off
+// while any of these remain open.
+type AssetDependencyCounts struct {
+	ActiveDriverAssignments int `json:"activeDriverAssignments"`
+	UnpaidDriverSettlements int `json:"unpaidDriverSettlements"`
+	LinkedPortalUsers       int `json:"linkedPortalUsers"`
+}
+
+func (c AssetDependencyCounts) HasOutstandingWork() bool {
+	return c.ActiveDriverAssignments > 0 ||
+		c.UnpaidDriverSettlements > 0 ||
+		c.LinkedPortalUsers > 0
+}
+
 type OrganizationRepository interface {
 	GetByID(ctx context.Context, req GetOrganizationByIDRequest) (*tenant.Organization, error)
 	GetByIDs(ctx context.Context, req GetOrganizationsByIDsRequest) ([]*tenant.Organization, error)
@@ -61,6 +76,10 @@ type OrganizationRepository interface {
 		ctx context.Context,
 		tenantInfo pagination.TenantInfo,
 	) (*BrokerageDependencyCounts, error)
+	CountAssetDependencies(
+		ctx context.Context,
+		tenantInfo pagination.TenantInfo,
+	) (*AssetDependencyCounts, error)
 }
 
 type OrganizationCacheRepository interface {

--- a/services/tms/internal/core/services/assignmentservice/capabilityguard_test.go
+++ b/services/tms/internal/core/services/assignmentservice/capabilityguard_test.go
@@ -19,8 +19,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// brokerageOnlyService builds an assignment service for an organization that
-// has asset operations switched off, wired only as far as the capability gate.
 func brokerageOnlyService(
 	t *testing.T,
 	tenantInfo pagination.TenantInfo,
@@ -141,7 +139,12 @@ func TestUnassign_PermittedWhenAssetOperationsDisabled(t *testing.T) {
 	}
 
 	orgRepo := assetOperationsOrgRepo(t, tenantInfo, false)
-	svc := newUnassignService(t, tenantInfo, shipmentID, moveID, orgRepo)
+	svc := newUnassignService(t, unassignServiceParams{
+		TenantInfo: tenantInfo,
+		ShipmentID: shipmentID,
+		MoveID:     moveID,
+		OrgRepo:    orgRepo,
+	})
 
 	err := svc.Unassign(t.Context(), &repositories.UnassignShipmentMoveRequest{
 		TenantInfo:     tenantInfo,

--- a/services/tms/internal/core/services/assignmentservice/capabilityguard_test.go
+++ b/services/tms/internal/core/services/assignmentservice/capabilityguard_test.go
@@ -1,0 +1,153 @@
+package assignmentservice
+
+import (
+	"testing"
+
+	"github.com/emoss08/trenova/internal/core/domain/shipment"
+	"github.com/emoss08/trenova/internal/core/domain/shipmentstate"
+	"github.com/emoss08/trenova/internal/core/domain/tenant"
+	"github.com/emoss08/trenova/internal/core/ports/repositories"
+	"github.com/emoss08/trenova/internal/core/services/shipmentcommercial"
+	"github.com/emoss08/trenova/internal/core/services/shipmentservice"
+	"github.com/emoss08/trenova/internal/testutil/mocks"
+	"github.com/emoss08/trenova/pkg/errortypes"
+	"github.com/emoss08/trenova/pkg/pagination"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// brokerageOnlyService builds an assignment service for an organization that
+// has asset operations switched off, wired only as far as the capability gate.
+func brokerageOnlyService(
+	t *testing.T,
+	tenantInfo pagination.TenantInfo,
+	moveID pulid.ID,
+) (*service, *mocks.MockOrganizationRepository) {
+	t.Helper()
+
+	repo := mocks.NewMockAssignmentRepository(t)
+	repo.EXPECT().
+		GetMoveByID(mock.Anything, tenantInfo, moveID).
+		Return(&shipment.ShipmentMove{
+			ID:             moveID,
+			ShipmentID:     pulid.MustNew("shp_"),
+			OrganizationID: tenantInfo.OrgID,
+			BusinessUnitID: tenantInfo.BuID,
+			Status:         shipment.MoveStatusNew,
+			CoverageType:   shipment.MoveCoverageTypeUnassigned,
+		}, nil).
+		Once()
+
+	orgRepo := mocks.NewMockOrganizationRepository(t)
+	orgRepo.EXPECT().
+		GetByID(mock.Anything, repositories.GetOrganizationByIDRequest{TenantInfo: tenantInfo}).
+		Return(&tenant.Organization{
+			ID:                     tenantInfo.OrgID,
+			BusinessUnitID:         tenantInfo.BuID,
+			BrokerageEnabled:       true,
+			AssetOperationsEnabled: false,
+		}, nil).
+		Once()
+
+	svc := &service{
+		l:            zap.NewNop(),
+		db:           testDBConnection{},
+		repo:         repo,
+		orgRepo:      orgRepo,
+		shipmentRepo: mocks.NewMockShipmentRepository(t),
+		holdRepo:     mocks.NewMockShipmentHoldRepository(t),
+		commercial: shipmentcommercial.New(shipmentcommercial.Params{
+			Formula:         mocks.NewMockFormulaCalculator(t),
+			AccessorialRepo: mocks.NewMockAccessorialChargeRepository(t),
+		}),
+		shipmentValidator: shipmentservice.NewTestValidator(t),
+		eventService:      noopShipmentEventService{},
+		coordinator:       shipmentstate.NewCoordinator(),
+	}
+
+	return svc, orgRepo
+}
+
+func assertAssetOperationsRefusal(t *testing.T, err error, moveID pulid.ID) {
+	t.Helper()
+
+	require.Error(t, err)
+	businessErr := new(errortypes.BusinessError)
+	require.ErrorAs(t, err, &businessErr)
+	assert.Equal(
+		t,
+		"Organization does not have asset operations enabled. "+
+			"Cover this shipment move with a carrier instead of assigning a driver",
+		businessErr.Message,
+	)
+	assert.Equal(t, moveID.String(), businessErr.Params["shipmentMoveId"])
+}
+
+func TestAssignToMove_RefusedWhenAssetOperationsDisabled(t *testing.T) {
+	t.Parallel()
+
+	moveID := pulid.MustNew("sm_")
+	tenantInfo := pagination.TenantInfo{
+		OrgID: pulid.MustNew("org_"),
+		BuID:  pulid.MustNew("bu_"),
+	}
+
+	svc, _ := brokerageOnlyService(t, tenantInfo, moveID)
+
+	entity, err := svc.AssignToMove(t.Context(), &repositories.AssignShipmentMoveRequest{
+		TenantInfo:      tenantInfo,
+		ShipmentMoveID:  moveID,
+		PrimaryWorkerID: pulid.MustNew("wrk_"),
+		TractorID:       pulid.MustNew("trac_"),
+	})
+
+	assert.Nil(t, entity)
+	assertAssetOperationsRefusal(t, err, moveID)
+}
+
+func TestReassign_RefusedWhenAssetOperationsDisabled(t *testing.T) {
+	t.Parallel()
+
+	moveID := pulid.MustNew("sm_")
+	tenantInfo := pagination.TenantInfo{
+		OrgID: pulid.MustNew("org_"),
+		BuID:  pulid.MustNew("bu_"),
+	}
+
+	svc, _ := brokerageOnlyService(t, tenantInfo, moveID)
+
+	entity, err := svc.Reassign(t.Context(), &repositories.ReassignShipmentMoveRequest{
+		TenantInfo:      tenantInfo,
+		ShipmentMoveID:  moveID,
+		PrimaryWorkerID: pulid.MustNew("wrk_"),
+		TractorID:       pulid.MustNew("trac_"),
+	})
+
+	assert.Nil(t, entity)
+	assertAssetOperationsRefusal(t, err, moveID)
+}
+
+func TestUnassign_PermittedWhenAssetOperationsDisabled(t *testing.T) {
+	t.Parallel()
+
+	moveID := pulid.MustNew("sm_")
+	shipmentID := pulid.MustNew("shp_")
+	tenantInfo := pagination.TenantInfo{
+		OrgID: pulid.MustNew("org_"),
+		BuID:  pulid.MustNew("bu_"),
+	}
+
+	orgRepo := assetOperationsOrgRepo(t, tenantInfo, false)
+	svc := newUnassignService(t, tenantInfo, shipmentID, moveID, orgRepo)
+
+	err := svc.Unassign(t.Context(), &repositories.UnassignShipmentMoveRequest{
+		TenantInfo:     tenantInfo,
+		ShipmentMoveID: moveID,
+	})
+
+	require.NoError(t, err)
+	orgRepo.AssertNotCalled(t, "GetByID", mock.Anything, mock.Anything)
+}

--- a/services/tms/internal/core/services/assignmentservice/service.go
+++ b/services/tms/internal/core/services/assignmentservice/service.go
@@ -471,6 +471,7 @@ func (s *service) unassignWithinTx(
 				WithParam("shipmentMoveId", req.ShipmentMoveID.String())
 		}
 		targetMove.Assignment = nil
+		targetMove.CoverageType = shipment.MoveCoverageTypeUnassigned
 		targetMove.Status = shipment.MoveStatusNew
 
 		control, err := s.controlRepo.Get(txCtx, repositories.GetShipmentControlRequest{
@@ -722,6 +723,7 @@ func (s *service) upsertAssignment( //nolint:gocognit // legacy workflow
 				WithParam("shipmentMoveId", moveID.String())
 		}
 		targetMove.Assignment = savedAssignment
+		targetMove.CoverageType = shipment.MoveCoverageTypeDriver
 
 		control, err := s.controlRepo.Get(txCtx, repositories.GetShipmentControlRequest{
 			TenantInfo: tenantInfo,

--- a/services/tms/internal/core/services/assignmentservice/service.go
+++ b/services/tms/internal/core/services/assignmentservice/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/emoss08/trenova/internal/core/ports"
 	"github.com/emoss08/trenova/internal/core/ports/repositories"
 	portservices "github.com/emoss08/trenova/internal/core/ports/services"
+	"github.com/emoss08/trenova/internal/core/services/capabilityguard"
 	"github.com/emoss08/trenova/internal/core/services/dispatchguard"
 	"github.com/emoss08/trenova/internal/core/services/drivernotificationservice"
 	"github.com/emoss08/trenova/internal/core/services/shipmentcommercial"
@@ -38,6 +39,7 @@ type Params struct {
 	DB                  ports.DBConnection
 	Repo                repositories.AssignmentRepository
 	ShipmentRepo        repositories.ShipmentRepository
+	OrgRepo             repositories.OrganizationRepository
 	HoldRepo            repositories.ShipmentHoldRepository
 	ControlRepo         repositories.ShipmentControlRepository
 	DispatchControlRepo repositories.DispatchControlRepository
@@ -62,6 +64,7 @@ type service struct {
 	db                  ports.DBConnection
 	repo                repositories.AssignmentRepository
 	shipmentRepo        repositories.ShipmentRepository
+	orgRepo             repositories.OrganizationRepository
 	holdRepo            repositories.ShipmentHoldRepository
 	controlRepo         repositories.ShipmentControlRepository
 	dispatchControlRepo repositories.DispatchControlRepository
@@ -87,6 +90,7 @@ func New(p Params) portservices.AssignmentService {
 		db:                  p.DB,
 		repo:                p.Repo,
 		shipmentRepo:        p.ShipmentRepo,
+		orgRepo:             p.OrgRepo,
 		holdRepo:            p.HoldRepo,
 		controlRepo:         p.ControlRepo,
 		dispatchControlRepo: p.DispatchControlRepo,
@@ -665,6 +669,14 @@ func (s *service) upsertAssignment( //nolint:gocognit // legacy workflow
 		}
 
 		if err = move.EnsureAssignable(); err != nil {
+			return err
+		}
+		if err = capabilityguard.EnsureDriverAssignable(
+			txCtx,
+			s.orgRepo,
+			tenantInfo,
+			moveID,
+		); err != nil {
 			return err
 		}
 		if err = dispatchguard.EnsureNoDispatchHold(txCtx, s.holdRepo, tenantInfo, move.ShipmentID); err != nil {

--- a/services/tms/internal/core/services/assignmentservice/service_test.go
+++ b/services/tms/internal/core/services/assignmentservice/service_test.go
@@ -40,6 +40,7 @@ func TestAssignToMove_DerivesAssignedStatusesThroughShipmentCoordinator(t *testi
 	}
 
 	original := validShipment(shipmentID, moveID, tenantInfo)
+	original.Moves[0].CoverageType = shipment.MoveCoverageTypeUnassigned
 
 	repo := mocks.NewMockAssignmentRepository(t)
 	repo.EXPECT().
@@ -50,6 +51,7 @@ func TestAssignToMove_DerivesAssignedStatusesThroughShipmentCoordinator(t *testi
 			OrganizationID: tenantInfo.OrgID,
 			BusinessUnitID: tenantInfo.BuID,
 			Status:         shipment.MoveStatusNew,
+			CoverageType:   shipment.MoveCoverageTypeUnassigned,
 		}, nil).
 		Once()
 	repo.EXPECT().GetByMoveID(mock.Anything, tenantInfo, moveID).Return(nil, nil).Once()
@@ -100,6 +102,7 @@ func TestAssignToMove_DerivesAssignedStatusesThroughShipmentCoordinator(t *testi
 		) (*shipment.Shipment, error) {
 			assert.Equal(t, shipment.StatusAssigned, entity.Status)
 			assert.Equal(t, shipment.MoveStatusAssigned, entity.Moves[0].Status)
+			assert.Equal(t, shipment.MoveCoverageTypeDriver, entity.Moves[0].CoverageType)
 			require.NotNil(t, entity.Moves[0].Assignment)
 			return entity, nil
 		}).
@@ -513,6 +516,7 @@ func TestUnassign_ClearsAssignmentAndDerivesUnassignedStatuses(t *testing.T) {
 	original := validShipment(shipmentID, moveID, tenantInfo)
 	original.Status = shipment.StatusAssigned
 	original.Moves[0].Status = shipment.MoveStatusAssigned
+	original.Moves[0].CoverageType = shipment.MoveCoverageTypeDriver
 	original.Moves[0].Assignment = &shipment.Assignment{
 		ID:              assignmentID,
 		OrganizationID:  tenantInfo.OrgID,
@@ -532,6 +536,7 @@ func TestUnassign_ClearsAssignmentAndDerivesUnassignedStatuses(t *testing.T) {
 			OrganizationID: tenantInfo.OrgID,
 			BusinessUnitID: tenantInfo.BuID,
 			Status:         shipment.MoveStatusAssigned,
+			CoverageType:   shipment.MoveCoverageTypeDriver,
 		}, nil).
 		Once()
 	repo.EXPECT().
@@ -566,6 +571,7 @@ func TestUnassign_ClearsAssignmentAndDerivesUnassignedStatuses(t *testing.T) {
 		RunAndReturn(func(_ context.Context, entity *shipment.Shipment) (*shipment.Shipment, error) {
 			assert.Equal(t, shipment.StatusNew, entity.Status)
 			assert.Equal(t, shipment.MoveStatusNew, entity.Moves[0].Status)
+			assert.Equal(t, shipment.MoveCoverageTypeUnassigned, entity.Moves[0].CoverageType)
 			assert.Nil(t, entity.Moves[0].Assignment)
 			return entity, nil
 		}).
@@ -832,6 +838,7 @@ func newAssignToMoveService(
 	t.Helper()
 
 	original := validShipment(shipmentID, moveID, tenantInfo)
+	original.Moves[0].CoverageType = shipment.MoveCoverageTypeUnassigned
 
 	repo := mocks.NewMockAssignmentRepository(t)
 	repo.EXPECT().
@@ -842,6 +849,7 @@ func newAssignToMoveService(
 			OrganizationID: tenantInfo.OrgID,
 			BusinessUnitID: tenantInfo.BuID,
 			Status:         shipment.MoveStatusNew,
+			CoverageType:   shipment.MoveCoverageTypeUnassigned,
 		}, nil).
 		Once()
 	repo.EXPECT().GetByMoveID(mock.Anything, tenantInfo, moveID).Return(nil, nil).Once()
@@ -891,6 +899,7 @@ func newAssignToMoveService(
 			_ context.Context,
 			entity *shipment.Shipment,
 		) (*shipment.Shipment, error) {
+			assert.Equal(t, shipment.MoveCoverageTypeDriver, entity.Moves[0].CoverageType)
 			return entity, nil
 		}).
 		Once()

--- a/services/tms/internal/core/services/assignmentservice/service_test.go
+++ b/services/tms/internal/core/services/assignmentservice/service_test.go
@@ -29,6 +29,30 @@ import (
 	"go.uber.org/zap"
 )
 
+// assetOperationsOrgRepo stands in for the organization behind a tenant, with
+// asset operations either enabled or switched off. The expectation is optional
+// so that tests refused before the capability gate still pass.
+func assetOperationsOrgRepo(
+	t *testing.T,
+	tenantInfo pagination.TenantInfo,
+	enabled bool,
+) *mocks.MockOrganizationRepository {
+	t.Helper()
+
+	orgRepo := mocks.NewMockOrganizationRepository(t)
+	orgRepo.EXPECT().
+		GetByID(mock.Anything, repositories.GetOrganizationByIDRequest{TenantInfo: tenantInfo}).
+		Return(&tenant.Organization{
+			ID:                     tenantInfo.OrgID,
+			BusinessUnitID:         tenantInfo.BuID,
+			BrokerageEnabled:       true,
+			AssetOperationsEnabled: enabled,
+		}, nil).
+		Maybe()
+
+	return orgRepo
+}
+
 func TestAssignToMove_DerivesAssignedStatusesThroughShipmentCoordinator(t *testing.T) {
 	t.Parallel()
 
@@ -126,6 +150,7 @@ func TestAssignToMove_DerivesAssignedStatusesThroughShipmentCoordinator(t *testi
 		Once()
 
 	svc := &service{
+		orgRepo:      assetOperationsOrgRepo(t, tenantInfo, true),
 		l:            zap.NewNop(),
 		db:           testDBConnection{},
 		repo:         repo,
@@ -163,8 +188,9 @@ func TestAssignToMove_RejectsCompletedMove(t *testing.T) {
 	}
 
 	svc := &service{
-		l:  zap.NewNop(),
-		db: testDBConnection{},
+		orgRepo: assetOperationsOrgRepo(t, tenantInfo, true),
+		l:       zap.NewNop(),
+		db:      testDBConnection{},
 		repo: func() *mocks.MockAssignmentRepository {
 			repo := mocks.NewMockAssignmentRepository(t)
 			repo.EXPECT().
@@ -226,6 +252,7 @@ func TestAssignToMove_RejectsDispatchBlockingHold(t *testing.T) {
 		Once()
 
 	svc := &service{
+		orgRepo:      assetOperationsOrgRepo(t, tenantInfo, true),
 		l:            zap.NewNop(),
 		db:           testDBConnection{},
 		repo:         repo,
@@ -343,6 +370,7 @@ func TestAssignToMove_RejectsTrailerContinuityMismatch(t *testing.T) {
 		Once()
 
 	svc := &service{
+		orgRepo:             assetOperationsOrgRepo(t, tenantInfo, true),
 		l:                   zap.NewNop(),
 		db:                  testDBConnection{},
 		repo:                repo,
@@ -473,6 +501,7 @@ func TestAssignToMove_DoesNotAdvanceTrailerContinuityBeforeCompletion(t *testing
 		Once()
 
 	svc := &service{
+		orgRepo:             assetOperationsOrgRepo(t, tenantInfo, true),
 		l:                   zap.NewNop(),
 		db:                  testDBConnection{},
 		repo:                repo,
@@ -502,15 +531,13 @@ func TestAssignToMove_DoesNotAdvanceTrailerContinuityBeforeCompletion(t *testing
 	require.NotNil(t, entity)
 }
 
-func TestUnassign_ClearsAssignmentAndDerivesUnassignedStatuses(t *testing.T) {
-	t.Parallel()
-
-	moveID := pulid.MustNew("sm_")
-	shipmentID := pulid.MustNew("shp_")
-	tenantInfo := pagination.TenantInfo{
-		OrgID: pulid.MustNew("org_"),
-		BuID:  pulid.MustNew("bu_"),
-	}
+func newUnassignService(
+	t *testing.T,
+	tenantInfo pagination.TenantInfo,
+	shipmentID, moveID pulid.ID,
+	orgRepo repositories.OrganizationRepository,
+) *service {
+	t.Helper()
 
 	assignmentID := pulid.MustNew("asn_")
 	original := validShipment(shipmentID, moveID, tenantInfo)
@@ -592,6 +619,7 @@ func TestUnassign_ClearsAssignmentAndDerivesUnassignedStatuses(t *testing.T) {
 		l:            zap.NewNop(),
 		db:           testDBConnection{},
 		repo:         repo,
+		orgRepo:      orgRepo,
 		shipmentRepo: shipmentRepo,
 		holdRepo:     holdRepo,
 		controlRepo:  controlRepo,
@@ -603,6 +631,21 @@ func TestUnassign_ClearsAssignmentAndDerivesUnassignedStatuses(t *testing.T) {
 		eventService:      noopShipmentEventService{},
 		coordinator:       shipmentstate.NewCoordinatorWithClock(func() int64 { return 10 }),
 	}
+
+	return svc
+}
+
+func TestUnassign_ClearsAssignmentAndDerivesUnassignedStatuses(t *testing.T) {
+	t.Parallel()
+
+	moveID := pulid.MustNew("sm_")
+	shipmentID := pulid.MustNew("shp_")
+	tenantInfo := pagination.TenantInfo{
+		OrgID: pulid.MustNew("org_"),
+		BuID:  pulid.MustNew("bu_"),
+	}
+
+	svc := newUnassignService(t, tenantInfo, shipmentID, moveID, nil)
 
 	err := svc.Unassign(t.Context(), &repositories.UnassignShipmentMoveRequest{
 		TenantInfo:     tenantInfo,
@@ -923,6 +966,7 @@ func newAssignToMoveService(
 		Once()
 
 	return &service{
+		orgRepo:      assetOperationsOrgRepo(t, tenantInfo, true),
 		l:            zap.NewNop(),
 		db:           testDBConnection{},
 		repo:         repo,

--- a/services/tms/internal/core/services/assignmentservice/service_test.go
+++ b/services/tms/internal/core/services/assignmentservice/service_test.go
@@ -29,9 +29,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// assetOperationsOrgRepo stands in for the organization behind a tenant, with
-// asset operations either enabled or switched off. The expectation is optional
-// so that tests refused before the capability gate still pass.
 func assetOperationsOrgRepo(
 	t *testing.T,
 	tenantInfo pagination.TenantInfo,

--- a/services/tms/internal/core/services/assignmentservice/service_test.go
+++ b/services/tms/internal/core/services/assignmentservice/service_test.go
@@ -531,13 +531,19 @@ func TestAssignToMove_DoesNotAdvanceTrailerContinuityBeforeCompletion(t *testing
 	require.NotNil(t, entity)
 }
 
-func newUnassignService(
-	t *testing.T,
-	tenantInfo pagination.TenantInfo,
-	shipmentID, moveID pulid.ID,
-	orgRepo repositories.OrganizationRepository,
-) *service {
+type unassignServiceParams struct {
+	TenantInfo pagination.TenantInfo
+	ShipmentID pulid.ID
+	MoveID     pulid.ID
+	OrgRepo    repositories.OrganizationRepository
+}
+
+func newUnassignService(t *testing.T, params unassignServiceParams) *service {
 	t.Helper()
+
+	tenantInfo := params.TenantInfo
+	shipmentID := params.ShipmentID
+	moveID := params.MoveID
 
 	assignmentID := pulid.MustNew("asn_")
 	original := validShipment(shipmentID, moveID, tenantInfo)
@@ -619,7 +625,7 @@ func newUnassignService(
 		l:            zap.NewNop(),
 		db:           testDBConnection{},
 		repo:         repo,
-		orgRepo:      orgRepo,
+		orgRepo:      params.OrgRepo,
 		shipmentRepo: shipmentRepo,
 		holdRepo:     holdRepo,
 		controlRepo:  controlRepo,
@@ -645,7 +651,11 @@ func TestUnassign_ClearsAssignmentAndDerivesUnassignedStatuses(t *testing.T) {
 		BuID:  pulid.MustNew("bu_"),
 	}
 
-	svc := newUnassignService(t, tenantInfo, shipmentID, moveID, nil)
+	svc := newUnassignService(t, unassignServiceParams{
+		TenantInfo: tenantInfo,
+		ShipmentID: shipmentID,
+		MoveID:     moveID,
+	})
 
 	err := svc.Unassign(t.Context(), &repositories.UnassignShipmentMoveRequest{
 		TenantInfo:     tenantInfo,

--- a/services/tms/internal/core/services/capabilityguard/capabilityguard.go
+++ b/services/tms/internal/core/services/capabilityguard/capabilityguard.go
@@ -1,6 +1,3 @@
-// Package capabilityguard holds the organization-capability gates shared by the
-// services that refuse asset-side work for organizations which do not run their
-// own drivers and equipment.
 package capabilityguard
 
 import (
@@ -12,8 +9,6 @@ import (
 	"github.com/emoss08/trenova/shared/pulid"
 )
 
-// AssetOperationsEnabled reports whether the organization dispatches its own
-// drivers and equipment rather than covering freight through carriers only.
 func AssetOperationsEnabled(
 	ctx context.Context,
 	orgRepo repositories.OrganizationRepository,
@@ -29,8 +24,6 @@ func AssetOperationsEnabled(
 	return org.AssetOperationsEnabled, nil
 }
 
-// EnsureDriverAssignable blocks driver coverage of a shipment move while the
-// organization has asset operations switched off.
 func EnsureDriverAssignable(
 	ctx context.Context,
 	orgRepo repositories.OrganizationRepository,

--- a/services/tms/internal/core/services/capabilityguard/capabilityguard.go
+++ b/services/tms/internal/core/services/capabilityguard/capabilityguard.go
@@ -1,0 +1,50 @@
+// Package capabilityguard holds the organization-capability gates shared by the
+// services that refuse asset-side work for organizations which do not run their
+// own drivers and equipment.
+package capabilityguard
+
+import (
+	"context"
+
+	"github.com/emoss08/trenova/internal/core/ports/repositories"
+	"github.com/emoss08/trenova/pkg/errortypes"
+	"github.com/emoss08/trenova/pkg/pagination"
+	"github.com/emoss08/trenova/shared/pulid"
+)
+
+// AssetOperationsEnabled reports whether the organization dispatches its own
+// drivers and equipment rather than covering freight through carriers only.
+func AssetOperationsEnabled(
+	ctx context.Context,
+	orgRepo repositories.OrganizationRepository,
+	tenantInfo pagination.TenantInfo,
+) (bool, error) {
+	org, err := orgRepo.GetByID(ctx, repositories.GetOrganizationByIDRequest{
+		TenantInfo: tenantInfo,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return org.AssetOperationsEnabled, nil
+}
+
+// EnsureDriverAssignable blocks driver coverage of a shipment move while the
+// organization has asset operations switched off.
+func EnsureDriverAssignable(
+	ctx context.Context,
+	orgRepo repositories.OrganizationRepository,
+	tenantInfo pagination.TenantInfo,
+	moveID pulid.ID,
+) error {
+	enabled, err := AssetOperationsEnabled(ctx, orgRepo, tenantInfo)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		return errortypes.NewBusinessError("Organization does not have asset operations enabled. Cover this shipment move with a carrier instead of assigning a driver").
+			WithParam("shipmentMoveId", moveID.String())
+	}
+
+	return nil
+}

--- a/services/tms/internal/core/services/carrierassignmentservice/coverage_test.go
+++ b/services/tms/internal/core/services/carrierassignmentservice/coverage_test.go
@@ -1,0 +1,144 @@
+package carrierassignmentservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/emoss08/trenova/internal/core/domain/shipment"
+	"github.com/emoss08/trenova/internal/core/domain/shipmentstate"
+	"github.com/emoss08/trenova/internal/core/domain/tenant"
+	"github.com/emoss08/trenova/internal/core/ports/repositories"
+	"github.com/emoss08/trenova/internal/core/services/shipmentservice"
+	"github.com/emoss08/trenova/internal/testutil/mocks"
+	"github.com/emoss08/trenova/pkg/pagination"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestApplyCoverageChangeStampsCoverageExplicitly(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		initial    shipment.MoveCoverageType
+		assignment *shipment.CarrierAssignment
+		want       shipment.MoveCoverageType
+	}{
+		{
+			name:       "assigning a carrier marks the move carrier covered",
+			initial:    shipment.MoveCoverageTypeUnassigned,
+			assignment: &shipment.CarrierAssignment{Status: shipment.CarrierAssignmentStatusPending},
+			want:       shipment.MoveCoverageTypeCarrier,
+		},
+		{
+			name:    "canceling a carrier returns the move to uncovered, not driver covered",
+			initial: shipment.MoveCoverageTypeCarrier,
+			want:    shipment.MoveCoverageTypeUnassigned,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			moveID := pulid.MustNew("sm_")
+			shipmentID := pulid.MustNew("shp_")
+			tenantInfo := pagination.TenantInfo{
+				OrgID: pulid.MustNew("org_"),
+				BuID:  pulid.MustNew("bu_"),
+			}
+
+			original := coverageShipment(shipmentID, moveID, tenantInfo)
+			original.Moves[0].CoverageType = tt.initial
+
+			var persisted *shipment.Shipment
+			shipmentRepo := mocks.NewMockShipmentRepository(t)
+			shipmentRepo.EXPECT().
+				Update(mock.Anything, mock.AnythingOfType("*shipment.Shipment")).
+				RunAndReturn(func(_ context.Context, entity *shipment.Shipment) (*shipment.Shipment, error) {
+					persisted = entity
+					return entity, nil
+				}).
+				Once()
+
+			controlRepo := mocks.NewMockShipmentControlRepository(t)
+			controlRepo.EXPECT().
+				Get(mock.Anything, repositories.GetShipmentControlRequest{TenantInfo: tenantInfo}).
+				Return(&tenant.ShipmentControl{}, nil).
+				Once()
+
+			svc := &Service{
+				l:                 zap.NewNop(),
+				shipmentRepo:      shipmentRepo,
+				controlRepo:       controlRepo,
+				shipmentValidator: shipmentservice.NewTestValidator(t),
+				coordinator:       shipmentstate.NewCoordinatorWithClock(func() int64 { return 10 }),
+			}
+
+			require.NoError(
+				t,
+				svc.applyCoverageChange(t.Context(), tenantInfo, original, moveID, tt.assignment),
+			)
+			require.NotNil(t, persisted)
+			assert.Equal(t, tt.want, persisted.Moves[0].CoverageType)
+			assert.Equal(t, tt.initial, original.Moves[0].CoverageType)
+		})
+	}
+}
+
+func coverageShipment(
+	shipmentID, moveID pulid.ID,
+	tenantInfo pagination.TenantInfo,
+) *shipment.Shipment {
+	return &shipment.Shipment{
+		ID:                shipmentID,
+		OrganizationID:    tenantInfo.OrgID,
+		BusinessUnitID:    tenantInfo.BuID,
+		ServiceTypeID:     pulid.MustNew("svc_"),
+		CustomerID:        pulid.MustNew("cust_"),
+		BOL:               "BOL-1",
+		FormulaTemplateID: pulid.MustNew("ft_"),
+		Status:            shipment.StatusNew,
+		Moves: []*shipment.ShipmentMove{
+			{
+				ID:             moveID,
+				ShipmentID:     shipmentID,
+				OrganizationID: tenantInfo.OrgID,
+				BusinessUnitID: tenantInfo.BuID,
+				Status:         shipment.MoveStatusNew,
+				Loaded:         true,
+				Stops: []*shipment.Stop{
+					{
+						ID:                   pulid.MustNew("stp_"),
+						ShipmentMoveID:       moveID,
+						OrganizationID:       tenantInfo.OrgID,
+						BusinessUnitID:       tenantInfo.BuID,
+						Sequence:             0,
+						Status:               shipment.StopStatusNew,
+						Type:                 shipment.StopTypePickup,
+						LocationID:           pulid.MustNew("loc_"),
+						ScheduleType:         shipment.StopScheduleTypeOpen,
+						ScheduledWindowStart: 1,
+						ScheduledWindowEnd:   new(int64(2)),
+					},
+					{
+						ID:                   pulid.MustNew("stp_"),
+						ShipmentMoveID:       moveID,
+						OrganizationID:       tenantInfo.OrgID,
+						BusinessUnitID:       tenantInfo.BuID,
+						Sequence:             1,
+						Status:               shipment.StopStatusNew,
+						Type:                 shipment.StopTypeDelivery,
+						LocationID:           pulid.MustNew("loc_"),
+						ScheduleType:         shipment.StopScheduleTypeOpen,
+						ScheduledWindowStart: 3,
+						ScheduledWindowEnd:   new(int64(4)),
+					},
+				},
+			},
+		},
+	}
+}

--- a/services/tms/internal/core/services/carrierassignmentservice/service.go
+++ b/services/tms/internal/core/services/carrierassignmentservice/service.go
@@ -433,7 +433,7 @@ func (s *Service) applyCoverageChange(
 	if assignment != nil {
 		targetMove.CoverageType = shipment.MoveCoverageTypeCarrier
 	} else {
-		targetMove.CoverageType = shipment.MoveCoverageTypeDriver
+		targetMove.CoverageType = shipment.MoveCoverageTypeUnassigned
 	}
 
 	control, err := s.controlRepo.Get(ctx, repositories.GetShipmentControlRequest{

--- a/services/tms/internal/core/services/driverportalservice/features.go
+++ b/services/tms/internal/core/services/driverportalservice/features.go
@@ -56,8 +56,6 @@ func (s *Service) requireFeature(
 	return control, nil
 }
 
-// requireAssetOperations refuses driver-facing setup for organizations that run
-// brokerage-only and therefore employ no drivers to grant portal access to.
 func (s *Service) requireAssetOperations(
 	ctx context.Context,
 	tenantInfo pagination.TenantInfo,

--- a/services/tms/internal/core/services/driverportalservice/features.go
+++ b/services/tms/internal/core/services/driverportalservice/features.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/emoss08/trenova/internal/core/domain/tenant"
+	"github.com/emoss08/trenova/internal/core/services/capabilityguard"
 	"github.com/emoss08/trenova/pkg/errortypes"
 	"github.com/emoss08/trenova/pkg/pagination"
 )
@@ -53,6 +54,27 @@ func (s *Service) requireFeature(
 		)
 	}
 	return control, nil
+}
+
+// requireAssetOperations refuses driver-facing setup for organizations that run
+// brokerage-only and therefore employ no drivers to grant portal access to.
+func (s *Service) requireAssetOperations(
+	ctx context.Context,
+	tenantInfo pagination.TenantInfo,
+) error {
+	enabled, err := capabilityguard.AssetOperationsEnabled(ctx, s.orgRepo, tenantInfo)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		return errortypes.NewValidationError(
+			"feature",
+			errortypes.ErrInvalidOperation,
+			"Driver portal access requires asset operations. Enable asset operations for this organization before inviting drivers",
+		)
+	}
+
+	return nil
 }
 
 func (s *Service) MyPortalFeatures(

--- a/services/tms/internal/core/services/driverportalservice/invitation.go
+++ b/services/tms/internal/core/services/driverportalservice/invitation.go
@@ -71,6 +71,10 @@ func (s *Service) InviteWorker(
 		)
 	}
 
+	if err := s.requireAssetOperations(ctx, req.TenantInfo); err != nil {
+		return nil, err
+	}
+
 	wrk, err := s.portalRepo.GetWorkerForPortalManagement(ctx, req.TenantInfo, req.WorkerID)
 	if err != nil {
 		return nil, err

--- a/services/tms/internal/core/services/driverportalservice/invitation_test.go
+++ b/services/tms/internal/core/services/driverportalservice/invitation_test.go
@@ -1,0 +1,106 @@
+package driverportalservice
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/emoss08/trenova/internal/core/domain/tenant"
+	"github.com/emoss08/trenova/internal/core/ports/repositories"
+	serviceports "github.com/emoss08/trenova/internal/core/ports/services"
+	"github.com/emoss08/trenova/internal/testutil/mocks"
+	"github.com/emoss08/trenova/pkg/errortypes"
+	"github.com/emoss08/trenova/pkg/pagination"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func assetOperationsOrgRepo(
+	t *testing.T,
+	tenantInfo pagination.TenantInfo,
+	enabled bool,
+) *mocks.MockOrganizationRepository {
+	t.Helper()
+
+	orgRepo := mocks.NewMockOrganizationRepository(t)
+	orgRepo.EXPECT().
+		GetByID(mock.Anything, repositories.GetOrganizationByIDRequest{TenantInfo: tenantInfo}).
+		Return(&tenant.Organization{
+			ID:                     tenantInfo.OrgID,
+			BusinessUnitID:         tenantInfo.BuID,
+			BrokerageEnabled:       true,
+			AssetOperationsEnabled: enabled,
+		}, nil).
+		Once()
+
+	return orgRepo
+}
+
+func TestInviteWorker_RefusedWhenAssetOperationsDisabled(t *testing.T) {
+	t.Parallel()
+
+	tenantInfo := pagination.TenantInfo{
+		OrgID: pulid.MustNew("org_"),
+		BuID:  pulid.MustNew("bu_"),
+	}
+
+	svc := &Service{
+		l:          zap.NewNop(),
+		orgRepo:    assetOperationsOrgRepo(t, tenantInfo, false),
+		portalRepo: mocks.NewMockPortalAccessRepository(t),
+	}
+
+	result, err := svc.InviteWorker(
+		t.Context(),
+		&InviteWorkerRequest{TenantInfo: tenantInfo, WorkerID: pulid.MustNew("wrk_")},
+		&serviceports.RequestActor{UserID: pulid.MustNew("usr_")},
+	)
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+
+	validationErr := new(errortypes.Error)
+	require.ErrorAs(t, err, &validationErr)
+	assert.Equal(t, "feature", validationErr.Field)
+	assert.Equal(t, errortypes.ErrInvalidOperation, validationErr.Code)
+	assert.Equal(
+		t,
+		"Driver portal access requires asset operations. Enable asset operations "+
+			"for this organization before inviting drivers",
+		validationErr.Message,
+	)
+}
+
+func TestInviteWorker_ProceedsWhenAssetOperationsEnabled(t *testing.T) {
+	t.Parallel()
+
+	tenantInfo := pagination.TenantInfo{
+		OrgID: pulid.MustNew("org_"),
+		BuID:  pulid.MustNew("bu_"),
+	}
+	workerID := pulid.MustNew("wrk_")
+	lookupErr := errors.New("worker lookup failed")
+
+	portalRepo := mocks.NewMockPortalAccessRepository(t)
+	portalRepo.EXPECT().
+		GetWorkerForPortalManagement(mock.Anything, tenantInfo, workerID).
+		Return(nil, lookupErr).
+		Once()
+
+	svc := &Service{
+		l:          zap.NewNop(),
+		orgRepo:    assetOperationsOrgRepo(t, tenantInfo, true),
+		portalRepo: portalRepo,
+	}
+
+	result, err := svc.InviteWorker(
+		t.Context(),
+		&InviteWorkerRequest{TenantInfo: tenantInfo, WorkerID: workerID},
+		&serviceports.RequestActor{UserID: pulid.MustNew("usr_")},
+	)
+
+	assert.Nil(t, result)
+	require.ErrorIs(t, err, lookupErr)
+}

--- a/services/tms/internal/core/services/driverportalservice/service.go
+++ b/services/tms/internal/core/services/driverportalservice/service.go
@@ -25,6 +25,7 @@ type Params struct {
 	Logger              *zap.Logger
 	Config              *config.Config
 	PortalRepo          repositories.PortalAccessRepository
+	OrgRepo             repositories.OrganizationRepository
 	SettlementRepo      repositories.DriverSettlementRepository
 	PayEventRepo        repositories.PayEventRepository
 	AdvanceRepo         repositories.PayAdvanceRepository
@@ -49,6 +50,7 @@ type Service struct {
 	l                   *zap.Logger
 	cfg                 *config.Config
 	portalRepo          repositories.PortalAccessRepository
+	orgRepo             repositories.OrganizationRepository
 	settlementRepo      repositories.DriverSettlementRepository
 	payEventRepo        repositories.PayEventRepository
 	advanceRepo         repositories.PayAdvanceRepository
@@ -74,6 +76,7 @@ func New(p Params) *Service { //nolint:gocritic // stable API shape
 		l:                   p.Logger.Named("service.driver-portal"),
 		cfg:                 p.Config,
 		portalRepo:          p.PortalRepo,
+		orgRepo:             p.OrgRepo,
 		settlementRepo:      p.SettlementRepo,
 		payEventRepo:        p.PayEventRepo,
 		advanceRepo:         p.AdvanceRepo,

--- a/services/tms/internal/core/services/organizationservice/capabilityguard.go
+++ b/services/tms/internal/core/services/organizationservice/capabilityguard.go
@@ -47,9 +47,6 @@ func (s *service) capabilityDisableGuards() [2]capabilityDisableGuard {
 	}
 }
 
-// guardCapabilityDisable refuses to turn an operating capability off while
-// dependent work is still outstanding. Enabling is always allowed: it is purely
-// additive and can strand nothing.
 func (s *service) guardCapabilityDisable(
 	ctx context.Context,
 	entity *tenant.Organization,

--- a/services/tms/internal/core/services/organizationservice/capabilityguard.go
+++ b/services/tms/internal/core/services/organizationservice/capabilityguard.go
@@ -17,17 +17,12 @@ const (
 	assetOperationsEnabledField = "assetOperationsEnabled"
 )
 
-// capabilityBlocker is one kind of outstanding work standing between an
-// organization and switching a capability off.
 type capabilityBlocker struct {
 	count    int
 	singular string
 	plural   string
 }
 
-// capabilityDisableGuard describes one operating capability: how to read its
-// flag off an organization, how to name it in the refusal, and how to describe
-// the work that keeps it switched on.
 type capabilityDisableGuard struct {
 	field    string
 	noun     string

--- a/services/tms/internal/core/services/organizationservice/capabilityguard.go
+++ b/services/tms/internal/core/services/organizationservice/capabilityguard.go
@@ -12,22 +12,62 @@ import (
 	"github.com/emoss08/trenova/shared/stringutils"
 )
 
-const brokerageEnabledField = "brokerageEnabled"
+const (
+	brokerageEnabledField       = "brokerageEnabled"
+	assetOperationsEnabledField = "assetOperationsEnabled"
+)
 
-type brokerageBlocker struct {
+// capabilityBlocker is one kind of outstanding work standing between an
+// organization and switching a capability off.
+type capabilityBlocker struct {
 	count    int
 	singular string
 	plural   string
 }
 
-// guardBrokerageDisable refuses to turn brokerage off while dependent work is
-// still outstanding. Enabling is always allowed: it is purely additive and can
-// strand nothing.
-func (s *service) guardBrokerageDisable(
+// capabilityDisableGuard describes one operating capability: how to read its
+// flag off an organization, how to name it in the refusal, and how to describe
+// the work that keeps it switched on.
+type capabilityDisableGuard struct {
+	field    string
+	noun     string
+	enabled  func(*tenant.Organization) bool
+	describe func(context.Context, pagination.TenantInfo) (string, error)
+}
+
+func (s *service) capabilityDisableGuards() [2]capabilityDisableGuard {
+	return [...]capabilityDisableGuard{
+		{
+			field:    brokerageEnabledField,
+			noun:     "brokerage",
+			enabled:  func(o *tenant.Organization) bool { return o.BrokerageEnabled },
+			describe: s.describeBrokerageDependencies,
+		},
+		{
+			field:    assetOperationsEnabledField,
+			noun:     "asset operations",
+			enabled:  func(o *tenant.Organization) bool { return o.AssetOperationsEnabled },
+			describe: s.describeAssetDependencies,
+		},
+	}
+}
+
+// guardCapabilityDisable refuses to turn an operating capability off while
+// dependent work is still outstanding. Enabling is always allowed: it is purely
+// additive and can strand nothing.
+func (s *service) guardCapabilityDisable(
 	ctx context.Context,
 	entity *tenant.Organization,
 ) error {
-	if entity.BrokerageEnabled {
+	guards := s.capabilityDisableGuards()
+
+	pending := make([]capabilityDisableGuard, 0, len(guards))
+	for _, guard := range guards {
+		if !guard.enabled(entity) {
+			pending = append(pending, guard)
+		}
+	}
+	if len(pending) == 0 {
 		return nil
 	}
 
@@ -43,32 +83,48 @@ func (s *service) guardBrokerageDisable(
 		return err
 	}
 
-	if !current.BrokerageEnabled {
-		return nil
-	}
-
-	counts, err := s.repo.CountBrokerageDependencies(ctx, tenantInfo)
-	if err != nil {
-		return err
-	}
-
-	if !counts.HasOutstandingWork() {
-		return nil
-	}
-
 	multiErr := errortypes.NewMultiError()
-	multiErr.Add(
-		brokerageEnabledField,
-		errortypes.ErrResourceInUse,
-		"Cannot disable brokerage: "+describeBrokerageDependencies(counts)+
-			". Resolve or close this work before turning brokerage off",
-	)
+	for _, guard := range pending {
+		if !guard.enabled(current) {
+			continue
+		}
 
-	return multiErr
+		description, dErr := guard.describe(ctx, tenantInfo)
+		if dErr != nil {
+			return dErr
+		}
+		if description == "" {
+			continue
+		}
+
+		multiErr.Add(
+			guard.field,
+			errortypes.ErrResourceInUse,
+			"Cannot disable "+guard.noun+": "+description+
+				". Resolve or close this work before turning "+guard.noun+" off",
+		)
+	}
+
+	if multiErr.HasErrors() {
+		return multiErr
+	}
+
+	return nil
 }
 
-func describeBrokerageDependencies(counts *repositories.BrokerageDependencyCounts) string {
-	blockers := [...]brokerageBlocker{
+func (s *service) describeBrokerageDependencies(
+	ctx context.Context,
+	tenantInfo pagination.TenantInfo,
+) (string, error) {
+	counts, err := s.repo.CountBrokerageDependencies(ctx, tenantInfo)
+	if err != nil {
+		return "", err
+	}
+	if !counts.HasOutstandingWork() {
+		return "", nil
+	}
+
+	return describeBlockers([]capabilityBlocker{
 		{
 			count:    counts.ActiveTenders,
 			singular: "active tender",
@@ -94,8 +150,41 @@ func describeBrokerageDependencies(counts *repositories.BrokerageDependencyCount
 			singular: "active carrier assignment",
 			plural:   "active carrier assignments",
 		},
+	}), nil
+}
+
+func (s *service) describeAssetDependencies(
+	ctx context.Context,
+	tenantInfo pagination.TenantInfo,
+) (string, error) {
+	counts, err := s.repo.CountAssetDependencies(ctx, tenantInfo)
+	if err != nil {
+		return "", err
+	}
+	if !counts.HasOutstandingWork() {
+		return "", nil
 	}
 
+	return describeBlockers([]capabilityBlocker{
+		{
+			count:    counts.ActiveDriverAssignments,
+			singular: "active driver assignment",
+			plural:   "active driver assignments",
+		},
+		{
+			count:    counts.UnpaidDriverSettlements,
+			singular: "unpaid driver settlement",
+			plural:   "unpaid driver settlements",
+		},
+		{
+			count:    counts.LinkedPortalUsers,
+			singular: "linked driver portal user",
+			plural:   "linked driver portal users",
+		},
+	}), nil
+}
+
+func describeBlockers(blockers []capabilityBlocker) string {
 	parts := make([]string, 0, len(blockers))
 	for _, blocker := range blockers {
 		if blocker.count == 0 {

--- a/services/tms/internal/core/services/organizationservice/capabilityguard_test.go
+++ b/services/tms/internal/core/services/organizationservice/capabilityguard_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func brokerageErrorMessage(t *testing.T, err error) string {
+func capabilityErrorMessage(t *testing.T, err error, field string) string {
 	t.Helper()
 
 	multiErr := new(errortypes.MultiError)
 	require.ErrorAs(t, err, &multiErr)
 	require.Len(t, multiErr.Errors, 1)
-	assert.Equal(t, "brokerageEnabled", multiErr.Errors[0].Field)
+	assert.Equal(t, field, multiErr.Errors[0].Field)
 	assert.Equal(t, errortypes.ErrResourceInUse, multiErr.Errors[0].Code)
 
 	return multiErr.Errors[0].Message
@@ -86,7 +86,7 @@ func TestUpdate_DisableBrokerage_BlockedByEachDependency(t *testing.T) {
 
 			require.Error(t, err)
 			assert.Nil(t, result)
-			assert.Contains(t, brokerageErrorMessage(t, err), tt.expected)
+			assert.Contains(t, capabilityErrorMessage(t, err, "brokerageEnabled"), tt.expected)
 			deps.repo.AssertNotCalled(t, "Update")
 			deps.repo.AssertExpectations(t)
 		})
@@ -130,7 +130,7 @@ func TestUpdate_DisableBrokerage_CombinesEveryBlocker(t *testing.T) {
 			"3 unpaid carrier settlements, 1 open carrier invoice match, "+
 			"5 active carrier assignments. Resolve or close this work before "+
 			"turning brokerage off",
-		brokerageErrorMessage(t, err),
+		capabilityErrorMessage(t, err, "brokerageEnabled"),
 	)
 	deps.repo.AssertNotCalled(t, "Update")
 	deps.repo.AssertExpectations(t)
@@ -244,19 +244,266 @@ func TestUpdate_DisableBrokerage_PropagatesCountError(t *testing.T) {
 	deps.repo.AssertExpectations(t)
 }
 
-func TestUpdate_AssetOperationsFlag_IsNotGuarded(t *testing.T) {
+func TestUpdate_DisableAssetOperations_BlockedByEachDependency(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		counts   *repositories.AssetDependencyCounts
+		expected string
+	}{
+		{
+			name:     "driver assignments",
+			counts:   &repositories.AssetDependencyCounts{ActiveDriverAssignments: 1},
+			expected: "Cannot disable asset operations: 1 active driver assignment.",
+		},
+		{
+			name:     "driver settlements",
+			counts:   &repositories.AssetDependencyCounts{UnpaidDriverSettlements: 2},
+			expected: "Cannot disable asset operations: 2 unpaid driver settlements.",
+		},
+		{
+			name:     "portal users",
+			counts:   &repositories.AssetDependencyCounts{LinkedPortalUsers: 3},
+			expected: "Cannot disable asset operations: 3 linked driver portal users.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			deps := setupTest(t)
+
+			entity := newTestOrganization()
+			entity.AssetOperationsEnabled = false
+
+			stored := newTestOrganization()
+			stored.ID = entity.ID
+			stored.BusinessUnitID = entity.BusinessUnitID
+
+			tenantInfo := pagination.TenantInfo{
+				OrgID: entity.ID,
+				BuID:  entity.BusinessUnitID,
+			}
+
+			deps.repo.On("GetByID", mock.Anything, repositories.GetOrganizationByIDRequest{
+				TenantInfo: tenantInfo,
+			}).Return(stored, nil)
+			deps.repo.On("CountAssetDependencies", mock.Anything, tenantInfo).
+				Return(tt.counts, nil)
+
+			result, err := deps.svc.Update(t.Context(), entity)
+
+			require.Error(t, err)
+			assert.Nil(t, result)
+			assert.Contains(
+				t,
+				capabilityErrorMessage(t, err, "assetOperationsEnabled"),
+				tt.expected,
+			)
+			deps.repo.AssertNotCalled(t, "Update")
+			deps.repo.AssertNotCalled(t, "CountBrokerageDependencies")
+			deps.repo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestUpdate_DisableAssetOperations_CombinesEveryBlocker(t *testing.T) {
 	t.Parallel()
 	deps := setupTest(t)
 
 	entity := newTestOrganization()
 	entity.AssetOperationsEnabled = false
 
+	stored := newTestOrganization()
+	stored.ID = entity.ID
+	stored.BusinessUnitID = entity.BusinessUnitID
+
+	tenantInfo := pagination.TenantInfo{
+		OrgID: entity.ID,
+		BuID:  entity.BusinessUnitID,
+	}
+
+	deps.repo.On("GetByID", mock.Anything, repositories.GetOrganizationByIDRequest{
+		TenantInfo: tenantInfo,
+	}).Return(stored, nil)
+	deps.repo.On("CountAssetDependencies", mock.Anything, tenantInfo).
+		Return(&repositories.AssetDependencyCounts{
+			ActiveDriverAssignments: 4,
+			UnpaidDriverSettlements: 1,
+			LinkedPortalUsers:       2,
+		}, nil)
+
+	result, err := deps.svc.Update(t.Context(), entity)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t,
+		"Cannot disable asset operations: 4 active driver assignments, "+
+			"1 unpaid driver settlement, 2 linked driver portal users. "+
+			"Resolve or close this work before turning asset operations off",
+		capabilityErrorMessage(t, err, "assetOperationsEnabled"),
+	)
+	deps.repo.AssertNotCalled(t, "Update")
+	deps.repo.AssertExpectations(t)
+}
+
+func TestUpdate_DisableAssetOperations_AllowedWhenNothingOutstanding(t *testing.T) {
+	t.Parallel()
+	deps := setupTest(t)
+
+	entity := newTestOrganization()
+	entity.AssetOperationsEnabled = false
+
+	stored := newTestOrganization()
+	stored.ID = entity.ID
+	stored.BusinessUnitID = entity.BusinessUnitID
+
+	tenantInfo := pagination.TenantInfo{
+		OrgID: entity.ID,
+		BuID:  entity.BusinessUnitID,
+	}
+
+	deps.repo.On("GetByID", mock.Anything, repositories.GetOrganizationByIDRequest{
+		TenantInfo: tenantInfo,
+	}).Return(stored, nil)
+	deps.repo.On("CountAssetDependencies", mock.Anything, tenantInfo).
+		Return(&repositories.AssetDependencyCounts{}, nil)
 	deps.repo.On("Update", mock.Anything, entity).Return(entity, nil)
 
 	result, err := deps.svc.Update(t.Context(), entity)
 
 	require.NoError(t, err)
 	assert.False(t, result.AssetOperationsEnabled)
+	deps.repo.AssertExpectations(t)
+}
+
+func TestUpdate_EnableAssetOperations_IsAlwaysAllowed(t *testing.T) {
+	t.Parallel()
+	deps := setupTest(t)
+
+	entity := newTestOrganization()
+	entity.AssetOperationsEnabled = true
+
+	deps.repo.On("Update", mock.Anything, entity).Return(entity, nil)
+
+	result, err := deps.svc.Update(t.Context(), entity)
+
+	require.NoError(t, err)
+	assert.True(t, result.AssetOperationsEnabled)
+	deps.repo.AssertNotCalled(t, "GetByID")
+	deps.repo.AssertNotCalled(t, "CountAssetDependencies")
+	deps.repo.AssertExpectations(t)
+}
+
+func TestUpdate_AssetOperationsAlreadyDisabled_SkipsDependencyCount(t *testing.T) {
+	t.Parallel()
+	deps := setupTest(t)
+
+	entity := newTestOrganization()
+	entity.AssetOperationsEnabled = false
+
+	stored := newTestOrganization()
+	stored.ID = entity.ID
+	stored.BusinessUnitID = entity.BusinessUnitID
+	stored.AssetOperationsEnabled = false
+
+	deps.repo.On("GetByID", mock.Anything, repositories.GetOrganizationByIDRequest{
+		TenantInfo: pagination.TenantInfo{
+			OrgID: entity.ID,
+			BuID:  entity.BusinessUnitID,
+		},
+	}).Return(stored, nil)
+	deps.repo.On("Update", mock.Anything, entity).Return(entity, nil)
+
+	result, err := deps.svc.Update(t.Context(), entity)
+
+	require.NoError(t, err)
+	assert.False(t, result.AssetOperationsEnabled)
+	deps.repo.AssertNotCalled(t, "CountAssetDependencies")
+	deps.repo.AssertExpectations(t)
+}
+
+func TestUpdate_DisableAssetOperations_PropagatesCountError(t *testing.T) {
+	t.Parallel()
+	deps := setupTest(t)
+
+	entity := newTestOrganization()
+	entity.AssetOperationsEnabled = false
+
+	stored := newTestOrganization()
+	stored.ID = entity.ID
+	stored.BusinessUnitID = entity.BusinessUnitID
+
+	tenantInfo := pagination.TenantInfo{
+		OrgID: entity.ID,
+		BuID:  entity.BusinessUnitID,
+	}
+
+	countErr := errors.New("count failed")
+
+	deps.repo.On("GetByID", mock.Anything, repositories.GetOrganizationByIDRequest{
+		TenantInfo: tenantInfo,
+	}).Return(stored, nil)
+	deps.repo.On("CountAssetDependencies", mock.Anything, tenantInfo).
+		Return(nil, countErr)
+
+	result, err := deps.svc.Update(t.Context(), entity)
+
+	require.ErrorIs(t, err, countErr)
+	assert.Nil(t, result)
+	deps.repo.AssertNotCalled(t, "Update")
+	deps.repo.AssertExpectations(t)
+}
+
+func TestUpdate_DisableBothCapabilities_IsRejected(t *testing.T) {
+	t.Parallel()
+	deps := setupTest(t)
+
+	entity := newTestOrganization()
+	entity.BrokerageEnabled = false
+	entity.AssetOperationsEnabled = false
+
+	result, err := deps.svc.Update(t.Context(), entity)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+
+	multiErr := new(errortypes.MultiError)
+	require.ErrorAs(t, err, &multiErr)
+	require.Len(t, multiErr.Errors, 2)
+
+	const message = "At least one operating capability must be enabled. " +
+		"An organization with neither brokerage nor asset operations cannot move freight"
+
+	fields := make([]string, 0, len(multiErr.Errors))
+	for _, fieldErr := range multiErr.Errors {
+		fields = append(fields, fieldErr.Field)
+		assert.Equal(t, errortypes.ErrInvalid, fieldErr.Code)
+		assert.Equal(t, message, fieldErr.Message)
+	}
+	assert.ElementsMatch(t, []string{"brokerageEnabled", "assetOperationsEnabled"}, fields)
+
+	deps.repo.AssertNotCalled(t, "GetByID")
+	deps.repo.AssertNotCalled(t, "Update")
+	deps.repo.AssertExpectations(t)
+}
+
+func TestUpdate_AssetOperationsEnabled_IsUnaffectedByBrokerageGuard(t *testing.T) {
+	t.Parallel()
+	deps := setupTest(t)
+
+	entity := newTestOrganization()
+
+	deps.repo.On("Update", mock.Anything, entity).Return(entity, nil)
+
+	result, err := deps.svc.Update(t.Context(), entity)
+
+	require.NoError(t, err)
+	assert.True(t, result.AssetOperationsEnabled)
+	assert.True(t, result.BrokerageEnabled)
+	deps.repo.AssertNotCalled(t, "GetByID")
+	deps.repo.AssertNotCalled(t, "CountAssetDependencies")
 	deps.repo.AssertNotCalled(t, "CountBrokerageDependencies")
 	deps.repo.AssertExpectations(t)
 }

--- a/services/tms/internal/core/services/organizationservice/service.go
+++ b/services/tms/internal/core/services/organizationservice/service.go
@@ -98,7 +98,7 @@ func (s *service) Update(
 		return nil, err
 	}
 
-	if err := s.guardBrokerageDisable(ctx, entity); err != nil {
+	if err := s.guardCapabilityDisable(ctx, entity); err != nil {
 		return nil, err
 	}
 

--- a/services/tms/internal/core/services/organizationservice/service_test.go
+++ b/services/tms/internal/core/services/organizationservice/service_test.go
@@ -116,6 +116,17 @@ func (m *mockOrganizationRepo) CountBrokerageDependencies(
 	return args.Get(0).(*repositories.BrokerageDependencyCounts), args.Error(1)
 }
 
+func (m *mockOrganizationRepo) CountAssetDependencies(
+	ctx context.Context,
+	tenantInfo pagination.TenantInfo,
+) (*repositories.AssetDependencyCounts, error) {
+	args := m.Called(ctx, tenantInfo)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*repositories.AssetDependencyCounts), args.Error(1)
+}
+
 type testDeps struct {
 	repo *mockOrganizationRepo
 	svc  *service

--- a/services/tms/internal/core/services/organizationservice/validator.go
+++ b/services/tms/internal/core/services/organizationservice/validator.go
@@ -73,9 +73,6 @@ func NewValidator(p ValidatorParams) *Validator {
 	}
 }
 
-// validateOperatingCapabilities refuses a state where neither operating
-// capability is enabled: such an organization can neither broker freight to
-// carriers nor run it on its own assets, so it cannot move freight at all.
 func validateOperatingCapabilities(
 	_ context.Context,
 	entity *tenant.Organization,

--- a/services/tms/internal/core/services/organizationservice/validator.go
+++ b/services/tms/internal/core/services/organizationservice/validator.go
@@ -52,6 +52,12 @@ func NewValidator(p ValidatorParams) *Validator {
 			"login_slug",
 			"Organization with this login slug already exists",
 			func(o *tenant.Organization) any { return o.LoginSlug },
+		).
+		WithCustomRule(
+			validationframework.NewScopedRule[*tenant.Organization]("operating_capabilities").
+				OnUpdate().
+				WithParallelSafeExecution().
+				WithValidation(validateOperatingCapabilities),
 		)
 
 	if p.DB != nil {
@@ -65,6 +71,28 @@ func NewValidator(p ValidatorParams) *Validator {
 	return &Validator{
 		validator: builder.Build(),
 	}
+}
+
+// validateOperatingCapabilities refuses a state where neither operating
+// capability is enabled: such an organization can neither broker freight to
+// carriers nor run it on its own assets, so it cannot move freight at all.
+func validateOperatingCapabilities(
+	_ context.Context,
+	entity *tenant.Organization,
+	_ *validationframework.ScopedValidationContext,
+	multiErr *errortypes.MultiError,
+) error {
+	if entity.BrokerageEnabled || entity.AssetOperationsEnabled {
+		return nil
+	}
+
+	const message = "At least one operating capability must be enabled. " +
+		"An organization with neither brokerage nor asset operations cannot move freight"
+
+	multiErr.Add(brokerageEnabledField, errortypes.ErrInvalid, message)
+	multiErr.Add(assetOperationsEnabledField, errortypes.ErrInvalid, message)
+
+	return nil
 }
 
 func (v *Validator) ValidateCreate(

--- a/services/tms/internal/infrastructure/database/migrator/coverage_backfill_sqlite_test.go
+++ b/services/tms/internal/infrastructure/database/migrator/coverage_backfill_sqlite_test.go
@@ -99,9 +99,6 @@ func TestSQLiteCoverageTypeBackfillSplitsOnLiveAssignment(t *testing.T) {
 	}
 }
 
-// TestSQLiteCoverageTypeIndexTargetsCarrierCoverage guards the partial index the
-// migration narrows: with 'unassigned' as the neutral default, an index keyed on
-// "not driver" would cover nearly every row instead of the brokered exceptions.
 func TestSQLiteCoverageTypeIndexTargetsCarrierCoverage(t *testing.T) {
 	ctx := t.Context()
 	db := newSQLiteDB(t)
@@ -128,9 +125,6 @@ func assignmentStatusFor(archivedAt *int64) string {
 	return "Canceled"
 }
 
-// migrateBefore brings the schema up to the state an existing deployment would
-// be in on the eve of `version`, so a backfill can be tested against rows that
-// predate it rather than against rows inserted after it has already run.
 func migrateBefore(
 	ctx context.Context,
 	t *testing.T,

--- a/services/tms/internal/infrastructure/database/migrator/coverage_backfill_sqlite_test.go
+++ b/services/tms/internal/infrastructure/database/migrator/coverage_backfill_sqlite_test.go
@@ -13,10 +13,6 @@ import (
 
 const coverageBackfillVersion = "20260916000000"
 
-// TestSQLiteCoverageTypeBackfillSplitsOnLiveAssignment pins the assignment-aware
-// half of the coverage-type migration: a move labelled driver keeps that label
-// only when a live driver assignment actually backs it, and everything else that
-// inherited the old 'driver' column default becomes 'unassigned'.
 func TestSQLiteCoverageTypeBackfillSplitsOnLiveAssignment(t *testing.T) {
 	ctx := t.Context()
 	db := newSQLiteDB(t)
@@ -41,6 +37,9 @@ func TestSQLiteCoverageTypeBackfillSplitsOnLiveAssignment(t *testing.T) {
 		{id: "sm_no_assignment", coverageType: "driver", want: "unassigned"},
 		{id: "sm_carrier", coverageType: "carrier", want: "carrier"},
 		{id: "sm_carrier_with_driver", coverageType: "carrier", want: "carrier"},
+		{id: "sm_driver_label_live_carrier", coverageType: "driver", want: "carrier"},
+		{id: "sm_driver_label_canceled_carrier", coverageType: "driver", want: "unassigned"},
+		{id: "sm_live_driver_and_carrier", coverageType: "driver", want: "driver"},
 	}
 
 	for _, move := range moves {
@@ -66,10 +65,27 @@ func TestSQLiteCoverageTypeBackfillSplitsOnLiveAssignment(t *testing.T) {
 		require.NoError(t, execErr)
 	}
 
+	insertCarrierAssignment := func(id, moveID, status string) {
+		t.Helper()
+
+		_, execErr := db.NewRaw(
+			`INSERT INTO carrier_assignments
+                (id, organization_id, business_unit_id, shipment_move_id, carrier_id, status, version, created_at, updated_at)
+             VALUES (?, ?, ?, ?, 'car_1', ?, 0, 0, 0)`,
+			id, orgID, buID, moveID, status,
+		).Exec(ctx)
+		require.NoError(t, execErr)
+	}
+
 	archivedAt := int64(1700000000)
 	insertAssignment("asn_live", "sm_live_driver", nil)
 	insertAssignment("asn_archived", "sm_archived_driver", &archivedAt)
 	insertAssignment("asn_live_carrier", "sm_carrier_with_driver", nil)
+	insertAssignment("asn_live_both", "sm_live_driver_and_carrier", nil)
+
+	insertCarrierAssignment("ca_live", "sm_driver_label_live_carrier", "Confirmed")
+	insertCarrierAssignment("ca_canceled", "sm_driver_label_canceled_carrier", "Canceled")
+	insertCarrierAssignment("ca_live_with_driver", "sm_live_driver_and_carrier", "Pending")
 
 	runMigrationUp(ctx, t, migrator, coverageBackfillVersion)
 

--- a/services/tms/internal/infrastructure/database/migrator/coverage_backfill_sqlite_test.go
+++ b/services/tms/internal/infrastructure/database/migrator/coverage_backfill_sqlite_test.go
@@ -1,0 +1,133 @@
+package migrator_test
+
+import (
+	"context"
+	"testing"
+
+	sqlitemigrations "github.com/emoss08/trenova/internal/infrastructure/sqlite/migrations"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun/migrate"
+
+	_ "modernc.org/sqlite"
+)
+
+const coverageBackfillVersion = "20260916000000"
+
+// TestSQLiteCoverageTypeBackfillSplitsOnLiveAssignment pins the assignment-aware
+// half of the coverage-type migration: a move labelled driver keeps that label
+// only when a live driver assignment actually backs it, and everything else that
+// inherited the old 'driver' column default becomes 'unassigned'.
+func TestSQLiteCoverageTypeBackfillSplitsOnLiveAssignment(t *testing.T) {
+	ctx := t.Context()
+	db := newSQLiteDB(t)
+
+	migrator := migrate.NewMigrator(db, sqlitemigrations.Migrations)
+	require.NoError(t, migrator.Init(ctx))
+	_, err := migrator.Migrate(ctx)
+	require.NoError(t, err)
+
+	const (
+		orgID = "org_backfill"
+		buID  = "bu_backfill"
+	)
+
+	moves := []struct {
+		id           string
+		coverageType string
+		want         string
+	}{
+		{id: "sm_live_driver", coverageType: "driver", want: "driver"},
+		{id: "sm_archived_driver", coverageType: "driver", want: "unassigned"},
+		{id: "sm_no_assignment", coverageType: "driver", want: "unassigned"},
+		{id: "sm_carrier", coverageType: "carrier", want: "carrier"},
+		{id: "sm_carrier_with_driver", coverageType: "carrier", want: "carrier"},
+	}
+
+	for _, move := range moves {
+		_, err = db.NewRaw(
+			`INSERT INTO shipment_moves
+                (id, organization_id, business_unit_id, shipment_id, status, loaded, sequence, coverage_type, version, created_at, updated_at)
+             VALUES (?, ?, ?, ?, 'New', 1, 0, ?, 0, 0, 0)`,
+			move.id, orgID, buID, "shp_backfill", move.coverageType,
+		).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	insertAssignment := func(id, moveID string, archivedAt *int64) {
+		t.Helper()
+
+		_, execErr := db.NewRaw(
+			`INSERT INTO assignments
+                (id, organization_id, business_unit_id, shipment_move_id, primary_worker_id, tractor_id, status, archived_at, version, created_at, updated_at)
+             VALUES (?, ?, ?, ?, 'wrk_1', 'trc_1', ?, ?, 0, 0, 0)`,
+			id, orgID, buID, moveID,
+			assignmentStatusFor(archivedAt), archivedAt,
+		).Exec(ctx)
+		require.NoError(t, execErr)
+	}
+
+	archivedAt := int64(1700000000)
+	insertAssignment("asn_live", "sm_live_driver", nil)
+	insertAssignment("asn_archived", "sm_archived_driver", &archivedAt)
+	insertAssignment("asn_live_carrier", "sm_carrier_with_driver", nil)
+
+	runMigrationUp(ctx, t, migrator, coverageBackfillVersion)
+
+	for _, move := range moves {
+		var got string
+		require.NoError(t, db.NewRaw(
+			`SELECT coverage_type FROM shipment_moves WHERE id = ?`, move.id,
+		).Scan(ctx, &got))
+
+		require.Equalf(t, move.want, got, "coverage type for move %q", move.id)
+	}
+}
+
+// TestSQLiteCoverageTypeIndexTargetsCarrierCoverage guards the partial index the
+// migration narrows: with 'unassigned' as the neutral default, an index keyed on
+// "not driver" would cover nearly every row instead of the brokered exceptions.
+func TestSQLiteCoverageTypeIndexTargetsCarrierCoverage(t *testing.T) {
+	ctx := t.Context()
+	db := newSQLiteDB(t)
+
+	migrator := migrate.NewMigrator(db, sqlitemigrations.Migrations)
+	require.NoError(t, migrator.Init(ctx))
+	_, err := migrator.Migrate(ctx)
+	require.NoError(t, err)
+
+	var definition string
+	require.NoError(t, db.NewRaw(
+		`SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_shipment_moves_coverage_type'`,
+	).Scan(ctx, &definition))
+
+	require.Contains(t, definition, "'carrier'")
+	require.NotContains(t, definition, "<>")
+}
+
+func assignmentStatusFor(archivedAt *int64) string {
+	if archivedAt == nil {
+		return "New"
+	}
+
+	return "Canceled"
+}
+
+func runMigrationUp(
+	ctx context.Context,
+	t *testing.T,
+	migrator *migrate.Migrator,
+	version string,
+) {
+	t.Helper()
+
+	for _, candidate := range sqlitemigrations.Migrations.Sorted() {
+		if candidate.Name != version {
+			continue
+		}
+
+		require.NoError(t, candidate.Up(ctx, migrator, &candidate))
+		return
+	}
+
+	t.Fatalf("migration %s not found in the SQLite migration set", version)
+}

--- a/services/tms/internal/infrastructure/database/migrator/coverage_backfill_sqlite_test.go
+++ b/services/tms/internal/infrastructure/database/migrator/coverage_backfill_sqlite_test.go
@@ -6,6 +6,7 @@ import (
 
 	sqlitemigrations "github.com/emoss08/trenova/internal/infrastructure/sqlite/migrations"
 	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/migrate"
 
 	_ "modernc.org/sqlite"
@@ -17,15 +18,14 @@ func TestSQLiteCoverageTypeBackfillSplitsOnLiveAssignment(t *testing.T) {
 	ctx := t.Context()
 	db := newSQLiteDB(t)
 
-	migrator := migrate.NewMigrator(db, sqlitemigrations.Migrations)
-	require.NoError(t, migrator.Init(ctx))
-	_, err := migrator.Migrate(ctx)
-	require.NoError(t, err)
+	migrator := migrateBefore(ctx, t, db, coverageBackfillVersion)
 
 	const (
 		orgID = "org_backfill"
 		buID  = "bu_backfill"
 	)
+
+	var err error
 
 	moves := []struct {
 		id           string
@@ -126,6 +126,35 @@ func assignmentStatusFor(archivedAt *int64) string {
 	}
 
 	return "Canceled"
+}
+
+// migrateBefore brings the schema up to the state an existing deployment would
+// be in on the eve of `version`, so a backfill can be tested against rows that
+// predate it rather than against rows inserted after it has already run.
+func migrateBefore(
+	ctx context.Context,
+	t *testing.T,
+	db *bun.DB,
+	version string,
+) *migrate.Migrator {
+	t.Helper()
+
+	priors := migrate.NewMigrations()
+	for _, candidate := range sqlitemigrations.Migrations.Sorted() {
+		if candidate.Name >= version {
+			break
+		}
+
+		priors.Add(candidate)
+	}
+
+	migrator := migrate.NewMigrator(db, priors)
+	require.NoError(t, migrator.Init(ctx))
+
+	_, err := migrator.Migrate(ctx)
+	require.NoError(t, err)
+
+	return migrator
 }
 
 func runMigrationUp(

--- a/services/tms/internal/infrastructure/postgres/migrations/20260916000000_move_coverage_type_unassigned.tx.down.sql
+++ b/services/tms/internal/infrastructure/postgres/migrations/20260916000000_move_coverage_type_unassigned.tx.down.sql
@@ -1,0 +1,18 @@
+DROP INDEX IF EXISTS "idx_shipment_moves_coverage_type";
+
+--bun:split
+UPDATE
+    "shipment_moves"
+SET
+    "coverage_type" = 'driver'
+WHERE
+    "coverage_type" = 'unassigned';
+
+--bun:split
+CREATE INDEX IF NOT EXISTS "idx_shipment_moves_coverage_type" ON "shipment_moves"("coverage_type", "organization_id")
+WHERE
+    "coverage_type" <> 'driver';
+
+--bun:split
+ALTER TABLE "shipment_moves"
+    ALTER COLUMN "coverage_type" SET DEFAULT 'driver';

--- a/services/tms/internal/infrastructure/postgres/migrations/20260916000000_move_coverage_type_unassigned.tx.up.sql
+++ b/services/tms/internal/infrastructure/postgres/migrations/20260916000000_move_coverage_type_unassigned.tx.up.sql
@@ -2,6 +2,39 @@ ALTER TABLE "shipment_moves"
     ALTER COLUMN "coverage_type" SET DEFAULT 'unassigned';
 
 --bun:split
+-- A move labelled 'driver' that no live driver assignment backs but an active
+-- carrier assignment does is carrier coverage wearing the old column default.
+-- Relabel it before the 'unassigned' sweep so that coverage is never lost.
+-- Inactive is 'Canceled' for carrier assignments (they have no archived_at) and
+-- archived_at for driver assignments.
+UPDATE
+    "shipment_moves" AS "sm"
+SET
+    "coverage_type" = 'carrier'
+WHERE
+    "sm"."coverage_type" = 'driver'
+    AND NOT EXISTS (
+        SELECT
+            1
+        FROM
+            "assignments" AS "a"
+        WHERE
+            "a"."shipment_move_id" = "sm"."id"
+            AND "a"."organization_id" = "sm"."organization_id"
+            AND "a"."business_unit_id" = "sm"."business_unit_id"
+            AND "a"."archived_at" IS NULL)
+    AND EXISTS (
+        SELECT
+            1
+        FROM
+            "carrier_assignments" AS "ca"
+        WHERE
+            "ca"."shipment_move_id" = "sm"."id"
+            AND "ca"."organization_id" = "sm"."organization_id"
+            AND "ca"."business_unit_id" = "sm"."business_unit_id"
+            AND "ca"."status" <> 'Canceled');
+
+--bun:split
 UPDATE
     "shipment_moves" AS "sm"
 SET
@@ -17,7 +50,17 @@ WHERE
             "a"."shipment_move_id" = "sm"."id"
             AND "a"."organization_id" = "sm"."organization_id"
             AND "a"."business_unit_id" = "sm"."business_unit_id"
-            AND "a"."archived_at" IS NULL);
+            AND "a"."archived_at" IS NULL)
+    AND NOT EXISTS (
+        SELECT
+            1
+        FROM
+            "carrier_assignments" AS "ca"
+        WHERE
+            "ca"."shipment_move_id" = "sm"."id"
+            AND "ca"."organization_id" = "sm"."organization_id"
+            AND "ca"."business_unit_id" = "sm"."business_unit_id"
+            AND "ca"."status" <> 'Canceled');
 
 --bun:split
 DROP INDEX IF EXISTS "idx_shipment_moves_coverage_type";

--- a/services/tms/internal/infrastructure/postgres/migrations/20260916000000_move_coverage_type_unassigned.tx.up.sql
+++ b/services/tms/internal/infrastructure/postgres/migrations/20260916000000_move_coverage_type_unassigned.tx.up.sql
@@ -1,0 +1,31 @@
+ALTER TABLE "shipment_moves"
+    ALTER COLUMN "coverage_type" SET DEFAULT 'unassigned';
+
+--bun:split
+UPDATE
+    "shipment_moves" AS "sm"
+SET
+    "coverage_type" = 'unassigned'
+WHERE
+    "sm"."coverage_type" = 'driver'
+    AND NOT EXISTS (
+        SELECT
+            1
+        FROM
+            "assignments" AS "a"
+        WHERE
+            "a"."shipment_move_id" = "sm"."id"
+            AND "a"."organization_id" = "sm"."organization_id"
+            AND "a"."business_unit_id" = "sm"."business_unit_id"
+            AND "a"."archived_at" IS NULL);
+
+--bun:split
+DROP INDEX IF EXISTS "idx_shipment_moves_coverage_type";
+
+--bun:split
+CREATE INDEX IF NOT EXISTS "idx_shipment_moves_coverage_type" ON "shipment_moves"("coverage_type", "organization_id")
+WHERE
+    "coverage_type" = 'carrier';
+
+--bun:split
+COMMENT ON COLUMN "shipment_moves"."coverage_type" IS 'How the move is covered: unassigned until a company driver (driver) or an external carrier (carrier) takes it';

--- a/services/tms/internal/infrastructure/postgres/repositories/organizationrepository/assetdependencies.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/organizationrepository/assetdependencies.go
@@ -12,15 +12,11 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// activeAssignmentStatuses are the statuses for which an assignment still binds
-// a driver to a shipment move.
 var activeAssignmentStatuses = []shipment.AssignmentStatus{
 	shipment.AssignmentStatusNew,
 	shipment.AssignmentStatusInProgress,
 }
 
-// unpaidDriverSettlementStatuses mirrors the statuses for which
-// [driversettlement.Status.IsTerminal] returns false.
 var unpaidDriverSettlementStatuses = []driversettlement.Status{
 	driversettlement.StatusDraft,
 	driversettlement.StatusPendingApproval,

--- a/services/tms/internal/infrastructure/postgres/repositories/organizationrepository/assetdependencies.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/organizationrepository/assetdependencies.go
@@ -1,0 +1,80 @@
+package organizationrepository
+
+import (
+	"context"
+
+	"github.com/emoss08/trenova/internal/core/domain/driversettlement"
+	"github.com/emoss08/trenova/internal/core/domain/shipment"
+	"github.com/emoss08/trenova/internal/core/domain/worker"
+	"github.com/emoss08/trenova/internal/core/ports/repositories"
+	"github.com/emoss08/trenova/pkg/buncolgen"
+	"github.com/emoss08/trenova/pkg/pagination"
+	"github.com/uptrace/bun"
+)
+
+// activeAssignmentStatuses are the statuses for which an assignment still binds
+// a driver to a shipment move.
+var activeAssignmentStatuses = []shipment.AssignmentStatus{
+	shipment.AssignmentStatusNew,
+	shipment.AssignmentStatusInProgress,
+}
+
+// unpaidDriverSettlementStatuses mirrors the statuses for which
+// [driversettlement.Status.IsTerminal] returns false.
+var unpaidDriverSettlementStatuses = []driversettlement.Status{
+	driversettlement.StatusDraft,
+	driversettlement.StatusPendingApproval,
+	driversettlement.StatusApproved,
+	driversettlement.StatusPosted,
+}
+
+func (r *repository) CountAssetDependencies(
+	ctx context.Context,
+	tenantInfo pagination.TenantInfo,
+) (*repositories.AssetDependencyCounts, error) {
+	counts := new(repositories.AssetDependencyCounts)
+
+	if err := r.countDependencies(ctx, assetDependencyCounts(tenantInfo, counts)); err != nil {
+		return nil, err
+	}
+
+	return counts, nil
+}
+
+func assetDependencyCounts(
+	tenantInfo pagination.TenantInfo,
+	counts *repositories.AssetDependencyCounts,
+) []dependencyCount {
+	return []dependencyCount{
+		{
+			label:  "active driver assignments",
+			model:  (*shipment.Assignment)(nil),
+			target: &counts.ActiveDriverAssignments,
+			scope: func(sq *bun.SelectQuery) *bun.SelectQuery {
+				return buncolgen.AssignmentScopeTenant(sq, tenantInfo).
+					Where(buncolgen.AssignmentColumns.Status.In(), bun.List(activeAssignmentStatuses))
+			},
+		},
+		{
+			label:  "unpaid driver settlements",
+			model:  (*driversettlement.Settlement)(nil),
+			target: &counts.UnpaidDriverSettlements,
+			scope: func(sq *bun.SelectQuery) *bun.SelectQuery {
+				return buncolgen.SettlementScopeTenant(sq, tenantInfo).
+					Where(
+						buncolgen.SettlementColumns.Status.In(),
+						bun.List(unpaidDriverSettlementStatuses),
+					)
+			},
+		},
+		{
+			label:  "linked driver portal users",
+			model:  (*worker.Worker)(nil),
+			target: &counts.LinkedPortalUsers,
+			scope: func(sq *bun.SelectQuery) *bun.SelectQuery {
+				return buncolgen.WorkerScopeTenant(sq, tenantInfo).
+					Where(buncolgen.WorkerColumns.UserID.IsNotNull())
+			},
+		},
+	}
+}

--- a/services/tms/internal/infrastructure/postgres/repositories/organizationrepository/brokeragedependencies.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/organizationrepository/brokeragedependencies.go
@@ -2,7 +2,6 @@ package organizationrepository
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/emoss08/trenova/internal/core/domain/carriersettlement"
 	"github.com/emoss08/trenova/internal/core/domain/rateconfirmation"
@@ -38,30 +37,14 @@ var openInvoiceMatchStatuses = []carriersettlement.InvoiceMatchStatus{
 	carriersettlement.InvoiceMatchStatusVariance,
 }
 
-type dependencyCount struct {
-	label  string
-	model  any
-	target *int
-	scope  func(*bun.SelectQuery) *bun.SelectQuery
-}
-
 func (r *repository) CountBrokerageDependencies(
 	ctx context.Context,
 	tenantInfo pagination.TenantInfo,
 ) (*repositories.BrokerageDependencyCounts, error) {
 	counts := new(repositories.BrokerageDependencyCounts)
 
-	for _, dep := range brokerageDependencyCounts(tenantInfo, counts) {
-		total, err := r.db.DBForContext(ctx).
-			NewSelect().
-			Model(dep.model).
-			WhereGroup(" AND ", dep.scope).
-			Count(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("count %s: %w", dep.label, err)
-		}
-
-		*dep.target = total
+	if err := r.countDependencies(ctx, brokerageDependencyCounts(tenantInfo, counts)); err != nil {
+		return nil, err
 	}
 
 	return counts, nil

--- a/services/tms/internal/infrastructure/postgres/repositories/organizationrepository/dependencies.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/organizationrepository/dependencies.go
@@ -1,0 +1,35 @@
+package organizationrepository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+// dependencyCount describes one tenant-scoped count backing a capability
+// disable guard: the model to count, where to store the total, and the scope
+// that narrows it to the rows that still block the capability.
+type dependencyCount struct {
+	label  string
+	model  any
+	target *int
+	scope  func(*bun.SelectQuery) *bun.SelectQuery
+}
+
+func (r *repository) countDependencies(ctx context.Context, deps []dependencyCount) error {
+	for _, dep := range deps {
+		total, err := r.db.DBForContext(ctx).
+			NewSelect().
+			Model(dep.model).
+			WhereGroup(" AND ", dep.scope).
+			Count(ctx)
+		if err != nil {
+			return fmt.Errorf("count %s: %w", dep.label, err)
+		}
+
+		*dep.target = total
+	}
+
+	return nil
+}

--- a/services/tms/internal/infrastructure/postgres/repositories/organizationrepository/dependencies.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/organizationrepository/dependencies.go
@@ -7,9 +7,6 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// dependencyCount describes one tenant-scoped count backing a capability
-// disable guard: the model to count, where to store the total, and the scope
-// that narrows it to the rows that still block the capability.
 type dependencyCount struct {
 	label  string
 	model  any

--- a/services/tms/internal/infrastructure/postgres/repositories/organizationrepository/organization_test.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/organizationrepository/organization_test.go
@@ -107,10 +107,6 @@ func TestBrokerageDependencyStatusSetsMatchDomainPredicates(t *testing.T) {
 	}
 }
 
-// TestAssetDependencyStatusSetsMatchDomainPredicates keeps the SQL-side status
-// lists in step with the domain predicates they mirror; a predicate that changes
-// meaning without the list following it would silently narrow or widen the asset
-// operations disable guard.
 func TestAssetDependencyStatusSetsMatchDomainPredicates(t *testing.T) {
 	t.Parallel()
 

--- a/services/tms/internal/infrastructure/postgres/repositories/organizationrepository/organization_test.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/organizationrepository/organization_test.go
@@ -6,9 +6,14 @@ import (
 	"testing"
 
 	"github.com/emoss08/trenova/internal/core/domain/carriersettlement"
+	"github.com/emoss08/trenova/internal/core/domain/driversettlement"
+	"github.com/emoss08/trenova/internal/core/domain/shipment"
 	"github.com/emoss08/trenova/internal/core/domain/tenant"
 	"github.com/emoss08/trenova/internal/core/domain/tender"
+	"github.com/emoss08/trenova/internal/core/ports/repositories"
 	"github.com/emoss08/trenova/pkg/buncolgen"
+	"github.com/emoss08/trenova/pkg/pagination"
+	"github.com/emoss08/trenova/shared/pulid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
@@ -100,4 +105,115 @@ func TestBrokerageDependencyStatusSetsMatchDomainPredicates(t *testing.T) {
 			"carrier invoice match status %s", status,
 		)
 	}
+}
+
+// TestAssetDependencyStatusSetsMatchDomainPredicates keeps the SQL-side status
+// lists in step with the domain predicates they mirror; a predicate that changes
+// meaning without the list following it would silently narrow or widen the asset
+// operations disable guard.
+func TestAssetDependencyStatusSetsMatchDomainPredicates(t *testing.T) {
+	t.Parallel()
+
+	allAssignmentStatuses := []shipment.AssignmentStatus{
+		shipment.AssignmentStatusNew,
+		shipment.AssignmentStatusInProgress,
+		shipment.AssignmentStatusCompleted,
+		shipment.AssignmentStatusCanceled,
+	}
+	blockingAssignmentStatuses := map[shipment.AssignmentStatus]bool{
+		shipment.AssignmentStatusNew:        true,
+		shipment.AssignmentStatusInProgress: true,
+	}
+	for _, status := range allAssignmentStatuses {
+		assert.Equal(t,
+			blockingAssignmentStatuses[status],
+			slices.Contains(activeAssignmentStatuses, status),
+			"assignment status %s", status,
+		)
+	}
+
+	allSettlementStatuses := []driversettlement.Status{
+		driversettlement.StatusDraft,
+		driversettlement.StatusPendingApproval,
+		driversettlement.StatusApproved,
+		driversettlement.StatusPosted,
+		driversettlement.StatusPaid,
+		driversettlement.StatusVoided,
+	}
+	for _, status := range allSettlementStatuses {
+		assert.Equal(t,
+			!status.IsTerminal(),
+			slices.Contains(unpaidDriverSettlementStatuses, status),
+			"driver settlement status %s", status,
+		)
+	}
+}
+
+func TestAssetDependencyCountsScopeEveryQueryToTheTenant(t *testing.T) {
+	t.Parallel()
+
+	db := bun.NewDB(new(sql.DB), pgdialect.New())
+	tenantInfo := pagination.TenantInfo{
+		OrgID: pulid.MustNew("org_"),
+		BuID:  pulid.MustNew("bu_"),
+	}
+	counts := new(repositories.AssetDependencyCounts)
+
+	deps := assetDependencyCounts(tenantInfo, counts)
+	require.Len(t, deps, 3)
+
+	for _, dep := range deps {
+		query, err := db.NewSelect().
+			Model(dep.model).
+			WhereGroup(" AND ", dep.scope).
+			AppendQuery(db.QueryGen(), nil)
+		require.NoErrorf(t, err, "build %s query", dep.label)
+
+		rendered := string(query)
+		assert.Containsf(t, rendered, ".organization_id = '"+tenantInfo.OrgID.String()+"'",
+			"%s is scoped to the organization", dep.label)
+		assert.Containsf(t, rendered, ".business_unit_id = '"+tenantInfo.BuID.String()+"'",
+			"%s is scoped to the business unit", dep.label)
+	}
+}
+
+func TestAssetDependencyCountsNarrowToBlockingRows(t *testing.T) {
+	t.Parallel()
+
+	db := bun.NewDB(new(sql.DB), pgdialect.New())
+	tenantInfo := pagination.TenantInfo{
+		OrgID: pulid.MustNew("org_"),
+		BuID:  pulid.MustNew("bu_"),
+	}
+	counts := new(repositories.AssetDependencyCounts)
+
+	rendered := make(map[string]string, 3)
+	targets := make(map[string]*int, 3)
+	for _, dep := range assetDependencyCounts(tenantInfo, counts) {
+		query, err := db.NewSelect().
+			Model(dep.model).
+			WhereGroup(" AND ", dep.scope).
+			AppendQuery(db.QueryGen(), nil)
+		require.NoErrorf(t, err, "build %s query", dep.label)
+
+		rendered[dep.label] = string(query)
+		targets[dep.label] = dep.target
+	}
+
+	assignments := rendered["active driver assignments"]
+	assert.Contains(t, assignments, "status IN ('New', 'InProgress')")
+	assert.NotContains(t, assignments, "Completed")
+	assert.NotContains(t, assignments, "Canceled")
+
+	settlements := rendered["unpaid driver settlements"]
+	assert.Contains(t, settlements, "status IN ('Draft', 'PendingApproval', 'Approved', 'Posted')")
+	assert.NotContains(t, settlements, "Paid")
+	assert.NotContains(t, settlements, "Voided")
+
+	workers := rendered["linked driver portal users"]
+	assert.Contains(t, workers, "user_id IS NOT NULL")
+
+	assert.Same(t, &counts.ActiveDriverAssignments, targets["active driver assignments"])
+	assert.Same(t, &counts.UnpaidDriverSettlements, targets["unpaid driver settlements"])
+	assert.Same(t, &counts.LinkedPortalUsers, targets["linked driver portal users"])
 }

--- a/services/tms/internal/infrastructure/sqlite/migrations/20260916000000_move_coverage_type_unassigned.tx.down.sql
+++ b/services/tms/internal/infrastructure/sqlite/migrations/20260916000000_move_coverage_type_unassigned.tx.down.sql
@@ -1,0 +1,20 @@
+-- Code generated from the PostgreSQL migrations by
+-- scripts/dialect-convert/convert.py. Hand-edits are preserved only if you
+-- stop regenerating this file; see docs/databases.md.
+-- Source: 20260916000000_move_coverage_type_unassigned.tx.down.sql
+
+DROP INDEX IF EXISTS "idx_shipment_moves_coverage_type";
+
+--bun:split
+
+UPDATE
+    "shipment_moves"
+SET
+    "coverage_type" = 'driver'
+WHERE
+    "coverage_type" = 'unassigned';
+
+--bun:split
+
+CREATE INDEX IF NOT EXISTS "idx_shipment_moves_coverage_type" ON "shipment_moves" ("coverage_type", "organization_id")WHERE
+    "coverage_type" <> 'driver';

--- a/services/tms/internal/infrastructure/sqlite/migrations/20260916000000_move_coverage_type_unassigned.tx.up.sql
+++ b/services/tms/internal/infrastructure/sqlite/migrations/20260916000000_move_coverage_type_unassigned.tx.up.sql
@@ -9,8 +9,42 @@
 -- of "assignments", "stops" and "carrier_assignments" and PRAGMA foreign_keys
 -- cannot be toggled inside the transaction this migration runs in. The Go model
 -- stamps coverage_type on every insert, so the column default is never
--- exercised. The correlated backfill is written out by hand because the
+-- exercised. The correlated backfills are written out by hand because the
 -- converter refuses any statement containing a subquery.
+
+-- A move labelled 'driver' that no live driver assignment backs but an active
+-- carrier assignment does is carrier coverage wearing the old column default.
+-- Relabel it before the 'unassigned' sweep so that coverage is never lost.
+-- Inactive is 'Canceled' for carrier assignments (they have no archived_at) and
+-- archived_at for driver assignments.
+UPDATE
+    "shipment_moves"
+SET
+    "coverage_type" = 'carrier'
+WHERE
+    "coverage_type" = 'driver'
+    AND NOT EXISTS (
+        SELECT
+            1
+        FROM
+            "assignments" AS "a"
+        WHERE
+            "a"."shipment_move_id" = "shipment_moves"."id"
+            AND "a"."organization_id" = "shipment_moves"."organization_id"
+            AND "a"."business_unit_id" = "shipment_moves"."business_unit_id"
+            AND "a"."archived_at" IS NULL)
+    AND EXISTS (
+        SELECT
+            1
+        FROM
+            "carrier_assignments" AS "ca"
+        WHERE
+            "ca"."shipment_move_id" = "shipment_moves"."id"
+            AND "ca"."organization_id" = "shipment_moves"."organization_id"
+            AND "ca"."business_unit_id" = "shipment_moves"."business_unit_id"
+            AND "ca"."status" <> 'Canceled');
+
+--bun:split
 
 UPDATE
     "shipment_moves"
@@ -27,7 +61,17 @@ WHERE
             "a"."shipment_move_id" = "shipment_moves"."id"
             AND "a"."organization_id" = "shipment_moves"."organization_id"
             AND "a"."business_unit_id" = "shipment_moves"."business_unit_id"
-            AND "a"."archived_at" IS NULL);
+            AND "a"."archived_at" IS NULL)
+    AND NOT EXISTS (
+        SELECT
+            1
+        FROM
+            "carrier_assignments" AS "ca"
+        WHERE
+            "ca"."shipment_move_id" = "shipment_moves"."id"
+            AND "ca"."organization_id" = "shipment_moves"."organization_id"
+            AND "ca"."business_unit_id" = "shipment_moves"."business_unit_id"
+            AND "ca"."status" <> 'Canceled');
 
 --bun:split
 

--- a/services/tms/internal/infrastructure/sqlite/migrations/20260916000000_move_coverage_type_unassigned.tx.up.sql
+++ b/services/tms/internal/infrastructure/sqlite/migrations/20260916000000_move_coverage_type_unassigned.tx.up.sql
@@ -1,0 +1,39 @@
+-- Code generated from the PostgreSQL migrations by
+-- scripts/dialect-convert/convert.py. Hand-edits are preserved only if you
+-- stop regenerating this file; see docs/databases.md.
+-- Source: 20260916000000_move_coverage_type_unassigned.tx.up.sql
+--
+-- Hand-completed: the converter drops both statements this migration needs.
+-- ALTER COLUMN ... SET DEFAULT has no SQLite equivalent and rebuilding
+-- "shipment_moves" is not an option here because it is the foreign key target
+-- of "assignments", "stops" and "carrier_assignments" and PRAGMA foreign_keys
+-- cannot be toggled inside the transaction this migration runs in. The Go model
+-- stamps coverage_type on every insert, so the column default is never
+-- exercised. The correlated backfill is written out by hand because the
+-- converter refuses any statement containing a subquery.
+
+UPDATE
+    "shipment_moves"
+SET
+    "coverage_type" = 'unassigned'
+WHERE
+    "coverage_type" = 'driver'
+    AND NOT EXISTS (
+        SELECT
+            1
+        FROM
+            "assignments" AS "a"
+        WHERE
+            "a"."shipment_move_id" = "shipment_moves"."id"
+            AND "a"."organization_id" = "shipment_moves"."organization_id"
+            AND "a"."business_unit_id" = "shipment_moves"."business_unit_id"
+            AND "a"."archived_at" IS NULL);
+
+--bun:split
+
+DROP INDEX IF EXISTS "idx_shipment_moves_coverage_type";
+
+--bun:split
+
+CREATE INDEX IF NOT EXISTS "idx_shipment_moves_coverage_type" ON "shipment_moves" ("coverage_type", "organization_id")WHERE
+    "coverage_type" = 'carrier';

--- a/services/tms/internal/testutil/mocks/mock_OrganizationRepository.go
+++ b/services/tms/internal/testutil/mocks/mock_OrganizationRepository.go
@@ -115,6 +115,74 @@ func (_c *MockOrganizationRepository_ClearLogoURL_Call) RunAndReturn(run func(ct
 	return _c
 }
 
+// CountAssetDependencies provides a mock function for the type MockOrganizationRepository
+func (_mock *MockOrganizationRepository) CountAssetDependencies(ctx context.Context, tenantInfo pagination.TenantInfo) (*repositories.AssetDependencyCounts, error) {
+	ret := _mock.Called(ctx, tenantInfo)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountAssetDependencies")
+	}
+
+	var r0 *repositories.AssetDependencyCounts
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, pagination.TenantInfo) (*repositories.AssetDependencyCounts, error)); ok {
+		return returnFunc(ctx, tenantInfo)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, pagination.TenantInfo) *repositories.AssetDependencyCounts); ok {
+		r0 = returnFunc(ctx, tenantInfo)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*repositories.AssetDependencyCounts)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, pagination.TenantInfo) error); ok {
+		r1 = returnFunc(ctx, tenantInfo)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockOrganizationRepository_CountAssetDependencies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountAssetDependencies'
+type MockOrganizationRepository_CountAssetDependencies_Call struct {
+	*mock.Call
+}
+
+// CountAssetDependencies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tenantInfo pagination.TenantInfo
+func (_e *MockOrganizationRepository_Expecter) CountAssetDependencies(ctx any, tenantInfo any) *MockOrganizationRepository_CountAssetDependencies_Call {
+	return &MockOrganizationRepository_CountAssetDependencies_Call{Call: _e.mock.On("CountAssetDependencies", ctx, tenantInfo)}
+}
+
+func (_c *MockOrganizationRepository_CountAssetDependencies_Call) Run(run func(ctx context.Context, tenantInfo pagination.TenantInfo)) *MockOrganizationRepository_CountAssetDependencies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 pagination.TenantInfo
+		if args[1] != nil {
+			arg1 = args[1].(pagination.TenantInfo)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOrganizationRepository_CountAssetDependencies_Call) Return(assetDependencyCounts *repositories.AssetDependencyCounts, err error) *MockOrganizationRepository_CountAssetDependencies_Call {
+	_c.Call.Return(assetDependencyCounts, err)
+	return _c
+}
+
+func (_c *MockOrganizationRepository_CountAssetDependencies_Call) RunAndReturn(run func(ctx context.Context, tenantInfo pagination.TenantInfo) (*repositories.AssetDependencyCounts, error)) *MockOrganizationRepository_CountAssetDependencies_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CountBrokerageDependencies provides a mock function for the type MockOrganizationRepository
 func (_mock *MockOrganizationRepository) CountBrokerageDependencies(ctx context.Context, tenantInfo pagination.TenantInfo) (*repositories.BrokerageDependencyCounts, error) {
 	ret := _mock.Called(ctx, tenantInfo)

--- a/services/tms/pkg/reportcatalog/catalog_gen.go
+++ b/services/tms/pkg/reportcatalog/catalog_gen.go
@@ -5053,6 +5053,7 @@ var Default = Catalog{
 					Label:  "Coverage Type",
 					Type:   FieldEnum,
 					EnumValues: []EnumValue{
+						{Value: "unassigned", Label: "Unassigned"},
 						{Value: "driver", Label: "Driver"},
 						{Value: "carrier", Label: "Carrier"},
 					},


### PR DESCRIPTION
# Description

The mirror of #546. That PR gated brokerage features for asset-based carriers; `assetOperationsEnabled` was stored and editable but read by nothing. This wires it up: an organization that brokers its freight no longer sees workers, equipment or driver payroll, and **cannot assign a driver**.

**The two sides are deliberately asymmetric.** Brokerage features are hidden — the API stays open, permissions remain the access control. Asset features are *refused* server-side, because assigning a driver you do not employ is a data-integrity problem rather than clutter. The doc comment in `organization-capability.ts` that claimed these flags never affect the API has been corrected to describe the asymmetry rather than assert something now false.

A third value, `Unassigned`, was added to `MoveCoverageType` first, because everything else keys off it — and it is the part of this PR most worth reviewing on its own merits (below).

## Related Issue or Discussion

Requested directly by @emoss08 as the follow-up to #546.

## Type of Change

- [x] Bug fix
- [x] Feature
- [x] Refactor

## Scope

**Coverage type (`32d180c9f`, `64d060a8e`, `b26b9d3a0`)**
- `MoveCoverageType` gains `Unassigned` and defaults to it. Previously `driver` was both the column default and the Go default stamped on insert, so **every move ever created claimed a driver was expected**, whether or not one was. Nothing depended on it — coverage decisions read `HasCoverage()`, which is relation-based — but the field never meant what it said.
- That exposed an asymmetry: only the carrier path ever stamped the field. All four transitions are now explicit — driver assign sets `Driver`, unassign clears it, carrier assign sets `Carrier`, and carrier cancel clears it rather than falling back to `Driver` as it did before. The client had the same gap in `move-card.tsx`, where driver assign/unassign left coverage stale.
- Migration `20260916000000` in both trees, with an assignment-aware backfill (live assignment ⇒ keeps `driver`, otherwise `unassigned`; archived assignments correctly excluded, since `Unassign` soft-cancels).
- **A partial index would have silently inverted**: `WHERE coverage_type <> 'driver'` was written to cover the brokered exceptions, and with a neutral default it would have matched nearly every row. Narrowed to `= 'carrier'`, with a test pinning the predicate.

**Enforcement (`c56c42c8f`)**
- New `capabilityguard` package, shaped after `dispatchguard`. The refusal sits at `upsertAssignment` — the single funnel assign and reassign share — so one check covers REST, the console's bulk assign, and the auto-assignment agent.
- **Unassign is deliberately not gated**: an org inheriting driver assignments must be able to unwind them, and gating it would deadlock against the disable guard. Tests pass a nil org repo on that path, so an accidental lookup panics rather than passing silently.
- Driver portal invitations refused in that package's own validation idiom (no shipment move to attach a business error to).
- Asset disable guard mirrors the brokerage one; the two were **generalized into one driver and message template** rather than duplicated, so the brokerage message is byte-identical. Both-off is rejected in validation, ahead of any counting.

**Client (`b3ff0bec4`)**
- Nav + routes: workers, tractors, trailers, fleet codes, the whole `/payroll` module, settlement control, dash control, and the matching quick actions. **Equipment Types are deliberately not gated** — they describe freight requirements on the shipment, not owned assets.
- The command-centre timeline and the console's centre timeline are driver-lane layouts, so their view modes resolve away and the toggles disappear entirely — no one-option toggle, no empty board, lazy chunks never mounted.
- The console candidate list uses the capability hook rather than `CapabilityGate`, so the query is disabled and rank hotkeys disarmed; a gate would have hidden the render while still issuing the request.
- The assignment dialog already refused each coverage type when the other applied; the driver tab now refuses the same way, pre-empting the server error.
- Right-stack panel preferences are filtered at render and left in storage, so a layout survives the capability being switched back on.
- Dispatch controls keep the page; the ten driver-compliance fields hide.

## Validation

- [x] `cd services/tms && go test ./...` — green except the known Docker-dependent `internal/infrastructure/minio` tests
- [x] `golangci-lint run --new-from-rev=origin/master` — **0 issues**
- [x] `go build ./...`, `go vet`, `gofmt -l` — clean
- [x] `TestFullSeedRunOnSQLite` — passes uncached
- [x] Migration version-uniqueness across both trees — passes
- [x] `gqlgen generate`, `swag`/openapi-postprocess, `pnpm --filter @trenova/graphql codegen:check` — all clean
- [x] `pnpm --filter @trenova/web typecheck` / `lint` / `test` — 100 files / 788 tests
- [ ] `cd client && pnpm build` — not run; it fails repo-wide on master for the reason below

**Pre-existing failures, not from this PR and deliberately untouched**: master's hardcoded `API_BASE_URL` (`0191f6669`, "local dev changes") leaves `resolveApiBaseUrl` unused, which is 1 typecheck error, 2 `document.test.ts` failures, 2 `graphql.test.ts` failures in shared, and a repo-wide `pnpm build` failure at `tsc -b`. Baseline was recorded before starting and held exactly.

New tests: coverage-type defaulting and the backfill's live/archived/absent split run against a real SQLite schema; all four coverage transitions; the assignment refusal at the funnel for both assign and reassign; unassign still permitted with the capability off; the portal-invitation refusal; each disable blocker plus the combined message; both-off rejection; and the client capability matrix across nav, routes, timeline unmounting, right-stack degradation, the dialog, and dispatch-control fields.

## Deployment Notes

- **The coverage-type backfill rewrites existing rows.** Moves with a live assignment keep `driver`; the rest become `unassigned`. Rows already `carrier` are untouched. Reversible via the down migration.
- **The SQLite mirror cannot change the column default** — `ALTER COLUMN` is unsupported and `shipment_moves` cannot be rebuilt (it is the FK target of `assignments`, `stops` and `carrier_assignments`, and `PRAGMA foreign_keys` is a no-op inside the transaction a `.tx.` migration runs in). It relies on the model stamping `coverage_type` on every insert, which is now true at all four write sites. The migration header says so. **Anyone adding a fifth path that writes a move directly must stamp it too.**
- The SQLite migration is hand-written rather than converter-generated: `convert.py` discards `ALTER COLUMN` and rejects any statement containing a subquery, so it would have silently dropped both statements this migration needs.
- Generated artifacts (`gqlgen`, OpenAPI, report catalog) were hand-edited rather than regenerated, because master's `catalog_gen.go` is **already stale** — a full `go generate` pulls in ~158 unrelated lines. Verified against the real generators: no drift.
- Wording change visible to **all** organizations, not only brokerages: an uncovered move reads "Needs coverage" rather than "Needs driver", and the column header is "Coverage" rather than "Driver / Equip". The cell already rendered carriers, so the old label was wrong for anyone.
- Of the two neutral dispatch-control toggles, only Service Failure Monitoring has a client field; `EnableAutoStopActuals` is server-side only, so that page is thinner than intended but still reachable.

## Checklist

- [x] I kept the change focused and reviewable.
- [x] I followed `AGENTS.md`, `CLAUDE.md`, and existing repository patterns.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I updated relevant documentation, examples, migrations, or configuration.
- [x] I did not include secrets, credentials, private customer data, unrelated refactors, or placeholder code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGqQ3vR9PCHeooQwA3m9NG

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGqQ3vR9PCHeooQwA3m9NG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capability-based access controls for asset operations, including fleet, payroll, worker, settlement, and dashboard features.
  * Restricted driver assignment, driver portal invitations, and related controls to eligible organizations.
  * Added coverage tracking for unassigned moves, with clearer “Coverage” labels and messaging.
  * Timeline views and dispatch panels now adapt to available capabilities.

* **Bug Fixes**
  * Prevented unsupported timeline and driver-assignment views from appearing or loading.
  * Improved handling when carrier or driver coverage is removed.
  * Added safeguards when disabling capabilities with outstanding operational dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->