### PR TITLE
Rate management follow-up: CI fixes and client design rework

### DIFF
--- a/client/apps/web/src/routes/rate-agreement/_components/accessorial-schedule-editor.tsx
+++ b/client/apps/web/src/routes/rate-agreement/_components/accessorial-schedule-editor.tsx
@@ -7,7 +7,7 @@ import { accessorialChargeMethodChoices, rateUnitChoices } from "@/lib/choices";
 import { Button } from "@trenova/shared/components/ui/button";
 import { FormControl, FormGroup } from "@trenova/shared/components/ui/form";
 import type { RateAgreement, RateAgreementAccessorial } from "@trenova/shared/types/rate";
-import { PlusIcon, TrashIcon } from "lucide-react";
+import { PlusIcon } from "lucide-react";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 
 const NEW_ACCESSORIAL = {
@@ -49,10 +49,22 @@ export function AccessorialScheduleEditor() {
         const autoApplies = Boolean(row?.autoApply);
 
         return (
-          <div key={field.id} className="rounded-md border p-3">
-            <div className="mb-2 flex items-center justify-end">
-              <Button type="button" variant="ghost" size="sm" onClick={() => remove(index)}>
-                <TrashIcon className="size-3.5" />
+          <div key={field.id} className="rounded-md border bg-card p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <p className="text-sm font-medium">
+                Accessorial {index + 1}
+                {row?.waived && (
+                  <span className="text-muted-foreground ml-2 text-xs font-normal">Waived</span>
+                )}
+              </p>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-6 text-xs"
+                onClick={() => remove(index)}
+              >
+                Remove
               </Button>
             </div>
 
@@ -84,7 +96,7 @@ export function AccessorialScheduleEditor() {
                     control={control}
                     rules={{ required: true }}
                     name={`accessorials.${index}.rateUnit` as never}
-                    label="Per"
+                    label="Rate Unit"
                     placeholder="Unit"
                     description="What a unit is on this charge"
                     options={rateUnitChoices}
@@ -96,7 +108,10 @@ export function AccessorialScheduleEditor() {
                     control={control}
                     name={`accessorials.${index}.amount` as never}
                     label="Amount"
-                    placeholder="75"
+                    placeholder="75.00"
+                    sideText="$"
+                    decimalScale={2}
+                    thousandSeparator
                     description="What the contract charges"
                   />
                 </FormControl>
@@ -109,8 +124,11 @@ export function AccessorialScheduleEditor() {
                   <NumberField
                     control={control}
                     name={`accessorials.${index}.amount` as never}
-                    label="Amount per unit"
-                    placeholder="65"
+                    label="Amount Per Unit"
+                    placeholder="65.00"
+                    sideText="$"
+                    decimalScale={2}
+                    thousandSeparator
                     description="What the contract charges for each unit"
                   />
                 </FormControl>
@@ -118,7 +136,7 @@ export function AccessorialScheduleEditor() {
                   <NumberField
                     control={control}
                     name={`accessorials.${index}.freeUnits` as never}
-                    label="Free units"
+                    label="Free Units"
                     placeholder="2"
                     description="Units the contract gives away before charging"
                   />
@@ -127,8 +145,11 @@ export function AccessorialScheduleEditor() {
                   <NumberField
                     control={control}
                     name={`accessorials.${index}.maxAmount` as never}
-                    label="Maximum"
-                    placeholder=""
+                    label="Maximum Amount"
+                    placeholder="0.00"
+                    sideText="$"
+                    decimalScale={2}
+                    thousandSeparator
                     description="A ceiling on what this charge can reach"
                   />
                 </FormControl>
@@ -140,7 +161,7 @@ export function AccessorialScheduleEditor() {
                 <SwitchField
                   control={control}
                   name={`accessorials.${index}.autoApply` as never}
-                  label="Applies automatically"
+                  label="Auto Apply"
                   description="Added to every shipment this contract prices, so it never depends on somebody remembering"
                   outlined
                 />
@@ -162,7 +183,7 @@ export function AccessorialScheduleEditor() {
                   <InputField
                     control={control}
                     name={`accessorials.${index}.applyCondition` as never}
-                    label="Only when"
+                    label="Apply Condition"
                     placeholder="totalStops > 2"
                     description="An expression in the same language the rating formulas use. Leave empty to apply to every shipment."
                   />

--- a/client/apps/web/src/routes/rate-agreement/_components/fuel-binding-form.tsx
+++ b/client/apps/web/src/routes/rate-agreement/_components/fuel-binding-form.tsx
@@ -3,7 +3,7 @@ import { NumberField } from "@/components/fields/number-field";
 import { SwitchField } from "@/components/fields/switch-field";
 import { Alert, AlertDescription } from "@trenova/shared/components/ui/alert";
 import { Button } from "@trenova/shared/components/ui/button";
-import { FormControl, FormGroup } from "@trenova/shared/components/ui/form";
+import { FormControl, FormGroup, FormSection } from "@trenova/shared/components/ui/form";
 import type { RateAgreement } from "@trenova/shared/types/rate";
 import { InfoIcon } from "lucide-react";
 import { useFormContext, useWatch } from "react-hook-form";
@@ -50,79 +50,91 @@ export function FuelBindingForm() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      <FormGroup cols={2}>
-        <FormControl cols="full">
-          <FuelSurchargeProgramAutocompleteField
-            control={control}
-            rules={{ required: !waived }}
-            name="fuelBinding.fuelSurchargeProgramId"
-            label="Fuel program"
-            placeholder="Program"
-            description="Overrides whatever the customer's billing profile names, because one customer can hold several contracts"
-          />
-        </FormControl>
-
-        <FormControl cols="full">
-          <SwitchField
-            control={control}
-            name="fuelBinding.waived"
-            label="Fuel is included in the rate"
-            description="An all-in rate, with no surcharge billed at all"
-            outlined
-          />
-        </FormControl>
-      </FormGroup>
-
-      {waived ? (
-        <Alert>
-          <InfoIcon className="size-4" />
-          <AlertDescription>
-            A waived binding cannot also change the program&apos;s terms — the two describe opposite
-            intentions.
-          </AlertDescription>
-        </Alert>
-      ) : (
-        <FormGroup cols={3}>
-          <FormControl>
-            <NumberField
+    <div className="space-y-6">
+      <FormSection
+        title="Fuel Terms"
+        description="The program this contract's fuel surcharge reads, and the terms it negotiated over it."
+      >
+        <FormGroup cols={2}>
+          <FormControl cols="full">
+            <FuelSurchargeProgramAutocompleteField
               control={control}
-              name="fuelBinding.pegPriceOverride"
-              label="Peg price"
-              placeholder=""
-              description="The price the surcharge starts climbing from, when the contract negotiated its own"
+              rules={{ required: !waived }}
+              name="fuelBinding.fuelSurchargeProgramId"
+              label="Fuel Program"
+              placeholder="Select program"
+              description="Overrides whatever the customer's billing profile names, because one customer can hold several contracts"
             />
           </FormControl>
-          <FormControl>
-            <NumberField
+
+          <FormControl cols="full">
+            <SwitchField
               control={control}
-              name="fuelBinding.incrementRateOverride"
-              label="Increment rate"
-              placeholder=""
-              description="What each step above the peg adds, when the contract negotiated its own"
-            />
-          </FormControl>
-          <FormControl>
-            <NumberField
-              control={control}
-              name="fuelBinding.capAmount"
-              label="Cap"
-              placeholder=""
-              description="The most fuel this contract can ever be billed on one shipment"
+              name="fuelBinding.waived"
+              label="Fuel Included in Rate"
+              description="An all-in rate, with no surcharge billed at all"
+              outlined
             />
           </FormControl>
         </FormGroup>
-      )}
 
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="self-start"
-        onClick={() => setValue("fuelBinding", null, { shouldDirty: true })}
-      >
-        Remove fuel terms
-      </Button>
+        {waived ? (
+          <Alert>
+            <InfoIcon className="size-4" />
+            <AlertDescription>
+              A waived binding cannot also change the program&apos;s terms — the two describe
+              opposite intentions.
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <FormGroup cols={3}>
+            <FormControl>
+              <NumberField
+                control={control}
+                name="fuelBinding.pegPriceOverride"
+                label="Peg Price Override"
+                placeholder="0.00"
+                sideText="$"
+                decimalScale={3}
+                description="The price the surcharge starts climbing from, when the contract negotiated its own"
+              />
+            </FormControl>
+            <FormControl>
+              <NumberField
+                control={control}
+                name="fuelBinding.incrementRateOverride"
+                label="Increment Rate Override"
+                placeholder="0.00"
+                sideText="$"
+                decimalScale={4}
+                description="What each step above the peg adds, when the contract negotiated its own"
+              />
+            </FormControl>
+            <FormControl>
+              <NumberField
+                control={control}
+                name="fuelBinding.capAmount"
+                label="Cap Amount"
+                placeholder="0.00"
+                sideText="$"
+                decimalScale={2}
+                thousandSeparator
+                description="The most fuel this contract can ever be billed on one shipment"
+              />
+            </FormControl>
+          </FormGroup>
+        )}
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="self-start"
+          onClick={() => setValue("fuelBinding", null, { shouldDirty: true })}
+        >
+          Remove fuel terms
+        </Button>
+      </FormSection>
     </div>
   );
 }

--- a/client/apps/web/src/routes/rate-agreement/_components/lane-editor.tsx
+++ b/client/apps/web/src/routes/rate-agreement/_components/lane-editor.tsx
@@ -17,7 +17,7 @@ import {
   laneSpecificity,
 } from "@trenova/shared/lib/rate";
 import type { RateAgreement, RateAgreementRule } from "@trenova/shared/types/rate";
-import { PlusIcon, TrashIcon, TriangleAlertIcon } from "lucide-react";
+import { PlusIcon, TriangleAlertIcon } from "lucide-react";
 import { useMemo } from "react";
 import type { Control } from "react-hook-form";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
@@ -135,10 +135,10 @@ function LaneRow({ control, index, rule, issue, onRemove }: LaneRowProps) {
   const laneKey = rule ? laneKeyPreview(rule) : null;
 
   return (
-    <div className="rounded-md border p-3">
+    <div className="rounded-md border bg-card p-4">
       <div className="mb-3 flex items-start justify-between gap-2">
         <div className="flex flex-col gap-1">
-          <p className="text-xs font-medium">
+          <p className="text-sm font-medium">
             {rule ? laneDisplayLabel(rule, index) : `Lane ${index + 1}`}
           </p>
           <div className="flex flex-wrap items-center gap-1.5">
@@ -152,8 +152,8 @@ function LaneRow({ control, index, rule, issue, onRemove }: LaneRowProps) {
             )}
           </div>
         </div>
-        <Button type="button" variant="ghost" size="sm" onClick={onRemove}>
-          <TrashIcon className="size-3.5" />
+        <Button type="button" variant="ghost" size="sm" className="h-6 text-xs" onClick={onRemove}>
+          Remove
         </Button>
       </div>
 
@@ -184,8 +184,18 @@ function LaneRow({ control, index, rule, issue, onRemove }: LaneRowProps) {
       </FormGroup>
 
       <div className="mt-3 grid gap-3 md:grid-cols-2">
-        <LaneScopeFields control={control} side="origin" namePrefix={`rules.${index}.`} />
-        <LaneScopeFields control={control} side="destination" namePrefix={`rules.${index}.`} />
+        <div className="rounded-md border bg-muted/30 p-3">
+          <p className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
+            Origin
+          </p>
+          <LaneScopeFields control={control} side="origin" namePrefix={`rules.${index}.`} />
+        </div>
+        <div className="rounded-md border bg-muted/30 p-3">
+          <p className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
+            Destination
+          </p>
+          <LaneScopeFields control={control} side="destination" namePrefix={`rules.${index}.`} />
+        </div>
       </div>
 
       <FormGroup cols={3} className="mt-3">
@@ -194,7 +204,7 @@ function LaneRow({ control, index, rule, issue, onRemove }: LaneRowProps) {
             control={control}
             rules={{ required: true }}
             name={`rules.${index}.ratingBasis` as never}
-            label="Priced by"
+            label="Rating Basis"
             placeholder="Basis"
             description="How this lane arrives at a linehaul"
             options={ratingBasisChoices}
@@ -207,7 +217,7 @@ function LaneRow({ control, index, rule, issue, onRemove }: LaneRowProps) {
               control={control}
               rules={{ required: true }}
               name={`rules.${index}.rateMatrixId` as never}
-              label="Rate matrix"
+              label="Rate Matrix"
               placeholder="Matrix"
               description="The grid this lane reads its price from"
             />
@@ -218,7 +228,7 @@ function LaneRow({ control, index, rule, issue, onRemove }: LaneRowProps) {
               control={control}
               rules={{ required: true }}
               name={`rules.${index}.formulaTemplateId` as never}
-              label="Formula template"
+              label="Formula Template"
               placeholder="Template"
               description="The expression this lane evaluates, for rates no structured method covers"
             />
@@ -231,6 +241,9 @@ function LaneRow({ control, index, rule, issue, onRemove }: LaneRowProps) {
                 name={`rules.${index}.rate` as never}
                 label="Rate"
                 placeholder="2.55"
+                sideText="$"
+                decimalScale={4}
+                thousandSeparator
                 description="Leave empty when the lane is banded by weight"
               />
             </FormControl>
@@ -240,7 +253,7 @@ function LaneRow({ control, index, rule, issue, onRemove }: LaneRowProps) {
                   control={control}
                   rules={{ required: true }}
                   name={`rules.${index}.percentBasis` as never}
-                  label="Percent of"
+                  label="Percent Basis"
                   placeholder="Basis"
                   description="What the percentage is taken from"
                   options={ratePercentBasisChoices}
@@ -256,8 +269,11 @@ function LaneRow({ control, index, rule, issue, onRemove }: LaneRowProps) {
           <NumberField
             control={control}
             name={`rules.${index}.minCharge` as never}
-            label="Minimum charge"
-            placeholder="850"
+            label="Minimum Charge"
+            placeholder="850.00"
+            sideText="$"
+            decimalScale={2}
+            thousandSeparator
             description="The floor this lane never prices below"
           />
         </FormControl>
@@ -265,8 +281,11 @@ function LaneRow({ control, index, rule, issue, onRemove }: LaneRowProps) {
           <NumberField
             control={control}
             name={`rules.${index}.maxCharge` as never}
-            label="Maximum charge"
-            placeholder=""
+            label="Maximum Charge"
+            placeholder="0.00"
+            sideText="$"
+            decimalScale={2}
+            thousandSeparator
             description="A ceiling, when the contract sets one"
           />
         </FormControl>
@@ -274,8 +293,9 @@ function LaneRow({ control, index, rule, issue, onRemove }: LaneRowProps) {
           <NumberField
             control={control}
             name={`rules.${index}.minBillableDistance` as never}
-            label="Minimum miles"
+            label="Minimum Billable Miles"
             placeholder="250"
+            sideText="mi"
             description="Short hauls bill at this distance however far they actually ran"
           />
         </FormControl>

--- a/client/apps/web/src/routes/rate-agreement/_components/lane-scope-fields.tsx
+++ b/client/apps/web/src/routes/rate-agreement/_components/lane-scope-fields.tsx
@@ -71,8 +71,8 @@ export function LaneScopeFields<T extends FieldValues>({
           control={control}
           rules={{ required: true }}
           name={names.scopeType as never}
-          label={`${label} scope`}
-          placeholder="Scope"
+          label={`${label} Scope`}
+          placeholder="Select scope"
           description="How narrowly this end of the lane is written. A narrower scope beats a wider one covering the same load."
           options={rateScopeTypeChoices}
         />
@@ -84,8 +84,8 @@ export function LaneScopeFields<T extends FieldValues>({
             control={control}
             rules={{ required: true }}
             name={names.scopeValue as never}
-            label={`${label} zone`}
-            placeholder="Zone"
+            label={`${label} Zone`}
+            placeholder="Select zone"
             description="The market area this end covers"
           />
         </FormControl>
@@ -97,8 +97,8 @@ export function LaneScopeFields<T extends FieldValues>({
             control={control}
             rules={{ required: true }}
             name={names.scopeValue as never}
-            label={`${label} state`}
-            placeholder="State"
+            label={`${label} State`}
+            placeholder="Select state"
             description="The state this end covers"
           />
         </FormControl>
@@ -110,8 +110,8 @@ export function LaneScopeFields<T extends FieldValues>({
             control={control}
             rules={{ required: true }}
             name={names.scopeValue as never}
-            label={`${label} location`}
-            placeholder="Location"
+            label={`${label} Location`}
+            placeholder="Select location"
             description="The single facility this end covers"
           />
         </FormControl>
@@ -124,8 +124,8 @@ export function LaneScopeFields<T extends FieldValues>({
               control={control}
               rules={{ required: true }}
               name={names.scopeValue as never}
-              label={`${label} state`}
-              placeholder="State"
+              label={`${label} State`}
+              placeholder="Select state"
               description="The state the city sits in"
             />
           </FormControl>
@@ -134,7 +134,7 @@ export function LaneScopeFields<T extends FieldValues>({
               control={control}
               rules={{ required: true }}
               name={names.city as never}
-              label={`${label} city`}
+              label={`${label} City`}
               placeholder="City"
               description="Spelling and case do not matter — the city is folded before it is matched"
             />
@@ -148,7 +148,7 @@ export function LaneScopeFields<T extends FieldValues>({
             control={control}
             rules={{ required: true }}
             name={names.scopeValue as never}
-            label={scopeType === "Zip3" ? `${label} postal prefix` : `${label} postal code`}
+            label={scopeType === "Zip3" ? `${label} Postal Prefix` : `${label} Postal Code`}
             placeholder={scopeType === "Zip3" ? "606" : "60601"}
             description={
               scopeType === "Zip3"
@@ -165,7 +165,7 @@ export function LaneScopeFields<T extends FieldValues>({
             control={control}
             rules={{ required: true }}
             name={names.scopeValue as never}
-            label={`${label} country`}
+            label={`${label} Country`}
             placeholder="USA"
             description="Three letter country code"
           />
@@ -179,8 +179,9 @@ export function LaneScopeFields<T extends FieldValues>({
               control={control}
               rules={{ required: true }}
               name={names.radiusMeters as never}
-              label={`${label} radius (meters)`}
+              label={`${label} Radius`}
               placeholder="80000"
+              sideText="m"
               description="How far from the centre point this end reaches"
             />
           </FormControl>
@@ -189,7 +190,7 @@ export function LaneScopeFields<T extends FieldValues>({
               control={control}
               rules={{ required: true }}
               name={names.latitude as never}
-              label={`${label} latitude`}
+              label={`${label} Latitude`}
               placeholder="32.7767"
               description="The centre point this end measures from"
             />
@@ -199,7 +200,7 @@ export function LaneScopeFields<T extends FieldValues>({
               control={control}
               rules={{ required: true }}
               name={names.longitude as never}
-              label={`${label} longitude`}
+              label={`${label} Longitude`}
               placeholder="-96.7970"
               description="The centre point this end measures from"
             />

--- a/client/apps/web/src/routes/rate-agreement/_components/rate-agreement-form.tsx
+++ b/client/apps/web/src/routes/rate-agreement/_components/rate-agreement-form.tsx
@@ -9,12 +9,13 @@ import { SelectField } from "@/components/fields/select-field";
 import { SwitchField } from "@/components/fields/switch-field";
 import { TextareaField } from "@/components/fields/textarea-field";
 import {
+  currencyChoices,
   rateAgreementStatusChoices,
   rateAgreementTypeChoices,
   ratePartyTypeChoices,
   rateRoundingModeChoices,
 } from "@/lib/choices";
-import { FormControl, FormGroup } from "@trenova/shared/components/ui/form";
+import { FormControl, FormGroup, FormSection } from "@trenova/shared/components/ui/form";
 import type { RateAgreement } from "@trenova/shared/types/rate";
 import { useFormContext, useWatch } from "react-hook-form";
 
@@ -31,243 +32,283 @@ export function RateAgreementForm() {
   const partyType = useWatch({ control, name: "partyType" });
 
   return (
-    <div className="flex flex-col gap-4">
-      <FormGroup cols={2}>
-        <FormControl>
-          <SelectField
-            control={control}
-            rules={{ required: true }}
-            name="partyType"
-            label="Side"
-            placeholder="Side"
-            description="Whether this contract sets what a customer pays or what a carrier is paid"
-            options={ratePartyTypeChoices}
-          />
-        </FormControl>
-
-        {partyType === "Carrier" ? (
-          <FormControl>
-            <CarrierAutocompleteField
-              control={control}
-              rules={{ required: true }}
-              name="carrierId"
-              label="Carrier"
-              placeholder="Carrier"
-              description="The carrier this agreement pays"
-            />
-          </FormControl>
-        ) : (
-          <FormControl>
-            <CustomerAutocompleteField
-              control={control}
-              rules={{ required: true }}
-              name="customerId"
-              label="Customer"
-              placeholder="Customer"
-              description="The customer this agreement bills"
-            />
-          </FormControl>
-        )}
-
-        <FormControl>
-          <InputField
-            control={control}
-            rules={{ required: true }}
-            name="code"
-            label="Code"
-            placeholder="ACME-2026"
-            description="How this contract is referred to internally"
-          />
-        </FormControl>
-        <FormControl>
-          <InputField
-            control={control}
-            rules={{ required: true }}
-            name="name"
-            label="Name"
-            placeholder="Acme Freight Agreement"
-            description="The contract's name as somebody reading an invoice would recognise it"
-          />
-        </FormControl>
-
-        <FormControl cols="full">
-          <TextareaField
-            control={control}
-            name="description"
-            label="Description"
-            placeholder="What this agreement covers"
-            description="Anything the terms do not say that the next person will need"
-          />
-        </FormControl>
-
-        <FormControl>
-          <SelectField
-            control={control}
-            rules={{ required: true }}
-            name="agreementType"
-            label="Type"
-            placeholder="Type"
-            description="Contract, published tariff, spot deal, project or dedicated"
-            options={rateAgreementTypeChoices}
-          />
-        </FormControl>
-        <FormControl>
-          <SelectField
-            control={control}
-            name="status"
-            label="Status"
-            placeholder="Status"
-            description="Moved by the review actions, never by a save"
-            options={rateAgreementStatusChoices}
-            isReadOnly
-          />
-        </FormControl>
-
-        <FormControl>
-          <InputField
-            control={control}
-            name="contractRef"
-            label="Contract reference"
-            placeholder="MSA-2026-114"
-            description="The signed document's own number, for when somebody asks"
-          />
-        </FormControl>
-        <FormControl>
-          <NumberField
-            control={control}
-            name="priority"
-            label="Priority"
-            placeholder="0"
-            description="Breaks a tie when two agreements cover the same lane equally narrowly"
-          />
-        </FormControl>
-      </FormGroup>
-
-      <FormGroup cols={2}>
-        <FormControl>
-          <AutoCompleteDateField
-            control={control}
-            rules={{ required: true }}
-            name="effectiveFrom"
-            label="In force from"
-            placeholder="Start date"
-            description="Shipments moving on or after this date price against this contract"
-          />
-        </FormControl>
-        <FormControl>
-          <AutoCompleteDateField
-            control={control}
-            name="effectiveTo"
-            label="Until"
-            placeholder="End date"
-            description="Leave empty to run until somebody ends it"
-          />
-        </FormControl>
-        <FormControl>
-          <SwitchField
-            control={control}
-            name="autoRenew"
-            label="Renews automatically"
-            description="Whether the term rolls forward unless somebody gives notice"
-            outlined
-          />
-        </FormControl>
-        <FormControl>
-          <NumberField
-            control={control}
-            name="renewalNoticeDays"
-            label="Notice days"
-            placeholder="30"
-            description="How much warning the contract requires before it ends"
-          />
-        </FormControl>
-      </FormGroup>
-
-      <FormGroup cols={3}>
-        <FormControl>
-          <InputField
-            control={control}
-            rules={{ required: true }}
-            name="currency"
-            label="Currency"
-            placeholder="USD"
-            description="What this contract is written in, converted at the rating date when it differs from yours"
-          />
-        </FormControl>
-        <FormControl>
-          <NumberField
-            control={control}
-            name="defaultMinCharge"
-            label="Default minimum"
-            placeholder=""
-            description="The floor a lane inherits when it does not set its own"
-          />
-        </FormControl>
-        <FormControl>
-          <NumberField
-            control={control}
-            name="defaultMaxCharge"
-            label="Default maximum"
-            placeholder=""
-            description="A ceiling a lane inherits when it does not set its own"
-          />
-        </FormControl>
-        <FormControl>
-          <SelectField
-            control={control}
-            name="roundingMode"
-            label="Rounding"
-            placeholder="Rounding"
-            description="How the final amount is rounded"
-            options={rateRoundingModeChoices}
-          />
-        </FormControl>
-        <FormControl>
-          <NumberField
-            control={control}
-            name="roundingPrecision"
-            label="Precision"
-            placeholder="2"
-            description="How many decimal places the rounded amount keeps"
-          />
-        </FormControl>
-      </FormGroup>
-
-      {partyType === "Carrier" && (
+    <div className="space-y-6">
+      <FormSection
+        title="General Information"
+        description="Who the contract is with and how it is identified across the system."
+        className="border-b pb-4"
+      >
         <FormGroup cols={2}>
           <FormControl>
-            <NumberField
+            <SelectField
               control={control}
-              name="marginFloorPercent"
-              label="Margin floor (%)"
-              placeholder="12"
-              description="The thinnest margin this carrier may be paid down to"
+              rules={{ required: true }}
+              name="partyType"
+              label="Party Type"
+              placeholder="Select party type"
+              description="Whether this contract sets what a customer pays or what a carrier is paid"
+              options={ratePartyTypeChoices}
+            />
+          </FormControl>
+
+          {partyType === "Carrier" ? (
+            <FormControl>
+              <CarrierAutocompleteField
+                control={control}
+                rules={{ required: true }}
+                name="carrierId"
+                label="Carrier"
+                placeholder="Select carrier"
+                description="The carrier this agreement pays"
+              />
+            </FormControl>
+          ) : (
+            <FormControl>
+              <CustomerAutocompleteField
+                control={control}
+                rules={{ required: true }}
+                name="customerId"
+                label="Customer"
+                placeholder="Select customer"
+                description="The customer this agreement bills"
+              />
+            </FormControl>
+          )}
+
+          <FormControl>
+            <InputField
+              control={control}
+              rules={{ required: true }}
+              name="code"
+              label="Code"
+              placeholder="e.g., ACME-2026"
+              description="Short identifier used to reference this contract internally. Must be unique across your organization."
+            />
+          </FormControl>
+          <FormControl>
+            <InputField
+              control={control}
+              rules={{ required: true }}
+              name="name"
+              label="Name"
+              placeholder="e.g., Acme Freight Agreement"
+              description="The contract's name as somebody reading an invoice would recognize it"
+            />
+          </FormControl>
+
+          <FormControl cols="full">
+            <TextareaField
+              control={control}
+              name="description"
+              label="Description"
+              placeholder="What this agreement covers"
+              description="Anything the terms do not say that the next person will need"
+            />
+          </FormControl>
+
+          <FormControl>
+            <SelectField
+              control={control}
+              rules={{ required: true }}
+              name="agreementType"
+              label="Agreement Type"
+              placeholder="Select type"
+              description="Contract, published tariff, spot deal, project, or dedicated capacity"
+              options={rateAgreementTypeChoices}
+            />
+          </FormControl>
+          <FormControl>
+            <SelectField
+              control={control}
+              name="status"
+              label="Status"
+              placeholder="Status"
+              description="Moved by the review actions (submit, approve, suspend), never by a save"
+              options={rateAgreementStatusChoices}
+              isReadOnly
+            />
+          </FormControl>
+
+          <FormControl>
+            <InputField
+              control={control}
+              name="contractRef"
+              label="Contract Reference"
+              placeholder="e.g., MSA-2026-114"
+              description="The signed document's own number, for when somebody asks"
             />
           </FormControl>
           <FormControl>
             <NumberField
               control={control}
-              name="maxPayPercentOfSell"
-              label="Maximum pay (% of sell)"
-              placeholder="85"
-              description="A ceiling on the pay as a share of what the customer is billed"
+              name="priority"
+              label="Priority"
+              placeholder="0"
+              description="Breaks a tie when two agreements cover the same lane equally narrowly. Higher wins."
             />
           </FormControl>
         </FormGroup>
+      </FormSection>
+
+      <FormSection
+        title="Term"
+        description="When the contract is in force and how it renews."
+        className="border-b pb-4"
+      >
+        <FormGroup cols={2}>
+          <FormControl>
+            <AutoCompleteDateField
+              control={control}
+              rules={{ required: true }}
+              name="effectiveFrom"
+              label="Effective From"
+              placeholder="Select start date"
+              description="Shipments moving on or after this date price against this contract"
+            />
+          </FormControl>
+          <FormControl>
+            <AutoCompleteDateField
+              control={control}
+              name="effectiveTo"
+              label="Effective To"
+              placeholder="Select end date"
+              description="Leave empty to run until somebody ends it"
+            />
+          </FormControl>
+          <FormControl>
+            <SwitchField
+              control={control}
+              name="autoRenew"
+              label="Auto Renew"
+              description="The term rolls forward automatically unless somebody gives notice"
+              outlined
+            />
+          </FormControl>
+          <FormControl>
+            <NumberField
+              control={control}
+              name="renewalNoticeDays"
+              label="Renewal Notice"
+              placeholder="30"
+              sideText="days"
+              description="How much warning the contract requires before it ends"
+            />
+          </FormControl>
+        </FormGroup>
+      </FormSection>
+
+      <FormSection
+        title="Pricing Defaults"
+        description="The currency, guardrails, and rounding every lane inherits unless it sets its own."
+        className={partyType ? "border-b pb-4" : undefined}
+      >
+        <FormGroup cols={2}>
+          <FormControl>
+            <SelectField
+              control={control}
+              rules={{ required: true }}
+              name="currency"
+              label="Currency"
+              placeholder="Select currency"
+              description="What this contract is written in, converted at the rating date when it differs from yours"
+              options={currencyChoices}
+            />
+          </FormControl>
+          <FormControl>
+            <SelectField
+              control={control}
+              name="roundingMode"
+              label="Rounding Mode"
+              placeholder="Select rounding"
+              description="How the final amount is rounded"
+              options={rateRoundingModeChoices}
+            />
+          </FormControl>
+          <FormControl>
+            <NumberField
+              control={control}
+              name="defaultMinCharge"
+              label="Default Minimum Charge"
+              placeholder="0.00"
+              sideText="$"
+              decimalScale={2}
+              thousandSeparator
+              description="The floor a lane inherits when it does not set its own"
+            />
+          </FormControl>
+          <FormControl>
+            <NumberField
+              control={control}
+              name="defaultMaxCharge"
+              label="Default Maximum Charge"
+              placeholder="0.00"
+              sideText="$"
+              decimalScale={2}
+              thousandSeparator
+              description="A ceiling a lane inherits when it does not set its own"
+            />
+          </FormControl>
+          <FormControl>
+            <NumberField
+              control={control}
+              name="roundingPrecision"
+              label="Rounding Precision"
+              placeholder="2"
+              description="How many decimal places the rounded amount keeps"
+            />
+          </FormControl>
+        </FormGroup>
+      </FormSection>
+
+      {partyType === "Carrier" && (
+        <FormSection
+          title="Margin Guardrails"
+          description="Limits on what this carrier may be paid relative to what the load sells for."
+        >
+          <FormGroup cols={2}>
+            <FormControl>
+              <NumberField
+                control={control}
+                name="marginFloorPercent"
+                label="Margin Floor"
+                placeholder="12"
+                sideText="%"
+                decimalScale={2}
+                description="The thinnest margin this carrier may be paid down to"
+              />
+            </FormControl>
+            <FormControl>
+              <NumberField
+                control={control}
+                name="maxPayPercentOfSell"
+                label="Maximum Pay"
+                placeholder="85"
+                sideText="%"
+                decimalScale={2}
+                description="A ceiling on the pay as a share of what the customer is billed"
+              />
+            </FormControl>
+          </FormGroup>
+        </FormSection>
       )}
 
       {partyType === "Customer" && (
-        <FormGroup cols={2}>
-          <FormControl>
-            <CustomerAutocompleteField
-              control={control}
-              name="billToCustomerId"
-              label="Bill to"
-              placeholder="Bill-to customer"
-              description="Redirects invoicing, for a customer whose parent settles the freight"
-            />
-          </FormControl>
-        </FormGroup>
+        <FormSection
+          title="Invoicing"
+          description="Where invoices for this contract's freight are sent."
+        >
+          <FormGroup cols={2}>
+            <FormControl>
+              <CustomerAutocompleteField
+                control={control}
+                name="billToCustomerId"
+                label="Bill To"
+                placeholder="Select bill-to customer"
+                description="Redirects invoicing, for a customer whose parent settles the freight"
+              />
+            </FormControl>
+          </FormGroup>
+        </FormSection>
       )}
     </div>
   );

--- a/client/apps/web/src/routes/rate-agreement/_components/rate-agreement-panel.tsx
+++ b/client/apps/web/src/routes/rate-agreement/_components/rate-agreement-panel.tsx
@@ -115,6 +115,7 @@ export function RateAgreementPanel({
         onOpenChange={onOpenChange}
         row={row}
         form={form}
+        size="xl"
         queryKey="rate-agreement-list"
         title="Rate Agreement"
         fieldKey="name"
@@ -135,6 +136,7 @@ export function RateAgreementPanel({
       open={open}
       onOpenChange={onOpenChange}
       form={form}
+      size="xl"
       queryKey="rate-agreement-list"
       title="Rate Agreement"
       description="Write the contract once, and every shipment on its lanes prices itself against it."

--- a/client/apps/web/src/routes/rate-matrix/_components/dimension-editor.tsx
+++ b/client/apps/web/src/routes/rate-matrix/_components/dimension-editor.tsx
@@ -6,7 +6,7 @@ import { Button } from "@trenova/shared/components/ui/button";
 import { FormControl, FormGroup } from "@trenova/shared/components/ui/form";
 import { MAX_MATRIX_DIMENSIONS } from "@trenova/shared/lib/rate-matrix";
 import type { RateMatrix, RateMatrixDimension } from "@trenova/shared/types/rate";
-import { PlusIcon, TrashIcon, TriangleAlertIcon } from "lucide-react";
+import { PlusIcon, TriangleAlertIcon } from "lucide-react";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 
 /**
@@ -56,13 +56,17 @@ export function DimensionEditor() {
         const matchMode = dimensions[index]?.matchMode;
 
         return (
-          <div key={field.id} className="rounded-md border p-3">
-            <div className="mb-2 flex items-center justify-between">
-              <span className="text-muted-foreground text-xs font-medium">
-                {index === 0 ? "First axis" : `Axis ${index + 1}`}
-              </span>
-              <Button type="button" variant="ghost" size="sm" onClick={() => removeAxis(index)}>
-                <TrashIcon className="size-3.5" />
+          <div key={field.id} className="rounded-md border bg-card p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <p className="text-sm font-medium">Axis {index + 1}</p>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-6 text-xs"
+                onClick={() => removeAxis(index)}
+              >
+                Remove
               </Button>
             </div>
 
@@ -72,8 +76,8 @@ export function DimensionEditor() {
                   control={control}
                   rules={{ required: true }}
                   name={`dimensions.${index}.kind` as never}
-                  label="Looks up by"
-                  placeholder="Looks up by"
+                  label="Dimension"
+                  placeholder="Select dimension"
                   description="What about the shipment this axis reads"
                   options={rateMatrixDimensionKindChoices}
                 />
@@ -83,8 +87,8 @@ export function DimensionEditor() {
                   control={control}
                   rules={{ required: true }}
                   name={`dimensions.${index}.matchMode` as never}
-                  label="Matched as"
-                  placeholder="Matched as"
+                  label="Match Mode"
+                  placeholder="Select match mode"
                   description={
                     matchMode === "Range"
                       ? "Bands, each covering from its floor up to but not including the next"
@@ -97,7 +101,7 @@ export function DimensionEditor() {
                 <InputField
                   control={control}
                   name={`dimensions.${index}.label` as never}
-                  label="Header"
+                  label="Label"
                   placeholder="Origin zone"
                   description="What this axis is called in the grid — leave blank to use the kind"
                 />

--- a/client/apps/web/src/routes/rate-matrix/_components/rate-matrix-form.tsx
+++ b/client/apps/web/src/routes/rate-matrix/_components/rate-matrix-form.tsx
@@ -2,8 +2,13 @@ import { InputField } from "@/components/fields/input-field";
 import { NumberField } from "@/components/fields/number-field";
 import { SelectField } from "@/components/fields/select-field";
 import { TextareaField } from "@/components/fields/textarea-field";
-import { rateMatrixValueKindChoices, rateRoundingModeChoices, statusChoices } from "@/lib/choices";
-import { FormControl, FormGroup } from "@trenova/shared/components/ui/form";
+import {
+  currencyChoices,
+  rateMatrixValueKindChoices,
+  rateRoundingModeChoices,
+  statusChoices,
+} from "@/lib/choices";
+import { FormControl, FormGroup, FormSection } from "@trenova/shared/components/ui/form";
 import type { RateMatrix } from "@trenova/shared/types/rate";
 import { useFormContext } from "react-hook-form";
 
@@ -11,89 +16,106 @@ export function RateMatrixForm() {
   const { control } = useFormContext<RateMatrix>();
 
   return (
-    <FormGroup cols={2}>
-      <FormControl>
-        <SelectField
-          control={control}
-          rules={{ required: true }}
-          name="status"
-          label="Status"
-          placeholder="Status"
-          description="An inactive matrix stops pricing, and every lane pointing at it stops with it"
-          options={statusChoices}
-        />
-      </FormControl>
-      <FormControl>
-        <SelectField
-          control={control}
-          rules={{ required: true }}
-          name="valueKind"
-          label="Rates are"
-          placeholder="Rates are"
-          description="What each number in the grid means — the same grid is a per-mile tariff or a discount table depending on this"
-          options={rateMatrixValueKindChoices}
-        />
-      </FormControl>
-      <FormControl>
-        <InputField
-          control={control}
-          rules={{ required: true }}
-          name="code"
-          label="Code"
-          placeholder="LTL-2025-Q3"
-          description="The short name lanes refer to"
-        />
-      </FormControl>
-      <FormControl>
-        <InputField
-          control={control}
-          rules={{ required: true }}
-          name="name"
-          label="Name"
-          placeholder="LTL base tariff, Q3 2025"
-          description="What this tariff is called out loud"
-        />
-      </FormControl>
-      <FormControl cols="full">
-        <TextareaField
-          control={control}
-          name="description"
-          label="Description"
-          placeholder="Zone-to-zone base rates by weight break, published July 2025"
-          description="Where this tariff came from, so the next person knows what they are amending"
-        />
-      </FormControl>
-      <FormControl>
-        <InputField
-          control={control}
-          rules={{ required: true }}
-          name="currency"
-          label="Currency"
-          placeholder="USD"
-          description="The currency the numbers in the grid are in, converted at rating time when it differs from the contract's"
-        />
-      </FormControl>
-      <FormControl>
-        <SelectField
-          control={control}
-          rules={{ required: true }}
-          name="roundingMode"
-          label="Rounding"
-          placeholder="Rounding"
-          description="How a looked-up rate is rounded before it becomes a charge"
-          options={rateRoundingModeChoices}
-        />
-      </FormControl>
-      <FormControl>
-        <NumberField
-          control={control}
-          rules={{ required: true }}
-          name="roundingPrecision"
-          label="Decimal places"
-          placeholder="2"
-          description="How many decimals survive the rounding"
-        />
-      </FormControl>
-    </FormGroup>
+    <div className="space-y-6">
+      <FormSection
+        title="General Information"
+        description="How this tariff grid is identified and whether it is live."
+        className="border-b pb-4"
+      >
+        <FormGroup cols={2}>
+          <FormControl>
+            <SelectField
+              control={control}
+              rules={{ required: true }}
+              name="status"
+              label="Status"
+              placeholder="Status"
+              description="An inactive matrix stops pricing, and every lane pointing at it stops with it"
+              options={statusChoices}
+            />
+          </FormControl>
+          <FormControl>
+            <InputField
+              control={control}
+              rules={{ required: true }}
+              name="code"
+              label="Code"
+              placeholder="LTL-2025-Q3"
+              description="The short name lanes refer to"
+            />
+          </FormControl>
+          <FormControl>
+            <InputField
+              control={control}
+              rules={{ required: true }}
+              name="name"
+              label="Name"
+              placeholder="LTL base tariff, Q3 2025"
+              description="What this tariff is called out loud"
+            />
+          </FormControl>
+          <FormControl cols="full">
+            <TextareaField
+              control={control}
+              name="description"
+              label="Description"
+              placeholder="Zone-to-zone base rates by weight break, published July 2025"
+              description="Where this tariff came from, so the next person knows what they are amending"
+            />
+          </FormControl>
+        </FormGroup>
+      </FormSection>
+
+      <FormSection
+        title="Pricing"
+        description="What the numbers in the grid mean and how a looked-up rate becomes a charge."
+      >
+        <FormGroup cols={2}>
+          <FormControl>
+            <SelectField
+              control={control}
+              rules={{ required: true }}
+              name="valueKind"
+              label="Value Kind"
+              placeholder="Select value kind"
+              description="What each number in the grid means — the same grid is a per-mile tariff or a discount table depending on this"
+              options={rateMatrixValueKindChoices}
+            />
+          </FormControl>
+          <FormControl>
+            <SelectField
+              control={control}
+              rules={{ required: true }}
+              name="currency"
+              label="Currency"
+              placeholder="Select currency"
+              description="The currency the numbers in the grid are in, converted at rating time when it differs from the contract's"
+              options={currencyChoices}
+            />
+          </FormControl>
+          <FormControl>
+            <SelectField
+              control={control}
+              rules={{ required: true }}
+              name="roundingMode"
+              label="Rounding Mode"
+              placeholder="Select rounding"
+              description="How a looked-up rate is rounded before it becomes a charge"
+              options={rateRoundingModeChoices}
+            />
+          </FormControl>
+          <FormControl>
+            <NumberField
+              control={control}
+              rules={{ required: true }}
+              name="roundingPrecision"
+              label="Rounding Precision"
+              placeholder="2"
+              description="How many decimals survive the rounding"
+            />
+          </FormControl>
+        </FormGroup>
+      </FormSection>
+    </div>
   );
 }

--- a/client/apps/web/src/routes/rate-matrix/_components/rate-matrix-panel.tsx
+++ b/client/apps/web/src/routes/rate-matrix/_components/rate-matrix-panel.tsx
@@ -66,6 +66,7 @@ export function RateMatrixPanel({
         onOpenChange={onOpenChange}
         row={row}
         form={form}
+        size="xl"
         queryKey="rate-matrix-list"
         title="Rate Matrix"
         fieldKey="name"
@@ -86,6 +87,7 @@ export function RateMatrixPanel({
       open={open}
       onOpenChange={onOpenChange}
       form={form}
+      size="xl"
       queryKey="rate-matrix-list"
       title="Rate Matrix"
       description="Enter a published tariff as the grid it was published as, and point any lane at it."

--- a/client/apps/web/src/routes/rate-zone/_components/rate-zone-form.tsx
+++ b/client/apps/web/src/routes/rate-zone/_components/rate-zone-form.tsx
@@ -2,7 +2,7 @@ import { InputField } from "@/components/fields/input-field";
 import { SelectField } from "@/components/fields/select-field";
 import { TextareaField } from "@/components/fields/textarea-field";
 import { rateZoneKindChoices, statusChoices } from "@/lib/choices";
-import { FormControl, FormGroup } from "@trenova/shared/components/ui/form";
+import { FormControl, FormGroup, FormSection } from "@trenova/shared/components/ui/form";
 import type { RateZone } from "@trenova/shared/types/rate";
 import { useFormContext } from "react-hook-form";
 import { ZoneMemberEditor } from "./zone-member-editor";
@@ -11,65 +11,73 @@ export function RateZoneForm() {
   const { control } = useFormContext<RateZone>();
 
   return (
-    <div className="flex flex-col gap-4">
-      <FormGroup cols={2}>
-        <FormControl>
-          <SelectField
-            control={control}
-            rules={{ required: true }}
-            name="status"
-            label="Status"
-            placeholder="Status"
-            description="An inactive zone stops matching, and every lane written against it stops with it"
-            options={statusChoices}
-          />
-        </FormControl>
-        <FormControl>
-          <SelectField
-            control={control}
-            rules={{ required: true }}
-            name="kind"
-            label="Kind"
-            placeholder="Kind"
-            description="What sort of area this is, which is how somebody else reads it later"
-            options={rateZoneKindChoices}
-          />
-        </FormControl>
-        <FormControl>
-          <InputField
-            control={control}
-            rules={{ required: true }}
-            name="code"
-            label="Code"
-            placeholder="SE"
-            description="The short name lanes and tariffs refer to"
-          />
-        </FormControl>
-        <FormControl>
-          <InputField
-            control={control}
-            rules={{ required: true }}
-            name="name"
-            label="Name"
-            placeholder="Southeast"
-            description="What this area is called out loud"
-          />
-        </FormControl>
-        <FormControl cols="full">
-          <TextareaField
-            control={control}
-            name="description"
-            label="Description"
-            placeholder="Atlantic and Gulf states from Virginia through Louisiana"
-            description="What the zone actually covers, for the next person deciding whether to reuse it"
-          />
-        </FormControl>
-      </FormGroup>
+    <div className="space-y-6">
+      <FormSection
+        title="General Information"
+        description="How this zone is identified and whether it is live."
+        className="border-b pb-4"
+      >
+        <FormGroup cols={2}>
+          <FormControl>
+            <SelectField
+              control={control}
+              rules={{ required: true }}
+              name="status"
+              label="Status"
+              placeholder="Status"
+              description="An inactive zone stops matching, and every lane written against it stops with it"
+              options={statusChoices}
+            />
+          </FormControl>
+          <FormControl>
+            <SelectField
+              control={control}
+              rules={{ required: true }}
+              name="kind"
+              label="Zone Kind"
+              placeholder="Select kind"
+              description="What sort of area this is, which is how somebody else reads it later"
+              options={rateZoneKindChoices}
+            />
+          </FormControl>
+          <FormControl>
+            <InputField
+              control={control}
+              rules={{ required: true }}
+              name="code"
+              label="Code"
+              placeholder="SE"
+              description="The short name lanes and tariffs refer to"
+            />
+          </FormControl>
+          <FormControl>
+            <InputField
+              control={control}
+              rules={{ required: true }}
+              name="name"
+              label="Name"
+              placeholder="Southeast"
+              description="What this area is called out loud"
+            />
+          </FormControl>
+          <FormControl cols="full">
+            <TextareaField
+              control={control}
+              name="description"
+              label="Description"
+              placeholder="Atlantic and Gulf states from Virginia through Louisiana"
+              description="What the zone actually covers, for the next person deciding whether to reuse it"
+            />
+          </FormControl>
+        </FormGroup>
+      </FormSection>
 
-      <div>
-        <h4 className="mb-2 text-sm font-medium">Places</h4>
+      <FormSection
+        title="Places"
+        description="The states, cities, postal codes, and locations this zone is a union of."
+      >
         <ZoneMemberEditor />
-      </div>
+      </FormSection>
     </div>
   );
 }

--- a/client/apps/web/src/routes/rate-zone/_components/rate-zone-panel.tsx
+++ b/client/apps/web/src/routes/rate-zone/_components/rate-zone-panel.tsx
@@ -27,6 +27,7 @@ export function RateZonePanel({ open, onOpenChange, mode, row }: DataTablePanelP
         onOpenChange={onOpenChange}
         row={row}
         form={form}
+        size="lg"
         url="/rate-zones/"
         queryKey="rate-zone-list"
         title="Rate Zone"
@@ -41,6 +42,7 @@ export function RateZonePanel({ open, onOpenChange, mode, row }: DataTablePanelP
       open={open}
       onOpenChange={onOpenChange}
       form={form}
+      size="lg"
       url="/rate-zones/"
       queryKey="rate-zone-list"
       title="Rate Zone"

--- a/client/apps/web/src/routes/rate-zone/_components/zone-member-editor.tsx
+++ b/client/apps/web/src/routes/rate-zone/_components/zone-member-editor.tsx
@@ -8,7 +8,7 @@ import { Button } from "@trenova/shared/components/ui/button";
 import { FormControl, FormGroup } from "@trenova/shared/components/ui/form";
 import type { GenericSelectOption } from "@trenova/shared/types/fields";
 import type { RateZone, RateZoneMember } from "@trenova/shared/types/rate";
-import { PlusIcon, TrashIcon } from "lucide-react";
+import { PlusIcon } from "lucide-react";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 
 /**
@@ -49,10 +49,17 @@ export function ZoneMemberEditor() {
         const scopeType = members[index]?.scopeType;
 
         return (
-          <div key={field.id} className="rounded-md border p-3">
-            <div className="mb-2 flex items-center justify-end">
-              <Button type="button" variant="ghost" size="sm" onClick={() => remove(index)}>
-                <TrashIcon className="size-3.5" />
+          <div key={field.id} className="rounded-md border bg-card p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <p className="text-sm font-medium">Place {index + 1}</p>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-6 text-xs"
+                onClick={() => remove(index)}
+              >
+                Remove
               </Button>
             </div>
 
@@ -62,8 +69,8 @@ export function ZoneMemberEditor() {
                   control={control}
                   rules={{ required: true }}
                   name={`members.${index}.scopeType` as never}
-                  label="Kind"
-                  placeholder="Kind"
+                  label="Place Type"
+                  placeholder="Select type"
                   description="How this place is named"
                   options={MEMBER_SCOPE_CHOICES}
                 />

--- a/client/apps/web/src/routes/shipment/_components/__tests__/assignment-dialog-capability.test.tsx
+++ b/client/apps/web/src/routes/shipment/_components/__tests__/assignment-dialog-capability.test.tsx
@@ -77,8 +77,8 @@ describe("AssignmentDialog coverage modes", () => {
 
     renderDialog();
 
-    expect(screen.getByRole("radio", { name: "Driver" })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "Carrier" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Driver" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Carrier" })).toBeInTheDocument();
   });
 
   it("drops the driver tab for an organization that employs no drivers", () => {
@@ -86,9 +86,9 @@ describe("AssignmentDialog coverage modes", () => {
 
     renderDialog();
 
-    expect(screen.queryByRole("radio", { name: "Driver" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Driver" })).toBeNull();
     // One remaining mode is not a choice, so the whole control goes with it.
-    expect(screen.queryByRole("radiogroup", { name: "Coverage type" })).toBeNull();
+    expect(screen.queryByRole("tablist", { name: "Coverage type" })).toBeNull();
   });
 
   it("opens straight into carrier coverage when the driver mode is unavailable", () => {

--- a/services/tms/internal/api/graphql/projection/gen/generator.go
+++ b/services/tms/internal/api/graphql/projection/gen/generator.go
@@ -478,7 +478,7 @@ func selectionForModelOverride(
 	}
 
 	fieldMap, ok := data.FieldMaps[st.Name]
-	if ok && !fieldMapCoversStruct(fieldMap, st) {
+	if ok && !fieldMapCoversStruct(&fieldMap, &st) {
 		// FieldMaps are keyed by unqualified struct name, so a same-named entity
 		// from another domain package (e.g. modeprofile.Profile vs email.Profile)
 		// can shadow the bound model's map. Treat a map that does not cover this
@@ -508,7 +508,7 @@ func selectionForModelOverride(
 	}, nil
 }
 
-func fieldMapCoversStruct(fieldMap fieldMapRegistration, st goStruct) bool {
+func fieldMapCoversStruct(fieldMap *fieldMapRegistration, st *goStruct) bool {
 	for _, field := range st.Fields {
 		if !field.IsColumn {
 			continue

--- a/services/tms/internal/api/graphql/projection/specs_gen.go
+++ b/services/tms/internal/api/graphql/projection/specs_gen.go
@@ -212,7 +212,15 @@ var PortalInvitationSpec TypeSpec
 
 var PortalPtoSpec TypeSpec
 
+var RateAgreementSpec TypeSpec
+
+var RateMatrixSpec TypeSpec
+
+var RateQuoteSpec TypeSpec
+
 var RateTableSpec TypeSpec
+
+var RateZoneSpec TypeSpec
 
 var RecurringDeductionSpec TypeSpec
 
@@ -9294,6 +9302,307 @@ func init() {
 		},
 	}
 
+	RateAgreementSpec = TypeSpec{
+		TypeName: "RateAgreement",
+		FieldMap: buncolgen.RateAgreementFieldMap,
+		AlwaysColumns: []string{
+			"id",
+			"created_at",
+		},
+		Fields: []FieldSpec{
+			{
+				Name:        "id",
+				FieldMapKey: "id",
+			},
+			{
+				Name:        "businessUnitId",
+				FieldMapKey: "businessUnitId",
+			},
+			{
+				Name:        "organizationId",
+				FieldMapKey: "organizationId",
+			},
+			{
+				Name:        "partyType",
+				FieldMapKey: "partyType",
+			},
+			{
+				Name:        "customerId",
+				FieldMapKey: "customerId",
+			},
+			{
+				Name:        "carrierId",
+				FieldMapKey: "carrierId",
+			},
+			{
+				Name:        "code",
+				FieldMapKey: "code",
+			},
+			{
+				Name:        "name",
+				FieldMapKey: "name",
+			},
+			{
+				Name:        "description",
+				FieldMapKey: "description",
+			},
+			{
+				Name:        "agreementType",
+				FieldMapKey: "agreementType",
+			},
+			{
+				Name:        "status",
+				FieldMapKey: "status",
+			},
+			{
+				Name:        "contractRef",
+				FieldMapKey: "contractRef",
+			},
+			{
+				Name:        "priority",
+				FieldMapKey: "priority",
+			},
+			{
+				Name:        "effectiveFrom",
+				FieldMapKey: "effectiveFrom",
+			},
+			{
+				Name:        "effectiveTo",
+				FieldMapKey: "effectiveTo",
+			},
+			{
+				Name:        "autoRenew",
+				FieldMapKey: "autoRenew",
+			},
+			{
+				Name:        "renewalNoticeDays",
+				FieldMapKey: "renewalNoticeDays",
+			},
+			{
+				Name:        "currency",
+				FieldMapKey: "currency",
+			},
+			{
+				Name:        "defaultMinCharge",
+				FieldMapKey: "defaultMinCharge",
+			},
+			{
+				Name:        "defaultMaxCharge",
+				FieldMapKey: "defaultMaxCharge",
+			},
+			{
+				Name:        "marginFloorPercent",
+				FieldMapKey: "marginFloorPercent",
+			},
+			{
+				Name:        "maxPayPercentOfSell",
+				FieldMapKey: "maxPayPercentOfSell",
+			},
+			{
+				Name:        "submittedById",
+				FieldMapKey: "submittedById",
+			},
+			{
+				Name:        "submittedAt",
+				FieldMapKey: "submittedAt",
+			},
+			{
+				Name:        "approvedById",
+				FieldMapKey: "approvedById",
+			},
+			{
+				Name:        "approvedAt",
+				FieldMapKey: "approvedAt",
+			},
+			{
+				Name:        "reviewComment",
+				FieldMapKey: "reviewComment",
+			},
+			{
+				Name:        "currentVersionNumber",
+				FieldMapKey: "currentVersionNumber",
+			},
+			{
+				Name:        "version",
+				FieldMapKey: "version",
+			},
+			{
+				Name:        "createdAt",
+				FieldMapKey: "createdAt",
+			},
+			{
+				Name:        "updatedAt",
+				FieldMapKey: "updatedAt",
+			},
+		},
+	}
+
+	RateMatrixSpec = TypeSpec{
+		TypeName: "RateMatrix",
+		FieldMap: buncolgen.RateMatrixFieldMap,
+		AlwaysColumns: []string{
+			"id",
+			"created_at",
+		},
+		Fields: []FieldSpec{
+			{
+				Name:        "id",
+				FieldMapKey: "id",
+			},
+			{
+				Name:        "businessUnitId",
+				FieldMapKey: "businessUnitId",
+			},
+			{
+				Name:        "organizationId",
+				FieldMapKey: "organizationId",
+			},
+			{
+				Name:        "code",
+				FieldMapKey: "code",
+			},
+			{
+				Name:        "name",
+				FieldMapKey: "name",
+			},
+			{
+				Name:        "description",
+				FieldMapKey: "description",
+			},
+			{
+				Name:        "status",
+				FieldMapKey: "status",
+			},
+			{
+				Name:        "valueKind",
+				FieldMapKey: "valueKind",
+			},
+			{
+				Name:        "currency",
+				FieldMapKey: "currency",
+			},
+			{
+				Name:        "version",
+				FieldMapKey: "version",
+			},
+			{
+				Name:        "createdAt",
+				FieldMapKey: "createdAt",
+			},
+			{
+				Name:        "updatedAt",
+				FieldMapKey: "updatedAt",
+			},
+		},
+	}
+
+	RateQuoteSpec = TypeSpec{
+		TypeName: "RateQuote",
+		FieldMap: buncolgen.RateQuoteFieldMap,
+		AlwaysColumns: []string{
+			"id",
+			"created_at",
+		},
+		Fields: []FieldSpec{
+			{
+				Name:        "id",
+				FieldMapKey: "id",
+			},
+			{
+				Name:        "businessUnitId",
+				FieldMapKey: "businessUnitId",
+			},
+			{
+				Name:        "organizationId",
+				FieldMapKey: "organizationId",
+			},
+			{
+				Name:        "shipmentId",
+				FieldMapKey: "shipmentId",
+			},
+			{
+				Name:        "partyType",
+				FieldMapKey: "partyType",
+			},
+			{
+				Name:        "partyId",
+				FieldMapKey: "partyId",
+			},
+			{
+				Name:        "purpose",
+				FieldMapKey: "purpose",
+			},
+			{
+				Name:        "outcome",
+				FieldMapKey: "outcome",
+			},
+			{
+				Name:        "rateAgreementId",
+				FieldMapKey: "rateAgreementId",
+			},
+			{
+				Name:        "rateAgreementRuleId",
+				FieldMapKey: "rateAgreementRuleId",
+			},
+			{
+				Name:        "formulaTemplateId",
+				FieldMapKey: "formulaTemplateId",
+			},
+			{
+				Name:        "specificityScore",
+				FieldMapKey: "specificityScore",
+			},
+			{
+				Name:        "currency",
+				FieldMapKey: "currency",
+			},
+			{
+				Name:        "billingCurrency",
+				FieldMapKey: "billingCurrency",
+			},
+			{
+				Name:        "linehaulAmount",
+				FieldMapKey: "linehaulAmount",
+			},
+			{
+				Name:        "totalAmount",
+				FieldMapKey: "totalAmount",
+			},
+			{
+				Name:        "billingAmount",
+				FieldMapKey: "billingAmount",
+			},
+			{
+				Name:        "foregoneAmount",
+				FieldMapKey: "foregoneAmount",
+			},
+			{
+				Name:        "overrideReason",
+				FieldMapKey: "overrideReason",
+			},
+			{
+				Name:        "asOf",
+				FieldMapKey: "asOf",
+			},
+			{
+				Name:        "ratedAt",
+				FieldMapKey: "ratedAt",
+			},
+			{
+				Name:        "ratedById",
+				FieldMapKey: "ratedById",
+			},
+			{
+				Name:        "engineVersion",
+				FieldMapKey: "engineVersion",
+			},
+			{
+				Name:        "createdAt",
+				FieldMapKey: "createdAt",
+			},
+		},
+	}
+
 	RateTableSpec = TypeSpec{
 		TypeName: "RateTable",
 		FieldMap: buncolgen.RateTableFieldMap,
@@ -9359,6 +9668,57 @@ func init() {
 				Relation: &RelationSpec{
 					Target: &OrganizationSpec,
 				},
+			},
+		},
+	}
+
+	RateZoneSpec = TypeSpec{
+		TypeName: "RateZone",
+		FieldMap: buncolgen.RateZoneFieldMap,
+		AlwaysColumns: []string{
+			"id",
+			"created_at",
+		},
+		Fields: []FieldSpec{
+			{
+				Name:        "id",
+				FieldMapKey: "id",
+			},
+			{
+				Name:        "businessUnitId",
+				FieldMapKey: "businessUnitId",
+			},
+			{
+				Name:        "organizationId",
+				FieldMapKey: "organizationId",
+			},
+			{
+				Name:        "code",
+				FieldMapKey: "code",
+			},
+			{
+				Name:        "name",
+				FieldMapKey: "name",
+			},
+			{
+				Name:        "description",
+				FieldMapKey: "description",
+			},
+			{
+				Name:        "status",
+				FieldMapKey: "status",
+			},
+			{
+				Name:        "version",
+				FieldMapKey: "version",
+			},
+			{
+				Name:        "createdAt",
+				FieldMapKey: "createdAt",
+			},
+			{
+				Name:        "updatedAt",
+				FieldMapKey: "updatedAt",
 			},
 		},
 	}

--- a/services/tms/internal/core/services/invoiceadjustmentservice/service_integration_test.go
+++ b/services/tms/internal/core/services/invoiceadjustmentservice/service_integration_test.go
@@ -1120,7 +1120,7 @@ func TestInvoiceAdjustmentService_EngineScenarios(t *testing.T) {
 			assert.Equal(t, 1, batch.FailedCount)
 
 			temporalStarter := &fakeWorkflowStarter{enabled: true}
-			h.service = h.buildService(temporalStarter, decimal.NewFromInt(100))
+			h.service = h.buildService(t, temporalStarter, decimal.NewFromInt(100))
 			items := make([]*servicesports.InvoiceAdjustmentRequest, 0, batchInlineThreshold+1)
 			for i := range batchInlineThreshold + 1 {
 				items = append(items, &servicesports.InvoiceAdjustmentRequest{
@@ -1296,9 +1296,12 @@ func newIntegrationHarness(
 }
 
 func (h *integrationHarness) buildService(
+	t *testing.T,
 	starter servicesports.WorkflowStarter,
 	formulaAmount decimal.Decimal,
 ) servicesports.InvoiceAdjustmentService {
+	t.Helper()
+
 	return New(Params{
 		Logger:      zap.NewNop(),
 		DB:          h.conn,

--- a/services/tms/internal/infrastructure/database/seeds/development/16_rate_agreement.go
+++ b/services/tms/internal/infrastructure/database/seeds/development/16_rate_agreement.go
@@ -408,6 +408,7 @@ func (s *RateAgreementSeed) createMatrix(
 		Description:    "Per-mile linehaul by origin region and destination region",
 		Status:         domaintypes.StatusActive,
 		Currency:       "USD",
+		ValueKind:      ratematrix.ValueKindPerMile,
 		CreatedAt:      refs.now,
 		UpdatedAt:      refs.now,
 	}

--- a/services/tms/internal/infrastructure/postgres/migrations/20260926000000_additional_charge_owner_optional.tx.down.sql
+++ b/services/tms/internal/infrastructure/postgres/migrations/20260926000000_additional_charge_owner_optional.tx.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "additional_charges"
+    DROP CONSTRAINT IF EXISTS "chk_additional_charges_single_owner";
+
+--bun:split
+ALTER TABLE "additional_charges"
+    ADD CONSTRAINT "chk_additional_charges_single_owner" CHECK (NOT "is_system_generated" OR (("fuel_surcharge_program_id" IS NOT NULL)::int + ("detention_occurrence_id" IS NOT NULL)::int + ("rate_agreement_accessorial_id" IS NOT NULL)::int) = 1);

--- a/services/tms/internal/infrastructure/postgres/migrations/20260926000000_additional_charge_owner_optional.tx.up.sql
+++ b/services/tms/internal/infrastructure/postgres/migrations/20260926000000_additional_charge_owner_optional.tx.up.sql
@@ -1,0 +1,12 @@
+-- The legacy detention path writes a system charge that no owner column can
+-- name: it is generated from the shipment's own stop times, not from a
+-- detention occurrence, a fuel program or a contract accessorial. Insisting on
+-- exactly one owner outlawed it, which is stricter than the rule the constraint
+-- exists to enforce. What must never happen is one charge claimed by two
+-- engines, so the count is capped rather than fixed.
+ALTER TABLE "additional_charges"
+    DROP CONSTRAINT IF EXISTS "chk_additional_charges_single_owner";
+
+--bun:split
+ALTER TABLE "additional_charges"
+    ADD CONSTRAINT "chk_additional_charges_single_owner" CHECK (NOT "is_system_generated" OR (("fuel_surcharge_program_id" IS NOT NULL)::int + ("detention_occurrence_id" IS NOT NULL)::int + ("rate_agreement_accessorial_id" IS NOT NULL)::int) <= 1);

--- a/services/tms/pkg/reportcatalog/catalog_gen.go
+++ b/services/tms/pkg/reportcatalog/catalog_gen.go
@@ -10,7 +10,7 @@ import (
 	"github.com/emoss08/trenova/pkg/buncolgen"
 )
 
-const Version = "sha256:e9bda9e35c10740012c68e03845584daa3a60ac1a8f3d297dc918f54327f9191"
+const Version = "sha256:f328cc7994f08055dd0c0f628782fdfbc19e4ab8642383921096944eb9d67d93"
 
 var Default = Catalog{
 	Version: Version,
@@ -4845,6 +4845,84 @@ var Default = Catalog{
 					Label:    "Rating Detail",
 					Type:     FieldJSON,
 					Nullable: true,
+				},
+				{
+					Key:          "rateQuoteId",
+					Column:       buncolgen.NewColumn("rate_quote_id", "sp"),
+					Label:        "Rate Quote ID",
+					Type:         FieldRef,
+					Nullable:     true,
+					Aggregations: []Aggregation{AggCount, AggCountDistinct},
+					Filterable:   true,
+					Groupable:    true,
+				},
+				{
+					Key:          "rateAgreementId",
+					Column:       buncolgen.NewColumn("rate_agreement_id", "sp"),
+					Label:        "Rate Agreement ID",
+					Type:         FieldRef,
+					Nullable:     true,
+					Aggregations: []Aggregation{AggCount, AggCountDistinct},
+					Filterable:   true,
+					Groupable:    true,
+				},
+				{
+					Key:          "rateAgreementRuleId",
+					Column:       buncolgen.NewColumn("rate_agreement_rule_id", "sp"),
+					Label:        "Rate Agreement Rule ID",
+					Type:         FieldRef,
+					Nullable:     true,
+					Aggregations: []Aggregation{AggCount, AggCountDistinct},
+					Filterable:   true,
+					Groupable:    true,
+				},
+				{
+					Key:          "rateOverrideAmount",
+					Column:       buncolgen.NewColumn("rate_override_amount", "sp"),
+					Label:        "Rate Override Amount",
+					Type:         FieldDecimal,
+					Nullable:     true,
+					Aggregations: []Aggregation{AggCount, AggCountDistinct, AggSum, AggAvg, AggMin, AggMax},
+					Filterable:   true,
+				},
+				{
+					Key:          "rateOverrideReason",
+					Column:       buncolgen.NewColumn("rate_override_reason", "sp"),
+					Label:        "Rate Override Reason",
+					Type:         FieldString,
+					Nullable:     true,
+					Aggregations: []Aggregation{AggCount, AggCountDistinct},
+					Filterable:   true,
+					Groupable:    true,
+				},
+				{
+					Key:          "rateOverrideById",
+					Column:       buncolgen.NewColumn("rate_override_by_id", "sp"),
+					Label:        "Rate Override By ID",
+					Type:         FieldRef,
+					Nullable:     true,
+					Aggregations: []Aggregation{AggCount, AggCountDistinct},
+					Filterable:   true,
+					Groupable:    true,
+				},
+				{
+					Key:          "rateOverrideAt",
+					Column:       buncolgen.NewColumn("rate_override_at", "sp"),
+					Label:        "Rate Override At",
+					Type:         FieldEpoch,
+					Nullable:     true,
+					Aggregations: []Aggregation{AggCount, AggCountDistinct, AggAvg, AggMin, AggMax},
+					Filterable:   true,
+					Groupable:    true,
+				},
+				{
+					Key:          "rateLocked",
+					Column:       buncolgen.NewColumn("rate_locked", "sp"),
+					Label:        "Rate Locked",
+					Type:         FieldBool,
+					Aggregations: []Aggregation{AggCount, AggCountDistinct},
+					Filterable:   true,
+					Groupable:    true,
 				},
 				{
 					Key:          "version",


### PR DESCRIPTION
# Description

Follow-up to #551. Two threads of work:

**CI fixes** — everything that was red on the merge commit:
- Regenerated `pkg/reportcatalog/catalog_gen.go` (the shipment's new rate columns never reached the report catalog) and `internal/api/graphql/projection/specs_gen.go` (the RateAgreement/RateMatrix/RateQuote/RateZone GraphQL types had no projection specs) — this was the Codegen Checks failure.
- Fixed the golangci `hugeParam` finding in the projection generator (`fieldMapCoversStruct` now takes pointers) — the Lint failure.
- Fixed a compile error under the `integration` build tag: `buildService` in the invoice adjustment integration harness referenced a `t` that was never in scope. `go build`/`go vet` without the tag never see it.
- The `RateAgreement` development seed never set the matrix's `ValueKind`, a not-null enum with no default, so seeding failed and took every DB-seeding integration test down with it. (Same fix landed independently on master; the merge is deduplicated.)
- New migration `20260926000000_additional_charge_owner_optional`: the single-owner CHECK on `additional_charges` demanded *exactly* one owner column on system charges, but the legacy (pre-policy-engine) detention path legitimately writes a system charge with no owner — it derives from the shipment's own stop times, not from an occurrence, a fuel program, or a contract accessorial. The cap is now *at most* one, which still prevents double-billing.
- Updated the coverage-mode test for master's SegmentedControl→Tabs refactor of the assignment dialog (queries `tab`/`tablist` roles instead of `radio`/`radiogroup`).

**Client design rework** — the rate screens were bare walls of fields; they now follow the established slice design:
- Forms grouped into titled `FormSection`s with descriptions and dividers (General Information · Term · Pricing Defaults · Margin Guardrails, etc.), the way the carrier and commodity forms read.
- Labels moved to the product's Title Case convention ("Side" → Party Type, "Priced by" → Rating Basis, "Rates are" → Value Kind, …); real example placeholders instead of empty ones.
- Money/percent/unit fields carry `sideText` ($ / % / days / mi), decimal scale, and thousand separators; currency is chosen from the standard `currencyChoices` list instead of typed.
- Repeating rows (lanes, accessorials, zone places, matrix axes) get a proper header with a name and a text Remove action instead of a floating trash icon; a lane's origin/destination scope groups are visibly framed.
- The agreement and matrix panels open at `xl` and the zone panel at `lg` — the default 500px panel is what made the lane editor feel crushed.

## Related Issue or Discussion

Follow-up to #551 (rate agreements & auto-rating), addressing post-merge CI failures and design feedback on the rate management client.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [x] Tests
- [x] Build, CI, or infrastructure

## Scope

- `services/tms/pkg/reportcatalog/`, `internal/api/graphql/projection/` (regenerated + generator fix)
- `services/tms/internal/infrastructure/postgres/migrations/20260926000000_additional_charge_owner_optional.tx.{up,down}.sql`
- `services/tms/internal/infrastructure/database/seeds/development/16_rate_agreement.go`
- `services/tms/internal/core/services/invoiceadjustmentservice/service_integration_test.go`
- `client/apps/web/src/routes/{rate-agreement,rate-zone,rate-matrix}/_components/`
- `client/apps/web/src/routes/shipment/_components/__tests__/assignment-dialog-capability.test.tsx`

## Validation

- [x] `cd services/tms && go build ./...` and `go test ./...` — clean except the pre-existing Docker-dependent minio suite (no Docker in this environment)
- [x] `cd services/tms && golangci-lint run --new-from-rev=origin/master` — 0 issues
- [x] Full integration suite against local PostGIS + Redis (`go test -tags=integration` over all 45 tagged packages) — clean except pre-existing Docker-dependent minio/RedisJSON suites unavailable in this environment
- [x] Codegen drift checks reproduce clean: gqlgen, seed IDs, report catalog, projection specs, swagger/OpenAPI
- [x] SQLite migration mirror: `python3 scripts/dialect-convert/convert.py sqlite --check` applies 1,733/1,733 statements
- [x] `cd client && pnpm typecheck` — 4/4 packages clean
- [x] `cd client && pnpm --filter @trenova/web build` — clean
- [x] oxlint clean on the edited components; oxfmt run on exactly the edited files
- [x] Client tests: 358/358 web route tests pass; the two files that failed in a full parallel run pass in isolation (pre-existing flake, also red on master)
- [ ] Other: `task test` / `task lint` were run via their underlying commands directly (no task runner config change involved)

## Deployment Notes

One additive migration (`20260926000000`) that drops and re-adds the `chk_additional_charges_single_owner` CHECK constraint with a relaxed predicate (`= 1` → `<= 1` owner columns on system-generated charges). No data backfill, no rollout-order concern; the down migration restores the strict form.

## Checklist

- [x] I kept the change focused and reviewable.
- [x] I followed `AGENTS.md`, `CLAUDE.md`, and existing repository patterns.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I updated relevant documentation, examples, migrations, or configuration.
- [x] I did not include secrets, credentials, private customer data, unrelated refactors, or placeholder code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWqusugcK3FRSL6QFhUffZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWqusugcK3FRSL6QFhUffZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer, sectioned forms for rate agreements, rate matrices, and rate zones.
  - Added selectable currency options and improved monetary, distance, and unit formatting.
  - Added shipment report fields for rate quotes, agreements, overrides, and rate-lock status.
  - Expanded editing panels for rate agreements and matrices.

- **Improvements**
  - Updated labels, placeholders, descriptions, spacing, and card styling across rate configuration screens.
  - Replaced icon-only removal actions with clearly labeled “Remove” buttons.
  - Improved rate-zone place and lane field terminology.

- **Bug Fixes**
  - System-generated additional charges can now omit an owner while still preventing multiple owners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->