### PR TITLE
test(tms): cover the driver-pay domain and service money math

### DIFF
--- a/services/tms/internal/core/domain/driverpay/advance_test.go
+++ b/services/tms/internal/core/domain/driverpay/advance_test.go
@@ -152,7 +152,11 @@ func TestPayAdvance_SyncStatus(t *testing.T) {
 		writtenOff int64
 		want       AdvanceStatus
 	}{
-		{name: "untouched advance is outstanding", amount: 50_000, want: AdvanceStatusOutstanding},
+		{
+			name:   "untouched advance is outstanding",
+			amount: 50_000,
+			want:   AdvanceStatusOutstanding,
+		},
 		{
 			name:      "partial recovery",
 			amount:    50_000,

--- a/services/tms/internal/core/domain/driverpay/advance_test.go
+++ b/services/tms/internal/core/domain/driverpay/advance_test.go
@@ -1,0 +1,202 @@
+package driverpay
+
+import (
+	"testing"
+
+	"github.com/emoss08/trenova/pkg/errortypes"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/stretchr/testify/assert"
+)
+
+func validPayAdvance() PayAdvance {
+	return PayAdvance{
+		ID:             pulid.MustNew("padv_"),
+		BusinessUnitID: pulid.MustNew("bu_"),
+		OrganizationID: pulid.MustNew("org_"),
+		WorkerID:       pulid.MustNew("wrk_"),
+		Status:         AdvanceStatusOutstanding,
+		Source:         AdvanceSourceCash,
+		IssuedDate:     1_700_000_000,
+		AmountMinor:    50_000,
+		CurrencyCode:   "USD",
+	}
+}
+
+func TestPayAdvance_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(a *PayAdvance)
+		wantErr bool
+	}{
+		{
+			name:    "valid advance passes",
+			mutate:  func(a *PayAdvance) {},
+			wantErr: false,
+		},
+		{
+			name:    "missing worker fails",
+			mutate:  func(a *PayAdvance) { a.WorkerID = "" },
+			wantErr: true,
+		},
+		{
+			name:    "missing issued date fails",
+			mutate:  func(a *PayAdvance) { a.IssuedDate = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "invalid status fails",
+			mutate:  func(a *PayAdvance) { a.Status = "Pending" },
+			wantErr: true,
+		},
+		{
+			name:    "invalid source fails",
+			mutate:  func(a *PayAdvance) { a.Source = "Venmo" },
+			wantErr: true,
+		},
+		{
+			name:    "zero amount fails",
+			mutate:  func(a *PayAdvance) { a.AmountMinor = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "negative amount fails",
+			mutate:  func(a *PayAdvance) { a.AmountMinor = -1 },
+			wantErr: true,
+		},
+		{
+			name:    "negative recovered amount fails",
+			mutate:  func(a *PayAdvance) { a.RecoveredMinor = -1 },
+			wantErr: true,
+		},
+		{
+			name:    "negative written off amount fails",
+			mutate:  func(a *PayAdvance) { a.WrittenOffMinor = -1 },
+			wantErr: true,
+		},
+		{
+			name: "recovered plus written off exceeding amount fails",
+			mutate: func(a *PayAdvance) {
+				a.RecoveredMinor = 30_000
+				a.WrittenOffMinor = 30_000
+			},
+			wantErr: true,
+		},
+		{
+			name: "recovered plus written off equal to amount passes",
+			mutate: func(a *PayAdvance) {
+				a.Status = AdvanceStatusRecovered
+				a.RecoveredMinor = 30_000
+				a.WrittenOffMinor = 20_000
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			entity := validPayAdvance()
+			tt.mutate(&entity)
+			multiErr := errortypes.NewMultiError()
+			entity.Validate(multiErr)
+			assert.Equal(t, tt.wantErr, multiErr.HasErrors())
+		})
+	}
+}
+
+func TestPayAdvance_OutstandingMinor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		amount     int64
+		recovered  int64
+		writtenOff int64
+		want       int64
+	}{
+		{name: "nothing recovered", amount: 50_000, want: 50_000},
+		{name: "partially recovered", amount: 50_000, recovered: 20_000, want: 30_000},
+		{
+			name:       "recovered and written off",
+			amount:     50_000,
+			recovered:  20_000,
+			writtenOff: 10_000,
+			want:       20_000,
+		},
+		{name: "fully recovered", amount: 50_000, recovered: 50_000, want: 0},
+		{name: "over recovered clamps at zero", amount: 50_000, recovered: 60_000, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			advance := PayAdvance{
+				AmountMinor:     tt.amount,
+				RecoveredMinor:  tt.recovered,
+				WrittenOffMinor: tt.writtenOff,
+			}
+			assert.Equal(t, tt.want, advance.OutstandingMinor())
+		})
+	}
+}
+
+func TestPayAdvance_SyncStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		amount     int64
+		recovered  int64
+		writtenOff int64
+		want       AdvanceStatus
+	}{
+		{name: "untouched advance is outstanding", amount: 50_000, want: AdvanceStatusOutstanding},
+		{
+			name:      "partial recovery",
+			amount:    50_000,
+			recovered: 20_000,
+			want:      AdvanceStatusPartiallyRecovered,
+		},
+		{
+			name:      "full recovery",
+			amount:    50_000,
+			recovered: 50_000,
+			want:      AdvanceStatusRecovered,
+		},
+		{
+			name:       "full write off",
+			amount:     50_000,
+			writtenOff: 50_000,
+			want:       AdvanceStatusWrittenOff,
+		},
+		{
+			name:       "recovery then write off of the remainder",
+			amount:     50_000,
+			recovered:  30_000,
+			writtenOff: 20_000,
+			want:       AdvanceStatusWrittenOff,
+		},
+		{
+			name:       "partial write off still partially recovered",
+			amount:     50_000,
+			recovered:  10_000,
+			writtenOff: 10_000,
+			want:       AdvanceStatusPartiallyRecovered,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			advance := PayAdvance{
+				AmountMinor:     tt.amount,
+				RecoveredMinor:  tt.recovered,
+				WrittenOffMinor: tt.writtenOff,
+			}
+			advance.SyncStatus()
+			assert.Equal(t, tt.want, advance.Status)
+		})
+	}
+}

--- a/services/tms/internal/core/domain/driverpay/assignment_test.go
+++ b/services/tms/internal/core/domain/driverpay/assignment_test.go
@@ -114,7 +114,10 @@ func TestWorkerPayAssignment_Validate(t *testing.T) {
 			name: "valid overrides pass",
 			mutate: func(a *WorkerPayAssignment) {
 				a.RateOverrides = []RateOverride{
-					{ComponentID: componentID, Rate: decimal.NewFromFloat(0.62)},
+					{
+						ComponentID: componentID,
+						Rate:        decimal.NewFromFloat(0.62),
+					},
 					{ComponentID: pulid.MustNew("dppc_"), Rate: decimal.Zero},
 				}
 			},

--- a/services/tms/internal/core/domain/driverpay/assignment_test.go
+++ b/services/tms/internal/core/domain/driverpay/assignment_test.go
@@ -1,0 +1,173 @@
+package driverpay
+
+import (
+	"testing"
+
+	"github.com/emoss08/trenova/pkg/errortypes"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func validAssignment() WorkerPayAssignment {
+	return WorkerPayAssignment{
+		ID:             pulid.MustNew("wpa_"),
+		BusinessUnitID: pulid.MustNew("bu_"),
+		OrganizationID: pulid.MustNew("org_"),
+		WorkerID:       pulid.MustNew("wrk_"),
+		PayProfileID:   pulid.MustNew("dpp_"),
+		EffectiveFrom:  1_700_000_000,
+		SplitPercent:   decimal.NewFromInt(100),
+	}
+}
+
+func TestWorkerPayAssignment_Validate(t *testing.T) {
+	t.Parallel()
+
+	endBeforeStart := int64(1_600_000_000)
+	endAtStart := int64(1_700_000_000)
+	endAfterStart := int64(1_800_000_000)
+	componentID := pulid.MustNew("dppc_")
+
+	tests := []struct {
+		name    string
+		mutate  func(a *WorkerPayAssignment)
+		wantErr bool
+	}{
+		{
+			name:    "valid assignment passes",
+			mutate:  func(a *WorkerPayAssignment) {},
+			wantErr: false,
+		},
+		{
+			name:    "missing worker fails",
+			mutate:  func(a *WorkerPayAssignment) { a.WorkerID = "" },
+			wantErr: true,
+		},
+		{
+			name:    "missing pay profile fails",
+			mutate:  func(a *WorkerPayAssignment) { a.PayProfileID = "" },
+			wantErr: true,
+		},
+		{
+			name:    "missing effective from fails",
+			mutate:  func(a *WorkerPayAssignment) { a.EffectiveFrom = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "effective to before effective from fails",
+			mutate:  func(a *WorkerPayAssignment) { a.EffectiveTo = &endBeforeStart },
+			wantErr: true,
+		},
+		{
+			name:    "effective to equal to effective from fails",
+			mutate:  func(a *WorkerPayAssignment) { a.EffectiveTo = &endAtStart },
+			wantErr: true,
+		},
+		{
+			name:    "effective to after effective from passes",
+			mutate:  func(a *WorkerPayAssignment) { a.EffectiveTo = &endAfterStart },
+			wantErr: false,
+		},
+		{
+			name:    "zero split percent fails",
+			mutate:  func(a *WorkerPayAssignment) { a.SplitPercent = decimal.Zero },
+			wantErr: true,
+		},
+		{
+			name:    "negative split percent fails",
+			mutate:  func(a *WorkerPayAssignment) { a.SplitPercent = decimal.NewFromInt(-1) },
+			wantErr: true,
+		},
+		{
+			name:    "split percent above 100 fails",
+			mutate:  func(a *WorkerPayAssignment) { a.SplitPercent = decimal.NewFromFloat(100.01) },
+			wantErr: true,
+		},
+		{
+			name: "override without component fails",
+			mutate: func(a *WorkerPayAssignment) {
+				a.RateOverrides = []RateOverride{{Rate: decimal.NewFromFloat(0.5)}}
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate override component fails",
+			mutate: func(a *WorkerPayAssignment) {
+				a.RateOverrides = []RateOverride{
+					{ComponentID: componentID, Rate: decimal.NewFromFloat(0.5)},
+					{ComponentID: componentID, Rate: decimal.NewFromFloat(0.6)},
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative override rate fails",
+			mutate: func(a *WorkerPayAssignment) {
+				a.RateOverrides = []RateOverride{
+					{ComponentID: componentID, Rate: decimal.NewFromInt(-1)},
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid overrides pass",
+			mutate: func(a *WorkerPayAssignment) {
+				a.RateOverrides = []RateOverride{
+					{ComponentID: componentID, Rate: decimal.NewFromFloat(0.62)},
+					{ComponentID: pulid.MustNew("dppc_"), Rate: decimal.Zero},
+				}
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			entity := validAssignment()
+			tt.mutate(&entity)
+			multiErr := errortypes.NewMultiError()
+			entity.Validate(multiErr)
+			assert.Equal(t, tt.wantErr, multiErr.HasErrors())
+		})
+	}
+}
+
+func TestWorkerPayAssignment_OverrideFor(t *testing.T) {
+	t.Parallel()
+
+	componentID := pulid.MustNew("dppc_")
+	assignment := WorkerPayAssignment{
+		RateOverrides: []RateOverride{
+			{ComponentID: componentID, Rate: decimal.NewFromFloat(0.62)},
+		},
+	}
+
+	rate, found := assignment.OverrideFor(componentID)
+	assert.True(t, found)
+	assert.Equal(t, "0.62", rate.String())
+
+	rate, found = assignment.OverrideFor(pulid.MustNew("dppc_"))
+	assert.False(t, found)
+	assert.True(t, rate.IsZero())
+}
+
+func TestWorkerPayAssignment_IsEffectiveAt(t *testing.T) {
+	t.Parallel()
+
+	from := int64(1_700_000_000)
+	to := int64(1_800_000_000)
+
+	openEnded := WorkerPayAssignment{EffectiveFrom: from}
+	assert.False(t, openEnded.IsEffectiveAt(from-1))
+	assert.True(t, openEnded.IsEffectiveAt(from))
+	assert.True(t, openEnded.IsEffectiveAt(from+1_000_000_000))
+
+	bounded := WorkerPayAssignment{EffectiveFrom: from, EffectiveTo: &to}
+	assert.False(t, bounded.IsEffectiveAt(from-1))
+	assert.True(t, bounded.IsEffectiveAt(from))
+	assert.True(t, bounded.IsEffectiveAt(to-1))
+	assert.False(t, bounded.IsEffectiveAt(to))
+	assert.False(t, bounded.IsEffectiveAt(to+1))
+}

--- a/services/tms/internal/core/domain/driverpay/escrow_test.go
+++ b/services/tms/internal/core/domain/driverpay/escrow_test.go
@@ -1,0 +1,260 @@
+package driverpay
+
+import (
+	"testing"
+
+	"github.com/emoss08/trenova/pkg/errortypes"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func validEscrowAccount() EscrowAccount {
+	return EscrowAccount{
+		ID:                 pulid.MustNew("escr_"),
+		BusinessUnitID:     pulid.MustNew("bu_"),
+		OrganizationID:     pulid.MustNew("org_"),
+		WorkerID:           pulid.MustNew("wrk_"),
+		Status:             EscrowAccountStatusActive,
+		TargetAmountMinor:  500_000,
+		BalanceMinor:       0,
+		AnnualInterestRate: decimal.NewFromFloat(2.5),
+		OpenedDate:         1_700_000_000,
+		CurrencyCode:       "USD",
+	}
+}
+
+func TestEscrowAccount_Validate(t *testing.T) {
+	t.Parallel()
+
+	closedBeforeOpened := int64(1_600_000_000)
+	closedAfterOpened := int64(1_800_000_000)
+
+	tests := []struct {
+		name    string
+		mutate  func(e *EscrowAccount)
+		wantErr bool
+	}{
+		{
+			name:    "valid account passes",
+			mutate:  func(e *EscrowAccount) {},
+			wantErr: false,
+		},
+		{
+			name:    "missing worker fails",
+			mutate:  func(e *EscrowAccount) { e.WorkerID = "" },
+			wantErr: true,
+		},
+		{
+			name:    "missing opened date fails",
+			mutate:  func(e *EscrowAccount) { e.OpenedDate = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "missing currency code fails",
+			mutate:  func(e *EscrowAccount) { e.CurrencyCode = "" },
+			wantErr: true,
+		},
+		{
+			name:    "currency code longer than three characters fails",
+			mutate:  func(e *EscrowAccount) { e.CurrencyCode = "USDX" },
+			wantErr: true,
+		},
+		{
+			name:    "invalid status fails",
+			mutate:  func(e *EscrowAccount) { e.Status = "Frozen" },
+			wantErr: true,
+		},
+		{
+			name:    "negative target amount fails",
+			mutate:  func(e *EscrowAccount) { e.TargetAmountMinor = -1 },
+			wantErr: true,
+		},
+		{
+			name:    "negative interest rate fails",
+			mutate:  func(e *EscrowAccount) { e.AnnualInterestRate = decimal.NewFromInt(-1) },
+			wantErr: true,
+		},
+		{
+			name:    "interest rate above 100 fails",
+			mutate:  func(e *EscrowAccount) { e.AnnualInterestRate = decimal.NewFromFloat(100.01) },
+			wantErr: true,
+		},
+		{
+			name:    "closed date before opened date fails",
+			mutate:  func(e *EscrowAccount) { e.ClosedDate = &closedBeforeOpened },
+			wantErr: true,
+		},
+		{
+			name:    "closed date after opened date passes",
+			mutate:  func(e *EscrowAccount) { e.ClosedDate = &closedAfterOpened },
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			entity := validEscrowAccount()
+			tt.mutate(&entity)
+			multiErr := errortypes.NewMultiError()
+			entity.Validate(multiErr)
+			assert.Equal(t, tt.wantErr, multiErr.HasErrors())
+		})
+	}
+}
+
+func TestEscrowTransaction_Validate(t *testing.T) {
+	t.Parallel()
+
+	valid := func() EscrowTransaction {
+		return EscrowTransaction{
+			ID:              pulid.MustNew("esctx_"),
+			BusinessUnitID:  pulid.MustNew("bu_"),
+			OrganizationID:  pulid.MustNew("org_"),
+			EscrowAccountID: pulid.MustNew("escr_"),
+			Type:            EscrowTransactionTypeContribution,
+			AmountMinor:     10_000,
+			OccurredDate:    1_700_000_000,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(tx *EscrowTransaction)
+		wantErr bool
+	}{
+		{
+			name:    "valid contribution passes",
+			mutate:  func(tx *EscrowTransaction) {},
+			wantErr: false,
+		},
+		{
+			name:    "invalid type fails",
+			mutate:  func(tx *EscrowTransaction) { tx.Type = "Transfer" },
+			wantErr: true,
+		},
+		{
+			name:    "missing escrow account fails",
+			mutate:  func(tx *EscrowTransaction) { tx.EscrowAccountID = "" },
+			wantErr: true,
+		},
+		{
+			name:    "zero amount fails",
+			mutate:  func(tx *EscrowTransaction) { tx.AmountMinor = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "missing occurred date fails",
+			mutate:  func(tx *EscrowTransaction) { tx.OccurredDate = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "negative contribution fails",
+			mutate:  func(tx *EscrowTransaction) { tx.AmountMinor = -1 },
+			wantErr: true,
+		},
+		{
+			name: "negative interest accrual fails",
+			mutate: func(tx *EscrowTransaction) {
+				tx.Type = EscrowTransactionTypeInterestAccrual
+				tx.AmountMinor = -1
+			},
+			wantErr: true,
+		},
+		{
+			name: "positive application fails",
+			mutate: func(tx *EscrowTransaction) {
+				tx.Type = EscrowTransactionTypeApplication
+				tx.AmountMinor = 500
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative application passes",
+			mutate: func(tx *EscrowTransaction) {
+				tx.Type = EscrowTransactionTypeApplication
+				tx.AmountMinor = -500
+			},
+			wantErr: false,
+		},
+		{
+			name: "positive refund fails",
+			mutate: func(tx *EscrowTransaction) {
+				tx.Type = EscrowTransactionTypeRefund
+				tx.AmountMinor = 500
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative refund passes",
+			mutate: func(tx *EscrowTransaction) {
+				tx.Type = EscrowTransactionTypeRefund
+				tx.AmountMinor = -500
+			},
+			wantErr: false,
+		},
+		{
+			name: "positive adjustment passes",
+			mutate: func(tx *EscrowTransaction) {
+				tx.Type = EscrowTransactionTypeAdjustment
+				tx.AmountMinor = 500
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative adjustment passes",
+			mutate: func(tx *EscrowTransaction) {
+				tx.Type = EscrowTransactionTypeAdjustment
+				tx.AmountMinor = -500
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tx := valid()
+			tt.mutate(&tx)
+			multiErr := errortypes.NewMultiError()
+			tx.Validate(multiErr)
+			assert.Equal(t, tt.wantErr, multiErr.HasErrors())
+		})
+	}
+}
+
+func TestEscrowAccount_FundedPercent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		target  int64
+		balance int64
+		want    string
+	}{
+		{name: "zero target returns zero", target: 0, balance: 100, want: "0"},
+		{name: "negative target returns zero", target: -100, balance: 100, want: "0"},
+		{name: "half funded", target: 500_000, balance: 250_000, want: "50"},
+		{name: "fully funded", target: 500_000, balance: 500_000, want: "100"},
+		{name: "over funded exceeds 100", target: 500_000, balance: 750_000, want: "150"},
+		{name: "rounds to two decimals", target: 300, balance: 100, want: "33.33"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			account := EscrowAccount{TargetAmountMinor: tt.target, BalanceMinor: tt.balance}
+			assert.Equal(t, tt.want, account.FundedPercent().String())
+		})
+	}
+}
+
+func TestEscrowAccount_IsFullyFunded(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, (&EscrowAccount{TargetAmountMinor: 0, BalanceMinor: 100}).IsFullyFunded())
+	assert.False(t, (&EscrowAccount{TargetAmountMinor: 500, BalanceMinor: 499}).IsFullyFunded())
+	assert.True(t, (&EscrowAccount{TargetAmountMinor: 500, BalanceMinor: 500}).IsFullyFunded())
+	assert.True(t, (&EscrowAccount{TargetAmountMinor: 500, BalanceMinor: 600}).IsFullyFunded())
+}

--- a/services/tms/internal/core/domain/driverpay/escrow_test.go
+++ b/services/tms/internal/core/domain/driverpay/escrow_test.go
@@ -244,7 +244,10 @@ func TestEscrowAccount_FundedPercent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			account := EscrowAccount{TargetAmountMinor: tt.target, BalanceMinor: tt.balance}
+			account := EscrowAccount{
+				TargetAmountMinor: tt.target,
+				BalanceMinor:      tt.balance,
+			}
 			assert.Equal(t, tt.want, account.FundedPercent().String())
 		})
 	}

--- a/services/tms/internal/core/domain/driverpay/paycode_test.go
+++ b/services/tms/internal/core/domain/driverpay/paycode_test.go
@@ -1,0 +1,176 @@
+package driverpay
+
+import (
+	"testing"
+
+	"github.com/emoss08/trenova/pkg/domaintypes"
+	"github.com/emoss08/trenova/pkg/errortypes"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/stretchr/testify/assert"
+)
+
+func validPayCode() PayCode {
+	return PayCode{
+		ID:             pulid.MustNew("payc_"),
+		BusinessUnitID: pulid.MustNew("bu_"),
+		OrganizationID: pulid.MustNew("org_"),
+		Status:         domaintypes.StatusActive,
+		Direction:      PayCodeDirectionEarning,
+		Code:           "SAFETY",
+		Name:           "Safety Bonus",
+		Taxable:        true,
+	}
+}
+
+func TestPayCode_Validate(t *testing.T) {
+	t.Parallel()
+
+	invalidDefault := int64(0)
+	validDefault := int64(2_500)
+
+	tests := []struct {
+		name    string
+		mutate  func(p *PayCode)
+		wantErr bool
+	}{
+		{
+			name:    "valid pay code passes",
+			mutate:  func(p *PayCode) {},
+			wantErr: false,
+		},
+		{
+			name:    "code with digits dashes and underscores passes",
+			mutate:  func(p *PayCode) { p.Code = "9TRK-LEASE_2" },
+			wantErr: false,
+		},
+		{
+			name:    "missing code fails",
+			mutate:  func(p *PayCode) { p.Code = "" },
+			wantErr: true,
+		},
+		{
+			name:    "lowercase code fails",
+			mutate:  func(p *PayCode) { p.Code = "safety" },
+			wantErr: true,
+		},
+		{
+			name:    "code starting with dash fails",
+			mutate:  func(p *PayCode) { p.Code = "-SAFETY" },
+			wantErr: true,
+		},
+		{
+			name:    "code with spaces fails",
+			mutate:  func(p *PayCode) { p.Code = "SAFETY BONUS" },
+			wantErr: true,
+		},
+		{
+			name:    "code longer than 20 characters fails",
+			mutate:  func(p *PayCode) { p.Code = "ABCDEFGHIJKLMNOPQRSTU" },
+			wantErr: true,
+		},
+		{
+			name:    "missing name fails",
+			mutate:  func(p *PayCode) { p.Name = "" },
+			wantErr: true,
+		},
+		{
+			name:    "invalid direction fails",
+			mutate:  func(p *PayCode) { p.Direction = "Both" },
+			wantErr: true,
+		},
+		{
+			name:    "non active or inactive status fails",
+			mutate:  func(p *PayCode) { p.Status = "Archived" },
+			wantErr: true,
+		},
+		{
+			name:    "inactive status passes",
+			mutate:  func(p *PayCode) { p.Status = domaintypes.StatusInactive },
+			wantErr: false,
+		},
+		{
+			name:    "non positive default amount fails",
+			mutate:  func(p *PayCode) { p.DefaultAmountMinor = &invalidDefault },
+			wantErr: true,
+		},
+		{
+			name:    "positive default amount passes",
+			mutate:  func(p *PayCode) { p.DefaultAmountMinor = &validDefault },
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			entity := validPayCode()
+			tt.mutate(&entity)
+			multiErr := errortypes.NewMultiError()
+			entity.Validate(multiErr)
+			assert.Equal(t, tt.wantErr, multiErr.HasErrors())
+		})
+	}
+}
+
+func TestPayCode_LineIsReimbursement(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		direction PayCodeDirection
+		taxable   bool
+		want      bool
+	}{
+		{
+			name:      "non taxable earning is a reimbursement",
+			direction: PayCodeDirectionEarning,
+			taxable:   false,
+			want:      true,
+		},
+		{
+			name:      "taxable earning is not",
+			direction: PayCodeDirectionEarning,
+			taxable:   true,
+			want:      false,
+		},
+		{
+			name:      "non taxable deduction is not",
+			direction: PayCodeDirectionDeduction,
+			taxable:   false,
+			want:      false,
+		},
+		{
+			name:      "taxable deduction is not",
+			direction: PayCodeDirectionDeduction,
+			taxable:   true,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			code := PayCode{Direction: tt.direction, Taxable: tt.taxable}
+			assert.Equal(t, tt.want, code.LineIsReimbursement())
+		})
+	}
+}
+
+func TestSystemPayCodes(t *testing.T) {
+	t.Parallel()
+
+	codes := SystemPayCodes()
+	assert.NotEmpty(t, codes)
+
+	seen := make(map[string]struct{}, len(codes))
+	for _, code := range codes {
+		assert.True(t, code.Direction.IsValid(), "direction for %s must be valid", code.Code)
+		assert.Regexp(t, payCodePattern, code.Code)
+		assert.NotEmpty(t, code.Name)
+
+		key := code.Direction.String() + ":" + code.Code
+		_, dup := seen[key]
+		assert.False(t, dup, "duplicate system pay code %s", key)
+		seen[key] = struct{}{}
+	}
+}

--- a/services/tms/internal/core/domain/driverpay/paycode_test.go
+++ b/services/tms/internal/core/domain/driverpay/paycode_test.go
@@ -164,7 +164,12 @@ func TestSystemPayCodes(t *testing.T) {
 
 	seen := make(map[string]struct{}, len(codes))
 	for _, code := range codes {
-		assert.True(t, code.Direction.IsValid(), "direction for %s must be valid", code.Code)
+		assert.True(
+			t,
+			code.Direction.IsValid(),
+			"direction for %s must be valid",
+			code.Code,
+		)
 		assert.Regexp(t, payCodePattern, code.Code)
 		assert.NotEmpty(t, code.Name)
 

--- a/services/tms/internal/core/domain/driverpay/payprofile.go
+++ b/services/tms/internal/core/domain/driverpay/payprofile.go
@@ -79,9 +79,11 @@ const searchFieldDescription = "description"
 
 func (p *PayProfile) Validate(multiErr *errortypes.MultiError) {
 	multiErr.AddOzzoError(validation.ValidateStruct(p,
-		validation.Field(&p.Name,
+		validation.Field(
+			&p.Name,
 			validation.Required.Error("Name is required"),
-			validation.Length(1, 100).Error("Name must be between 1 and 100 characters"),
+			validation.Length(1, 100).
+				Error("Name must be between 1 and 100 characters"),
 		),
 		validation.Field(&p.CurrencyCode,
 			validation.Required.Error("Currency code is required"),
@@ -287,7 +289,11 @@ func (p *PayProfile) GetPostgresSearchConfig() domaintypes.PostgresSearchConfig 
 		TableAlias:      "dpp",
 		UseSearchVector: false,
 		SearchableFields: []domaintypes.SearchableField{
-			{Name: "name", Type: domaintypes.FieldTypeText, Weight: domaintypes.SearchWeightA},
+			{
+				Name:   "name",
+				Type:   domaintypes.FieldTypeText,
+				Weight: domaintypes.SearchWeightA,
+			},
 			{
 				Name:   searchFieldDescription,
 				Type:   domaintypes.FieldTypeText,

--- a/services/tms/internal/core/domain/driverpay/payprofile.go
+++ b/services/tms/internal/core/domain/driverpay/payprofile.go
@@ -239,7 +239,7 @@ func (c *PayProfileComponent) validateBands(multiErr *errortypes.MultiError) {
 			multiErr.Add("bands", errortypes.ErrInvalid, "Band rate cannot be negative")
 			return
 		}
-		if band.MinMiles <= prevMax {
+		if band.MinMiles < prevMax {
 			multiErr.Add(
 				"bands",
 				errortypes.ErrInvalid,

--- a/services/tms/internal/core/domain/driverpay/payprofile_test.go
+++ b/services/tms/internal/core/domain/driverpay/payprofile_test.go
@@ -186,7 +186,11 @@ func TestPayProfileComponent_Validate(t *testing.T) {
 			mutate: func(c *PayProfileComponent) {
 				c.Method = CalcMethodFlatPerShipment
 				c.Bands = []MileageBand{
-					{MinMiles: 0, MaxMiles: 100, Rate: decimal.NewFromFloat(0.5)},
+					{
+						MinMiles: 0,
+						MaxMiles: 100,
+						Rate:     decimal.NewFromFloat(0.5),
+					},
 				}
 			},
 			wantErr: true,
@@ -265,8 +269,10 @@ func TestPayProfileComponent_ValidateBands(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "negative band rate fails",
-			bands:   []MileageBand{{MinMiles: 0, MaxMiles: 100, Rate: decimal.NewFromInt(-1)}},
+			name: "negative band rate fails",
+			bands: []MileageBand{
+				{MinMiles: 0, MaxMiles: 100, Rate: decimal.NewFromInt(-1)},
+			},
 			wantErr: true,
 		},
 		{
@@ -343,23 +349,30 @@ func TestPayProfileComponent_ResolveMileageRate(t *testing.T) {
 		)
 	})
 
-	t.Run("miles outside every closed band fall back to the component rate", func(t *testing.T) {
-		t.Parallel()
-		closed := &PayProfileComponent{
-			Rate: fallback,
-			Bands: []MileageBand{
-				{MinMiles: 100, MaxMiles: 200, Rate: decimal.NewFromFloat(0.50)},
-			},
-		}
-		assert.Equal(
-			t,
-			fallback.String(),
-			closed.ResolveMileageRate(decimal.NewFromInt(50)).String(),
-		)
-		assert.Equal(
-			t,
-			fallback.String(),
-			closed.ResolveMileageRate(decimal.NewFromInt(300)).String(),
-		)
-	})
+	t.Run(
+		"miles outside every closed band fall back to the component rate",
+		func(t *testing.T) {
+			t.Parallel()
+			closed := &PayProfileComponent{
+				Rate: fallback,
+				Bands: []MileageBand{
+					{
+						MinMiles: 100,
+						MaxMiles: 200,
+						Rate:     decimal.NewFromFloat(0.50),
+					},
+				},
+			}
+			assert.Equal(
+				t,
+				fallback.String(),
+				closed.ResolveMileageRate(decimal.NewFromInt(50)).String(),
+			)
+			assert.Equal(
+				t,
+				fallback.String(),
+				closed.ResolveMileageRate(decimal.NewFromInt(300)).String(),
+			)
+		},
+	)
 }

--- a/services/tms/internal/core/domain/driverpay/payprofile_test.go
+++ b/services/tms/internal/core/domain/driverpay/payprofile_test.go
@@ -1,0 +1,365 @@
+package driverpay
+
+import (
+	"testing"
+
+	"github.com/emoss08/trenova/pkg/domaintypes"
+	"github.com/emoss08/trenova/pkg/errortypes"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func validComponent() *PayProfileComponent {
+	return &PayProfileComponent{
+		ID:             pulid.MustNew("dppc_"),
+		BusinessUnitID: pulid.MustNew("bu_"),
+		OrganizationID: pulid.MustNew("org_"),
+		PayProfileID:   pulid.MustNew("dpp_"),
+		Kind:           ComponentKindLinehaul,
+		Method:         CalcMethodPerLoadedMile,
+		Rate:           decimal.NewFromFloat(0.55),
+		IsActive:       true,
+	}
+}
+
+func validPayProfile() PayProfile {
+	return PayProfile{
+		ID:             pulid.MustNew("dpp_"),
+		BusinessUnitID: pulid.MustNew("bu_"),
+		OrganizationID: pulid.MustNew("org_"),
+		Status:         domaintypes.StatusActive,
+		Name:           "OTR Company Driver",
+		Classification: PayeeClassificationCompanyDriver,
+		CurrencyCode:   "USD",
+		Components:     []*PayProfileComponent{validComponent()},
+	}
+}
+
+func TestPayProfile_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(p *PayProfile)
+		wantErr bool
+	}{
+		{
+			name:    "valid profile passes",
+			mutate:  func(p *PayProfile) {},
+			wantErr: false,
+		},
+		{
+			name:    "missing name fails",
+			mutate:  func(p *PayProfile) { p.Name = "" },
+			wantErr: true,
+		},
+		{
+			name:    "invalid classification fails",
+			mutate:  func(p *PayProfile) { p.Classification = "LeaseOperator" },
+			wantErr: true,
+		},
+		{
+			name:    "negative guaranteed minimum fails",
+			mutate:  func(p *PayProfile) { p.GuaranteedPeriodMinimumMinor = -1 },
+			wantErr: true,
+		},
+		{
+			name:    "negative per diem rate fails",
+			mutate:  func(p *PayProfile) { p.PerDiemRatePerMile = decimal.NewFromInt(-1) },
+			wantErr: true,
+		},
+		{
+			name:    "negative per diem cap fails",
+			mutate:  func(p *PayProfile) { p.PerDiemDailyCapMinor = -1 },
+			wantErr: true,
+		},
+		{
+			name:    "no components fails",
+			mutate:  func(p *PayProfile) { p.Components = nil },
+			wantErr: true,
+		},
+		{
+			name:    "nil component fails",
+			mutate:  func(p *PayProfile) { p.Components = []*PayProfileComponent{nil} },
+			wantErr: true,
+		},
+		{
+			name: "invalid component surfaces through the profile",
+			mutate: func(p *PayProfile) {
+				p.Components[0].Method = "PerParsec"
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			entity := validPayProfile()
+			tt.mutate(&entity)
+			multiErr := errortypes.NewMultiError()
+			entity.Validate(multiErr)
+			assert.Equal(t, tt.wantErr, multiErr.HasErrors())
+		})
+	}
+}
+
+func TestPayProfileComponent_Validate(t *testing.T) {
+	t.Parallel()
+
+	minAmount := int64(10_000)
+	maxAmount := int64(5_000)
+
+	tests := []struct {
+		name    string
+		mutate  func(c *PayProfileComponent)
+		wantErr bool
+	}{
+		{
+			name:    "valid per mile component passes",
+			mutate:  func(c *PayProfileComponent) {},
+			wantErr: false,
+		},
+		{
+			name:    "invalid kind fails",
+			mutate:  func(c *PayProfileComponent) { c.Kind = "Parking" },
+			wantErr: true,
+		},
+		{
+			name: "custom kind without description fails",
+			mutate: func(c *PayProfileComponent) {
+				c.Kind = ComponentKindCustom
+				c.Description = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "custom kind with description passes",
+			mutate: func(c *PayProfileComponent) {
+				c.Kind = ComponentKindCustom
+				c.Description = "Northeast regional premium"
+			},
+			wantErr: false,
+		},
+		{
+			name: "percent of revenue without basis fails",
+			mutate: func(c *PayProfileComponent) {
+				c.Method = CalcMethodPercentOfRevenue
+				c.Rate = decimal.NewFromInt(25)
+			},
+			wantErr: true,
+		},
+		{
+			name: "percent of revenue above 100 fails",
+			mutate: func(c *PayProfileComponent) {
+				c.Method = CalcMethodPercentOfRevenue
+				c.RevenueBasis = RevenueBasisLinehaul
+				c.Rate = decimal.NewFromInt(101)
+			},
+			wantErr: true,
+		},
+		{
+			name: "percent of revenue with basis passes",
+			mutate: func(c *PayProfileComponent) {
+				c.Method = CalcMethodPercentOfRevenue
+				c.RevenueBasis = RevenueBasisTotalRevenue
+				c.Rate = decimal.NewFromInt(72)
+			},
+			wantErr: false,
+		},
+		{
+			name:    "negative per mile rate fails",
+			mutate:  func(c *PayProfileComponent) { c.Rate = decimal.NewFromInt(-1) },
+			wantErr: true,
+		},
+		{
+			name: "negative flat rate fails",
+			mutate: func(c *PayProfileComponent) {
+				c.Method = CalcMethodFlatPerShipment
+				c.Rate = decimal.NewFromInt(-1)
+			},
+			wantErr: true,
+		},
+		{
+			name: "bands on non per mile method fails",
+			mutate: func(c *PayProfileComponent) {
+				c.Method = CalcMethodFlatPerShipment
+				c.Bands = []MileageBand{
+					{MinMiles: 0, MaxMiles: 100, Rate: decimal.NewFromFloat(0.5)},
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name:    "negative free time fails",
+			mutate:  func(c *PayProfileComponent) { c.FreeTimeMinutes = -1 },
+			wantErr: true,
+		},
+		{
+			name: "detention with non hourly method fails",
+			mutate: func(c *PayProfileComponent) {
+				c.Kind = ComponentKindDetention
+				c.Method = CalcMethodPerDay
+			},
+			wantErr: true,
+		},
+		{
+			name: "detention with hourly method passes",
+			mutate: func(c *PayProfileComponent) {
+				c.Kind = ComponentKindDetention
+				c.Method = CalcMethodPerHour
+				c.Rate = decimal.NewFromInt(50)
+			},
+			wantErr: false,
+		},
+		{
+			name: "minimum above maximum fails",
+			mutate: func(c *PayProfileComponent) {
+				c.MinAmountMinor = &minAmount
+				c.MaxAmountMinor = &maxAmount
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			component := validComponent()
+			tt.mutate(component)
+			multiErr := errortypes.NewMultiError()
+			component.Validate(multiErr)
+			assert.Equal(t, tt.wantErr, multiErr.HasErrors())
+		})
+	}
+}
+
+func TestPayProfileComponent_ValidateBands(t *testing.T) {
+	t.Parallel()
+
+	rate := decimal.NewFromFloat(0.5)
+
+	tests := []struct {
+		name    string
+		bands   []MileageBand
+		wantErr bool
+	}{
+		{
+			name: "ascending bands with open end pass",
+			bands: []MileageBand{
+				{MinMiles: 0, MaxMiles: 500, Rate: rate},
+				{MinMiles: 500, MaxMiles: 1000, Rate: rate},
+				{MinMiles: 1000, MaxMiles: 0, Rate: rate},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "negative minimum fails",
+			bands:   []MileageBand{{MinMiles: -1, MaxMiles: 100, Rate: rate}},
+			wantErr: true,
+		},
+		{
+			name:    "maximum not above minimum fails",
+			bands:   []MileageBand{{MinMiles: 100, MaxMiles: 100, Rate: rate}},
+			wantErr: true,
+		},
+		{
+			name:    "negative band rate fails",
+			bands:   []MileageBand{{MinMiles: 0, MaxMiles: 100, Rate: decimal.NewFromInt(-1)}},
+			wantErr: true,
+		},
+		{
+			name: "overlapping bands fail",
+			bands: []MileageBand{
+				{MinMiles: 0, MaxMiles: 500, Rate: rate},
+				{MinMiles: 400, MaxMiles: 800, Rate: rate},
+			},
+			wantErr: true,
+		},
+		{
+			name: "open ended band before the last fails",
+			bands: []MileageBand{
+				{MinMiles: 0, MaxMiles: 0, Rate: rate},
+				{MinMiles: 500, MaxMiles: 1000, Rate: rate},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			component := validComponent()
+			component.Bands = tt.bands
+			multiErr := errortypes.NewMultiError()
+			component.Validate(multiErr)
+			assert.Equal(t, tt.wantErr, multiErr.HasErrors())
+		})
+	}
+}
+
+func TestPayProfileComponent_ResolveMileageRate(t *testing.T) {
+	t.Parallel()
+
+	fallback := decimal.NewFromFloat(0.40)
+	component := &PayProfileComponent{
+		Method: CalcMethodPerTotalMile,
+		Rate:   fallback,
+		Bands: []MileageBand{
+			{MinMiles: 0, MaxMiles: 500, Rate: decimal.NewFromFloat(0.50)},
+			{MinMiles: 500, MaxMiles: 1000, Rate: decimal.NewFromFloat(0.55)},
+			{MinMiles: 1000, MaxMiles: 0, Rate: decimal.NewFromFloat(0.60)},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		miles int64
+		want  string
+	}{
+		{name: "first band", miles: 100, want: "0.5"},
+		{name: "band boundary belongs to the next band", miles: 500, want: "0.55"},
+		{name: "second band", miles: 999, want: "0.55"},
+		{name: "open ended band", miles: 5000, want: "0.6"},
+		{name: "zero miles uses first band", miles: 0, want: "0.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := component.ResolveMileageRate(decimal.NewFromInt(tt.miles))
+			assert.Equal(t, tt.want, got.String())
+		})
+	}
+
+	t.Run("no bands falls back to the component rate", func(t *testing.T) {
+		t.Parallel()
+		flat := &PayProfileComponent{Rate: fallback}
+		assert.Equal(
+			t,
+			fallback.String(),
+			flat.ResolveMileageRate(decimal.NewFromInt(750)).String(),
+		)
+	})
+
+	t.Run("miles outside every closed band fall back to the component rate", func(t *testing.T) {
+		t.Parallel()
+		closed := &PayProfileComponent{
+			Rate: fallback,
+			Bands: []MileageBand{
+				{MinMiles: 100, MaxMiles: 200, Rate: decimal.NewFromFloat(0.50)},
+			},
+		}
+		assert.Equal(
+			t,
+			fallback.String(),
+			closed.ResolveMileageRate(decimal.NewFromInt(50)).String(),
+		)
+		assert.Equal(
+			t,
+			fallback.String(),
+			closed.ResolveMileageRate(decimal.NewFromInt(300)).String(),
+		)
+	})
+}

--- a/services/tms/internal/core/domain/driverpay/recurring_test.go
+++ b/services/tms/internal/core/domain/driverpay/recurring_test.go
@@ -53,7 +53,11 @@ func TestRecurringDeduction_Validate(t *testing.T) {
 		mutate  func(r *RecurringDeduction)
 		wantErr bool
 	}{
-		{name: "valid deduction passes", mutate: func(r *RecurringDeduction) {}, wantErr: false},
+		{
+			name:    "valid deduction passes",
+			mutate:  func(r *RecurringDeduction) {},
+			wantErr: false,
+		},
 		{
 			name:    "missing worker fails",
 			mutate:  func(r *RecurringDeduction) { r.WorkerID = "" },
@@ -188,7 +192,11 @@ func TestRecurringEarning_Validate(t *testing.T) {
 		mutate  func(r *RecurringEarning)
 		wantErr bool
 	}{
-		{name: "valid earning passes", mutate: func(r *RecurringEarning) {}, wantErr: false},
+		{
+			name:    "valid earning passes",
+			mutate:  func(r *RecurringEarning) {},
+			wantErr: false,
+		},
 		{
 			name:    "missing worker fails",
 			mutate:  func(r *RecurringEarning) { r.WorkerID = "" },

--- a/services/tms/internal/core/domain/driverpay/recurring_test.go
+++ b/services/tms/internal/core/domain/driverpay/recurring_test.go
@@ -1,0 +1,278 @@
+package driverpay
+
+import (
+	"testing"
+
+	"github.com/emoss08/trenova/pkg/errortypes"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/stretchr/testify/assert"
+)
+
+func validRecurringDeduction() RecurringDeduction {
+	return RecurringDeduction{
+		ID:             pulid.MustNew("rded_"),
+		BusinessUnitID: pulid.MustNew("bu_"),
+		OrganizationID: pulid.MustNew("org_"),
+		WorkerID:       pulid.MustNew("wrk_"),
+		PayCodeID:      pulid.MustNew("payc_"),
+		Status:         DeductionStatusActive,
+		Frequency:      DeductionFrequencyEverySettlement,
+		Description:    "Truck lease payment",
+		AmountMinor:    45_000,
+		StartDate:      1_700_000_000,
+		CurrencyCode:   "USD",
+	}
+}
+
+func validRecurringEarning() RecurringEarning {
+	return RecurringEarning{
+		ID:             pulid.MustNew("rern_"),
+		BusinessUnitID: pulid.MustNew("bu_"),
+		OrganizationID: pulid.MustNew("org_"),
+		WorkerID:       pulid.MustNew("wrk_"),
+		PayCodeID:      pulid.MustNew("payc_"),
+		Status:         EarningStatusActive,
+		Frequency:      EarningFrequencyEverySettlement,
+		Description:    "Longevity bonus",
+		AmountMinor:    10_000,
+		StartDate:      1_700_000_000,
+		CurrencyCode:   "USD",
+	}
+}
+
+func TestRecurringDeduction_Validate(t *testing.T) {
+	t.Parallel()
+
+	invalidCap := int64(0)
+	validCap := int64(500_000)
+	endBeforeStart := int64(1_600_000_000)
+	endAfterStart := int64(1_800_000_000)
+
+	tests := []struct {
+		name    string
+		mutate  func(r *RecurringDeduction)
+		wantErr bool
+	}{
+		{name: "valid deduction passes", mutate: func(r *RecurringDeduction) {}, wantErr: false},
+		{
+			name:    "missing worker fails",
+			mutate:  func(r *RecurringDeduction) { r.WorkerID = "" },
+			wantErr: true,
+		},
+		{
+			name:    "missing pay code fails",
+			mutate:  func(r *RecurringDeduction) { r.PayCodeID = "" },
+			wantErr: true,
+		},
+		{
+			name:    "missing description fails",
+			mutate:  func(r *RecurringDeduction) { r.Description = "" },
+			wantErr: true,
+		},
+		{
+			name:    "invalid status fails",
+			mutate:  func(r *RecurringDeduction) { r.Status = "Suspended" },
+			wantErr: true,
+		},
+		{
+			name:    "invalid frequency fails",
+			mutate:  func(r *RecurringDeduction) { r.Frequency = "Weekly" },
+			wantErr: true,
+		},
+		{
+			name:    "non positive amount fails",
+			mutate:  func(r *RecurringDeduction) { r.AmountMinor = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "non positive cap fails",
+			mutate:  func(r *RecurringDeduction) { r.TotalCapMinor = &invalidCap },
+			wantErr: true,
+		},
+		{
+			name:    "positive cap passes",
+			mutate:  func(r *RecurringDeduction) { r.TotalCapMinor = &validCap },
+			wantErr: false,
+		},
+		{
+			name:    "end date before start fails",
+			mutate:  func(r *RecurringDeduction) { r.EndDate = &endBeforeStart },
+			wantErr: true,
+		},
+		{
+			name:    "end date after start passes",
+			mutate:  func(r *RecurringDeduction) { r.EndDate = &endAfterStart },
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			entity := validRecurringDeduction()
+			tt.mutate(&entity)
+			multiErr := errortypes.NewMultiError()
+			entity.Validate(multiErr)
+			assert.Equal(t, tt.wantErr, multiErr.HasErrors())
+		})
+	}
+}
+
+func TestRecurringDeduction_CapMath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no cap yields nil remaining and full next amount", func(t *testing.T) {
+		t.Parallel()
+		deduction := validRecurringDeduction()
+		assert.Nil(t, deduction.RemainingCapMinor())
+		assert.Equal(t, deduction.AmountMinor, deduction.NextAmountMinor())
+	})
+
+	t.Run("remaining cap limits the next amount", func(t *testing.T) {
+		t.Parallel()
+		cap := int64(100_000)
+		deduction := validRecurringDeduction()
+		deduction.TotalCapMinor = &cap
+		deduction.DeductedToDateMinor = 80_000
+
+		remaining := deduction.RemainingCapMinor()
+		assert.NotNil(t, remaining)
+		assert.EqualValues(t, 20_000, *remaining)
+		assert.EqualValues(t, 20_000, deduction.NextAmountMinor())
+	})
+
+	t.Run("exhausted cap clamps at zero", func(t *testing.T) {
+		t.Parallel()
+		cap := int64(100_000)
+		deduction := validRecurringDeduction()
+		deduction.TotalCapMinor = &cap
+		deduction.DeductedToDateMinor = 120_000
+
+		remaining := deduction.RemainingCapMinor()
+		assert.NotNil(t, remaining)
+		assert.EqualValues(t, 0, *remaining)
+		assert.EqualValues(t, 0, deduction.NextAmountMinor())
+	})
+
+	t.Run("inactive deduction yields zero next amount", func(t *testing.T) {
+		t.Parallel()
+		deduction := validRecurringDeduction()
+		deduction.Status = DeductionStatusPaused
+		assert.EqualValues(t, 0, deduction.NextAmountMinor())
+	})
+}
+
+func TestRecurringDeduction_IsEscrowContribution(t *testing.T) {
+	t.Parallel()
+
+	deduction := validRecurringDeduction()
+	assert.False(t, deduction.IsEscrowContribution())
+
+	escrowID := pulid.MustNew("escr_")
+	deduction.EscrowAccountID = &escrowID
+	assert.True(t, deduction.IsEscrowContribution())
+
+	nilID := pulid.Nil
+	deduction.EscrowAccountID = &nilID
+	assert.False(t, deduction.IsEscrowContribution())
+}
+
+func TestRecurringEarning_Validate(t *testing.T) {
+	t.Parallel()
+
+	invalidCap := int64(-1)
+	endBeforeStart := int64(1_600_000_000)
+
+	tests := []struct {
+		name    string
+		mutate  func(r *RecurringEarning)
+		wantErr bool
+	}{
+		{name: "valid earning passes", mutate: func(r *RecurringEarning) {}, wantErr: false},
+		{
+			name:    "missing worker fails",
+			mutate:  func(r *RecurringEarning) { r.WorkerID = "" },
+			wantErr: true,
+		},
+		{
+			name:    "invalid status fails",
+			mutate:  func(r *RecurringEarning) { r.Status = "Suspended" },
+			wantErr: true,
+		},
+		{
+			name:    "invalid frequency fails",
+			mutate:  func(r *RecurringEarning) { r.Frequency = "Weekly" },
+			wantErr: true,
+		},
+		{
+			name:    "non positive amount fails",
+			mutate:  func(r *RecurringEarning) { r.AmountMinor = -5 },
+			wantErr: true,
+		},
+		{
+			name:    "negative cap fails",
+			mutate:  func(r *RecurringEarning) { r.TotalCapMinor = &invalidCap },
+			wantErr: true,
+		},
+		{
+			name:    "end date before start fails",
+			mutate:  func(r *RecurringEarning) { r.EndDate = &endBeforeStart },
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			entity := validRecurringEarning()
+			tt.mutate(&entity)
+			multiErr := errortypes.NewMultiError()
+			entity.Validate(multiErr)
+			assert.Equal(t, tt.wantErr, multiErr.HasErrors())
+		})
+	}
+}
+
+func TestRecurringEarning_CapMath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no cap yields nil remaining and full next amount", func(t *testing.T) {
+		t.Parallel()
+		earning := validRecurringEarning()
+		assert.Nil(t, earning.RemainingCapMinor())
+		assert.Equal(t, earning.AmountMinor, earning.NextAmountMinor())
+	})
+
+	t.Run("remaining cap limits the next amount", func(t *testing.T) {
+		t.Parallel()
+		cap := int64(25_000)
+		earning := validRecurringEarning()
+		earning.TotalCapMinor = &cap
+		earning.PaidToDateMinor = 20_000
+
+		remaining := earning.RemainingCapMinor()
+		assert.NotNil(t, remaining)
+		assert.EqualValues(t, 5_000, *remaining)
+		assert.EqualValues(t, 5_000, earning.NextAmountMinor())
+	})
+
+	t.Run("exhausted cap clamps at zero", func(t *testing.T) {
+		t.Parallel()
+		cap := int64(25_000)
+		earning := validRecurringEarning()
+		earning.TotalCapMinor = &cap
+		earning.PaidToDateMinor = 30_000
+
+		remaining := earning.RemainingCapMinor()
+		assert.NotNil(t, remaining)
+		assert.EqualValues(t, 0, *remaining)
+		assert.EqualValues(t, 0, earning.NextAmountMinor())
+	})
+
+	t.Run("paused earning yields zero next amount", func(t *testing.T) {
+		t.Parallel()
+		earning := validRecurringEarning()
+		earning.Status = EarningStatusPaused
+		assert.EqualValues(t, 0, earning.NextAmountMinor())
+	})
+}

--- a/services/tms/internal/core/services/driverpayservice/assignment_advance_test.go
+++ b/services/tms/internal/core/services/driverpayservice/assignment_advance_test.go
@@ -1,0 +1,379 @@
+package driverpayservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/emoss08/trenova/internal/core/domain/driverpay"
+	"github.com/emoss08/trenova/internal/core/ports/repositories"
+	"github.com/emoss08/trenova/pkg/pagination"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/emoss08/trenova/shared/timeutils"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newAssignmentEntity() *driverpay.WorkerPayAssignment {
+	return &driverpay.WorkerPayAssignment{
+		BusinessUnitID: pulid.MustNew("bu_"),
+		OrganizationID: pulid.MustNew("org_"),
+		WorkerID:       pulid.MustNew("wrk_"),
+		PayProfileID:   pulid.MustNew("dpp_"),
+		EffectiveFrom:  1_700_000_000,
+		SplitPercent:   decimal.NewFromInt(100),
+	}
+}
+
+func profileForAssignment(
+	entity *driverpay.WorkerPayAssignment,
+	componentIDs ...pulid.ID,
+) *driverpay.PayProfile {
+	components := make([]*driverpay.PayProfileComponent, 0, len(componentIDs))
+	for _, id := range componentIDs {
+		components = append(components, &driverpay.PayProfileComponent{
+			ID:     id,
+			Kind:   driverpay.ComponentKindLinehaul,
+			Method: driverpay.CalcMethodPerLoadedMile,
+			Rate:   decimal.NewFromFloat(0.55),
+		})
+	}
+	return &driverpay.PayProfile{
+		ID:             entity.PayProfileID,
+		BusinessUnitID: entity.BusinessUnitID,
+		OrganizationID: entity.OrganizationID,
+		Name:           "OTR",
+		Components:     components,
+	}
+}
+
+func TestAssignProfileToWorker_RejectsOverrideForForeignComponent(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	entity := newAssignmentEntity()
+	entity.RateOverrides = []driverpay.RateOverride{
+		{ComponentID: pulid.MustNew("dppc_"), Rate: decimal.NewFromFloat(0.6)},
+	}
+	profile := profileForAssignment(entity, pulid.MustNew("dppc_"))
+
+	svc.profileRepo = &fakeProfileRepo{
+		getByID: func(context.Context, repositories.GetPayProfileByIDRequest) (*driverpay.PayProfile, error) {
+			return profile, nil
+		},
+	}
+
+	_, err := svc.AssignProfileToWorker(t.Context(), entity, testActor())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not belong")
+}
+
+func TestAssignProfileToWorker_RejectsLaterExistingAssignment(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	entity := newAssignmentEntity()
+	profile := profileForAssignment(entity)
+
+	svc.profileRepo = &fakeProfileRepo{
+		getByID: func(context.Context, repositories.GetPayProfileByIDRequest) (*driverpay.PayProfile, error) {
+			return profile, nil
+		},
+	}
+	svc.assignmentRepo = &fakeAssignmentRepo{
+		listOverlapping: func(context.Context, *driverpay.WorkerPayAssignment) ([]*driverpay.WorkerPayAssignment, error) {
+			return []*driverpay.WorkerPayAssignment{
+				{EffectiveFrom: entity.EffectiveFrom + 100},
+			}, nil
+		},
+	}
+
+	_, err := svc.AssignProfileToWorker(t.Context(), entity, testActor())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "starting on or after")
+}
+
+func TestAssignProfileToWorker_EndsEarlierOpenAssignment(t *testing.T) {
+	t.Parallel()
+	svc, audit := newTestService()
+
+	entity := newAssignmentEntity()
+	profile := profileForAssignment(entity)
+	existing := &driverpay.WorkerPayAssignment{
+		ID:            pulid.MustNew("wpa_"),
+		WorkerID:      entity.WorkerID,
+		EffectiveFrom: entity.EffectiveFrom - 10_000,
+	}
+
+	var endedAssignment *driverpay.WorkerPayAssignment
+	var created *driverpay.WorkerPayAssignment
+	svc.profileRepo = &fakeProfileRepo{
+		getByID: func(context.Context, repositories.GetPayProfileByIDRequest) (*driverpay.PayProfile, error) {
+			return profile, nil
+		},
+	}
+	svc.assignmentRepo = &fakeAssignmentRepo{
+		listOverlapping: func(context.Context, *driverpay.WorkerPayAssignment) ([]*driverpay.WorkerPayAssignment, error) {
+			return []*driverpay.WorkerPayAssignment{existing}, nil
+		},
+		update: func(_ context.Context, assignment *driverpay.WorkerPayAssignment) (*driverpay.WorkerPayAssignment, error) {
+			endedAssignment = assignment
+			return assignment, nil
+		},
+		create: func(_ context.Context, assignment *driverpay.WorkerPayAssignment) (*driverpay.WorkerPayAssignment, error) {
+			assignment.ID = pulid.MustNew("wpa_")
+			created = assignment
+			return assignment, nil
+		},
+	}
+
+	actor := testActor()
+	result, err := svc.AssignProfileToWorker(t.Context(), entity, actor)
+	require.NoError(t, err)
+
+	require.NotNil(t, endedAssignment)
+	require.NotNil(t, endedAssignment.EffectiveTo)
+	assert.Equal(t, entity.EffectiveFrom, *endedAssignment.EffectiveTo)
+
+	require.NotNil(t, created)
+	assert.Equal(t, actor.UserID, result.CreatedByID)
+	assert.Len(t, audit.logged, 1)
+}
+
+func TestAssignProfileToWorker_SkipsAssignmentsAlreadyEnded(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	entity := newAssignmentEntity()
+	profile := profileForAssignment(entity)
+	endedAt := entity.EffectiveFrom - 100
+	existing := &driverpay.WorkerPayAssignment{
+		EffectiveFrom: entity.EffectiveFrom - 10_000,
+		EffectiveTo:   &endedAt,
+	}
+
+	updateCalls := 0
+	svc.profileRepo = &fakeProfileRepo{
+		getByID: func(context.Context, repositories.GetPayProfileByIDRequest) (*driverpay.PayProfile, error) {
+			return profile, nil
+		},
+	}
+	svc.assignmentRepo = &fakeAssignmentRepo{
+		listOverlapping: func(context.Context, *driverpay.WorkerPayAssignment) ([]*driverpay.WorkerPayAssignment, error) {
+			return []*driverpay.WorkerPayAssignment{existing}, nil
+		},
+		update: func(_ context.Context, assignment *driverpay.WorkerPayAssignment) (*driverpay.WorkerPayAssignment, error) {
+			updateCalls++
+			return assignment, nil
+		},
+		create: func(_ context.Context, assignment *driverpay.WorkerPayAssignment) (*driverpay.WorkerPayAssignment, error) {
+			return assignment, nil
+		},
+	}
+
+	_, err := svc.AssignProfileToWorker(t.Context(), entity, testActor())
+	require.NoError(t, err)
+	assert.Equal(t, 0, updateCalls)
+}
+
+func TestEndAssignment_RejectsEndDateBeforeStart(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	assignment := newAssignmentEntity()
+	assignment.ID = pulid.MustNew("wpa_")
+	svc.assignmentRepo = &fakeAssignmentRepo{
+		getByID: func(context.Context, pagination.TenantInfo, pulid.ID) (*driverpay.WorkerPayAssignment, error) {
+			return assignment, nil
+		},
+	}
+
+	_, err := svc.EndAssignment(
+		t.Context(),
+		pagination.TenantInfo{},
+		assignment.ID,
+		assignment.EffectiveFrom,
+		testActor(),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "after the assignment")
+}
+
+func TestEndAssignment_SetsEffectiveTo(t *testing.T) {
+	t.Parallel()
+	svc, audit := newTestService()
+
+	assignment := newAssignmentEntity()
+	assignment.ID = pulid.MustNew("wpa_")
+	svc.assignmentRepo = &fakeAssignmentRepo{
+		getByID: func(context.Context, pagination.TenantInfo, pulid.ID) (*driverpay.WorkerPayAssignment, error) {
+			return assignment, nil
+		},
+		update: func(_ context.Context, entity *driverpay.WorkerPayAssignment) (*driverpay.WorkerPayAssignment, error) {
+			return entity, nil
+		},
+	}
+
+	endDate := assignment.EffectiveFrom + 1_000
+	updated, err := svc.EndAssignment(
+		t.Context(),
+		pagination.TenantInfo{},
+		assignment.ID,
+		endDate,
+		testActor(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, updated.EffectiveTo)
+	assert.Equal(t, endDate, *updated.EffectiveTo)
+	assert.Len(t, audit.logged, 1)
+}
+
+func newAdvanceEntity() *driverpay.PayAdvance {
+	return &driverpay.PayAdvance{
+		BusinessUnitID: pulid.MustNew("bu_"),
+		OrganizationID: pulid.MustNew("org_"),
+		WorkerID:       pulid.MustNew("wrk_"),
+		Source:         driverpay.AdvanceSourceCash,
+		IssuedDate:     timeutils.NowUnix(),
+		AmountMinor:    50_000,
+		CurrencyCode:   "USD",
+	}
+}
+
+func TestIssueAdvance_ForcesCleanRecoveryState(t *testing.T) {
+	t.Parallel()
+	svc, audit := newTestService()
+
+	var created *driverpay.PayAdvance
+	svc.advanceRepo = &fakeAdvanceRepo{
+		create: func(_ context.Context, entity *driverpay.PayAdvance) (*driverpay.PayAdvance, error) {
+			entity.ID = pulid.MustNew("padv_")
+			created = entity
+			return entity, nil
+		},
+	}
+
+	entity := newAdvanceEntity()
+	entity.Status = driverpay.AdvanceStatusRecovered
+	entity.RecoveredMinor = 10_000
+	entity.WrittenOffMinor = 5_000
+
+	actor := testActor()
+	result, err := svc.IssueAdvance(t.Context(), entity, actor)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	assert.Equal(t, driverpay.AdvanceStatusOutstanding, result.Status)
+	assert.EqualValues(t, 0, result.RecoveredMinor)
+	assert.EqualValues(t, 0, result.WrittenOffMinor)
+	assert.Equal(t, actor.UserID, result.CreatedByID)
+	assert.Len(t, audit.logged, 1)
+}
+
+func TestIssueAdvance_RejectsInvalidEntity(t *testing.T) {
+	t.Parallel()
+	svc, audit := newTestService()
+
+	entity := newAdvanceEntity()
+	entity.AmountMinor = 0
+
+	_, err := svc.IssueAdvance(t.Context(), entity, testActor())
+	require.Error(t, err)
+	assert.Empty(t, audit.logged)
+}
+
+func TestUpdateAdvance_RejectsNonOutstandingAdvance(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	previous := newAdvanceEntity()
+	previous.ID = pulid.MustNew("padv_")
+	previous.Status = driverpay.AdvanceStatusPartiallyRecovered
+	previous.RecoveredMinor = 10_000
+
+	svc.advanceRepo = &fakeAdvanceRepo{
+		getByID: func(context.Context, repositories.GetPayAdvanceByIDRequest) (*driverpay.PayAdvance, error) {
+			return previous, nil
+		},
+	}
+
+	entity := newAdvanceEntity()
+	entity.ID = previous.ID
+
+	_, err := svc.UpdateAdvance(t.Context(), entity, testActor())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Only outstanding advances")
+}
+
+func TestWriteOffAdvance_RequiresReason(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	_, err := svc.WriteOffAdvance(
+		t.Context(),
+		pagination.TenantInfo{},
+		pulid.MustNew("padv_"),
+		"",
+		testActor(),
+	)
+	require.Error(t, err)
+}
+
+func TestWriteOffAdvance_RejectsFullyRecoveredAdvance(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	advance := newAdvanceEntity()
+	advance.ID = pulid.MustNew("padv_")
+	advance.RecoveredMinor = advance.AmountMinor
+	svc.advanceRepo = &fakeAdvanceRepo{
+		getByID: func(context.Context, repositories.GetPayAdvanceByIDRequest) (*driverpay.PayAdvance, error) {
+			return advance, nil
+		},
+	}
+
+	_, err := svc.WriteOffAdvance(
+		t.Context(),
+		pagination.TenantInfo{},
+		advance.ID,
+		"uncollectible",
+		testActor(),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no outstanding balance")
+}
+
+func TestWriteOffAdvance_WritesOffOutstandingBalance(t *testing.T) {
+	t.Parallel()
+	svc, audit := newTestService()
+
+	advance := newAdvanceEntity()
+	advance.ID = pulid.MustNew("padv_")
+	advance.RecoveredMinor = 20_000
+	svc.advanceRepo = &fakeAdvanceRepo{
+		getByID: func(context.Context, repositories.GetPayAdvanceByIDRequest) (*driverpay.PayAdvance, error) {
+			return advance, nil
+		},
+		update: func(_ context.Context, entity *driverpay.PayAdvance) (*driverpay.PayAdvance, error) {
+			return entity, nil
+		},
+	}
+
+	actor := testActor()
+	updated, err := svc.WriteOffAdvance(
+		t.Context(),
+		pagination.TenantInfo{},
+		advance.ID,
+		"driver terminated",
+		actor,
+	)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 30_000, updated.WrittenOffMinor)
+	assert.EqualValues(t, 0, updated.OutstandingMinor())
+	assert.Equal(t, driverpay.AdvanceStatusWrittenOff, updated.Status)
+	assert.Equal(t, "driver terminated", updated.WriteOffReason)
+	assert.Equal(t, actor.UserID, updated.WrittenOffByID)
+	require.NotNil(t, updated.WrittenOffAt)
+	assert.Len(t, audit.logged, 1)
+}

--- a/services/tms/internal/core/services/driverpayservice/deduction_test.go
+++ b/services/tms/internal/core/services/driverpayservice/deduction_test.go
@@ -1,0 +1,136 @@
+package driverpayservice
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/emoss08/trenova/internal/core/domain/driverpay"
+	"github.com/emoss08/trenova/internal/core/ports/repositories"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/emoss08/trenova/shared/timeutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakePayCodeRepo struct {
+	repositories.PayCodeRepository
+	getByID func(
+		ctx context.Context,
+		req repositories.GetPayCodeByIDRequest,
+	) (*driverpay.PayCode, error)
+}
+
+func (f *fakePayCodeRepo) GetByID(
+	ctx context.Context,
+	req repositories.GetPayCodeByIDRequest,
+) (*driverpay.PayCode, error) {
+	return f.getByID(ctx, req)
+}
+
+type fakeDeductionRepo struct {
+	repositories.RecurringDeductionRepository
+	create func(
+		ctx context.Context,
+		entity *driverpay.RecurringDeduction,
+	) (*driverpay.RecurringDeduction, error)
+}
+
+func (f *fakeDeductionRepo) Create(
+	ctx context.Context,
+	entity *driverpay.RecurringDeduction,
+) (*driverpay.RecurringDeduction, error) {
+	return f.create(ctx, entity)
+}
+
+func newDeductionEntity() *driverpay.RecurringDeduction {
+	return &driverpay.RecurringDeduction{
+		BusinessUnitID: pulid.MustNew("bu_"),
+		OrganizationID: pulid.MustNew("org_"),
+		WorkerID:       pulid.MustNew("wrk_"),
+		PayCodeID:      pulid.MustNew("payc_"),
+		Status:         driverpay.DeductionStatusActive,
+		Frequency:      driverpay.DeductionFrequencyEverySettlement,
+		Description:    "Escrow contribution",
+		AmountMinor:    25_000,
+		StartDate:      timeutils.NowUnix(),
+		CurrencyCode:   "USD",
+	}
+}
+
+func deductionPayCode(direction driverpay.PayCodeDirection) *driverpay.PayCode {
+	return &driverpay.PayCode{
+		ID:        pulid.MustNew("payc_"),
+		Direction: direction,
+		Code:      "ESCROW",
+		Name:      "Escrow Contribution",
+	}
+}
+
+func TestCreateDeduction_RejectsEarningPayCode(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	svc.payCodeRepo = &fakePayCodeRepo{
+		getByID: func(context.Context, repositories.GetPayCodeByIDRequest) (*driverpay.PayCode, error) {
+			return deductionPayCode(driverpay.PayCodeDirectionEarning), nil
+		},
+	}
+
+	_, err := svc.CreateDeduction(t.Context(), newDeductionEntity(), false, testActor())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be used here")
+}
+
+func TestCreateDeduction_AutoLinksActiveEscrowAccount(t *testing.T) {
+	t.Parallel()
+	svc, audit := newTestService()
+
+	account := activeEscrowAccount(0)
+	svc.payCodeRepo = &fakePayCodeRepo{
+		getByID: func(context.Context, repositories.GetPayCodeByIDRequest) (*driverpay.PayCode, error) {
+			return deductionPayCode(driverpay.PayCodeDirectionDeduction), nil
+		},
+	}
+	svc.escrowRepo = &fakeEscrowRepo{
+		getActiveForWorker: func(context.Context, repositories.GetActiveEscrowAccountForWorkerRequest) (*driverpay.EscrowAccount, error) {
+			return account, nil
+		},
+	}
+	svc.deductionRepo = &fakeDeductionRepo{
+		create: func(_ context.Context, entity *driverpay.RecurringDeduction) (*driverpay.RecurringDeduction, error) {
+			entity.ID = pulid.MustNew("rded_")
+			return entity, nil
+		},
+	}
+
+	actor := testActor()
+	created, err := svc.CreateDeduction(t.Context(), newDeductionEntity(), true, actor)
+	require.NoError(t, err)
+
+	require.NotNil(t, created.EscrowAccountID)
+	assert.Equal(t, account.ID, *created.EscrowAccountID)
+	assert.True(t, created.IsEscrowContribution())
+	assert.Equal(t, actor.UserID, created.CreatedByID)
+	assert.Len(t, audit.logged, 1)
+}
+
+func TestCreateDeduction_AutoLinkFailsWithoutActiveEscrowAccount(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	svc.payCodeRepo = &fakePayCodeRepo{
+		getByID: func(context.Context, repositories.GetPayCodeByIDRequest) (*driverpay.PayCode, error) {
+			return deductionPayCode(driverpay.PayCodeDirectionDeduction), nil
+		},
+	}
+	svc.escrowRepo = &fakeEscrowRepo{
+		getActiveForWorker: func(context.Context, repositories.GetActiveEscrowAccountForWorkerRequest) (*driverpay.EscrowAccount, error) {
+			return nil, errors.New("not found")
+		},
+	}
+
+	_, err := svc.CreateDeduction(t.Context(), newDeductionEntity(), true, testActor())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active escrow account")
+}

--- a/services/tms/internal/core/services/driverpayservice/escrow_test.go
+++ b/services/tms/internal/core/services/driverpayservice/escrow_test.go
@@ -106,7 +106,10 @@ func TestOpenEscrowAccount_RejectsDuplicateActiveAccount(t *testing.T) {
 func TestAdjustEscrowAccount_ValidatesRequest(t *testing.T) {
 	t.Parallel()
 	svc, _ := newTestService()
-	tenantInfo := pagination.TenantInfo{OrgID: pulid.MustNew("org_"), BuID: pulid.MustNew("bu_")}
+	tenantInfo := pagination.TenantInfo{
+		OrgID: pulid.MustNew("org_"),
+		BuID:  pulid.MustNew("bu_"),
+	}
 
 	_, err := svc.AdjustEscrowAccount(t.Context(), &EscrowAdjustmentRequest{
 		TenantInfo:  tenantInfo,
@@ -214,7 +217,12 @@ func TestCloseEscrowAccount_RejectsAlreadyClosedAccount(t *testing.T) {
 		},
 	}
 
-	_, err := svc.CloseEscrowAccount(t.Context(), pagination.TenantInfo{}, account.ID, testActor())
+	_, err := svc.CloseEscrowAccount(
+		t.Context(),
+		pagination.TenantInfo{},
+		account.ID,
+		testActor(),
+	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already closed")
 }

--- a/services/tms/internal/core/services/driverpayservice/escrow_test.go
+++ b/services/tms/internal/core/services/driverpayservice/escrow_test.go
@@ -1,0 +1,403 @@
+package driverpayservice
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/emoss08/trenova/internal/core/domain/driverpay"
+	"github.com/emoss08/trenova/internal/core/domain/tenant"
+	"github.com/emoss08/trenova/internal/core/ports/repositories"
+	serviceports "github.com/emoss08/trenova/internal/core/ports/services"
+	"github.com/emoss08/trenova/pkg/pagination"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/emoss08/trenova/shared/timeutils"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newEscrowEntity() *driverpay.EscrowAccount {
+	return &driverpay.EscrowAccount{
+		BusinessUnitID:    pulid.MustNew("bu_"),
+		OrganizationID:    pulid.MustNew("org_"),
+		WorkerID:          pulid.MustNew("wrk_"),
+		TargetAmountMinor: 500_000,
+		OpenedDate:        timeutils.NowUnix(),
+		CurrencyCode:      "USD",
+	}
+}
+
+func activeEscrowAccount(balance int64) *driverpay.EscrowAccount {
+	account := newEscrowEntity()
+	account.ID = pulid.MustNew("escr_")
+	account.Status = driverpay.EscrowAccountStatusActive
+	account.BalanceMinor = balance
+	return account
+}
+
+func TestOpenEscrowAccount_RequiresActor(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	_, err := svc.OpenEscrowAccount(t.Context(), newEscrowEntity(), nil)
+	require.Error(t, err)
+
+	_, err = svc.OpenEscrowAccount(t.Context(), newEscrowEntity(), &serviceports.RequestActor{})
+	require.Error(t, err)
+}
+
+func TestOpenEscrowAccount_DefaultsInterestRateFromSettlementControl(t *testing.T) {
+	t.Parallel()
+	svc, audit := newTestService()
+
+	var created *driverpay.EscrowAccount
+	svc.escrowRepo = &fakeEscrowRepo{
+		getActiveForWorker: func(context.Context, repositories.GetActiveEscrowAccountForWorkerRequest) (*driverpay.EscrowAccount, error) {
+			return nil, errors.New("not found")
+		},
+		create: func(_ context.Context, entity *driverpay.EscrowAccount) (*driverpay.EscrowAccount, error) {
+			entity.ID = pulid.MustNew("escr_")
+			created = entity
+			return entity, nil
+		},
+	}
+	svc.settlementControl = &fakeSettlementControlRepo{
+		getOrCreate: func(context.Context, pagination.TenantInfo) (*tenant.SettlementControl, error) {
+			return &tenant.SettlementControl{
+				DefaultEscrowInterestRate: decimal.NewFromFloat(3.25),
+			}, nil
+		},
+	}
+
+	entity := newEscrowEntity()
+	entity.Status = driverpay.EscrowAccountStatusClosed
+	entity.BalanceMinor = 999
+
+	result, err := svc.OpenEscrowAccount(t.Context(), entity, testActor())
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	assert.Equal(t, driverpay.EscrowAccountStatusActive, result.Status)
+	assert.EqualValues(t, 0, result.BalanceMinor)
+	assert.Equal(t, "3.25", result.AnnualInterestRate.String())
+	assert.Len(t, audit.logged, 1)
+}
+
+func TestOpenEscrowAccount_RejectsDuplicateActiveAccount(t *testing.T) {
+	t.Parallel()
+	svc, audit := newTestService()
+
+	svc.escrowRepo = &fakeEscrowRepo{
+		getActiveForWorker: func(context.Context, repositories.GetActiveEscrowAccountForWorkerRequest) (*driverpay.EscrowAccount, error) {
+			return activeEscrowAccount(0), nil
+		},
+	}
+
+	entity := newEscrowEntity()
+	entity.AnnualInterestRate = decimal.NewFromInt(2)
+
+	_, err := svc.OpenEscrowAccount(t.Context(), entity, testActor())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "active escrow account")
+	assert.Empty(t, audit.logged)
+}
+
+func TestAdjustEscrowAccount_ValidatesRequest(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+	tenantInfo := pagination.TenantInfo{OrgID: pulid.MustNew("org_"), BuID: pulid.MustNew("bu_")}
+
+	_, err := svc.AdjustEscrowAccount(t.Context(), &EscrowAdjustmentRequest{
+		TenantInfo:  tenantInfo,
+		AccountID:   pulid.MustNew("escr_"),
+		AmountMinor: 0,
+		Description: "zero",
+	}, testActor())
+	require.Error(t, err)
+
+	_, err = svc.AdjustEscrowAccount(t.Context(), &EscrowAdjustmentRequest{
+		TenantInfo:  tenantInfo,
+		AccountID:   pulid.MustNew("escr_"),
+		AmountMinor: 1_000,
+	}, testActor())
+	require.Error(t, err)
+}
+
+func TestAdjustEscrowAccount_RejectsInactiveAccount(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	account := activeEscrowAccount(10_000)
+	account.Status = driverpay.EscrowAccountStatusClosed
+	svc.escrowRepo = &fakeEscrowRepo{
+		getByID: func(context.Context, repositories.GetEscrowAccountByIDRequest) (*driverpay.EscrowAccount, error) {
+			return account, nil
+		},
+	}
+
+	_, err := svc.AdjustEscrowAccount(t.Context(), &EscrowAdjustmentRequest{
+		AccountID:   account.ID,
+		AmountMinor: 1_000,
+		Description: "adjustment",
+	}, testActor())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not active")
+}
+
+func TestAdjustEscrowAccount_RejectsNegativeResultingBalance(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	account := activeEscrowAccount(5_000)
+	svc.escrowRepo = &fakeEscrowRepo{
+		getByID: func(context.Context, repositories.GetEscrowAccountByIDRequest) (*driverpay.EscrowAccount, error) {
+			return account, nil
+		},
+	}
+
+	_, err := svc.AdjustEscrowAccount(t.Context(), &EscrowAdjustmentRequest{
+		AccountID:   account.ID,
+		AmountMinor: -5_001,
+		Description: "drain",
+	}, testActor())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "negative")
+}
+
+func TestAdjustEscrowAccount_AppliesTransactionAndUpdatesBalance(t *testing.T) {
+	t.Parallel()
+	svc, audit := newTestService()
+
+	account := activeEscrowAccount(5_000)
+	repo := &fakeEscrowRepo{
+		getByID: func(context.Context, repositories.GetEscrowAccountByIDRequest) (*driverpay.EscrowAccount, error) {
+			return account, nil
+		},
+	}
+	var appended *driverpay.EscrowTransaction
+	repo.update = func(_ context.Context, entity *driverpay.EscrowAccount) (*driverpay.EscrowAccount, error) {
+		return entity, nil
+	}
+	repo.appendTransaction = func(_ context.Context, entity *driverpay.EscrowTransaction) (*driverpay.EscrowTransaction, error) {
+		appended = entity
+		return entity, nil
+	}
+	svc.escrowRepo = repo
+
+	updated, err := svc.AdjustEscrowAccount(t.Context(), &EscrowAdjustmentRequest{
+		AccountID:   account.ID,
+		AmountMinor: -2_000,
+		Description: "damage claim applied",
+	}, testActor())
+	require.NoError(t, err)
+	require.NotNil(t, appended)
+
+	assert.Equal(t, driverpay.EscrowTransactionTypeAdjustment, appended.Type)
+	assert.EqualValues(t, -2_000, appended.AmountMinor)
+	assert.EqualValues(t, 3_000, appended.BalanceAfterMinor)
+	assert.Equal(t, account.ID, appended.EscrowAccountID)
+	assert.Equal(t, account.OrganizationID, appended.OrganizationID)
+	assert.EqualValues(t, 3_000, updated.BalanceMinor)
+	assert.Len(t, audit.logged, 1)
+}
+
+func TestCloseEscrowAccount_RejectsAlreadyClosedAccount(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	account := activeEscrowAccount(0)
+	account.Status = driverpay.EscrowAccountStatusClosed
+	svc.escrowRepo = &fakeEscrowRepo{
+		getByID: func(context.Context, repositories.GetEscrowAccountByIDRequest) (*driverpay.EscrowAccount, error) {
+			return account, nil
+		},
+	}
+
+	_, err := svc.CloseEscrowAccount(t.Context(), pagination.TenantInfo{}, account.ID, testActor())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already closed")
+}
+
+func TestCloseEscrowAccount_RefundsRemainingBalance(t *testing.T) {
+	t.Parallel()
+	svc, audit := newTestService()
+
+	account := activeEscrowAccount(75_000)
+	repo := &fakeEscrowRepo{
+		getByID: func(context.Context, repositories.GetEscrowAccountByIDRequest) (*driverpay.EscrowAccount, error) {
+			return account, nil
+		},
+	}
+	var appended *driverpay.EscrowTransaction
+	repo.update = func(_ context.Context, entity *driverpay.EscrowAccount) (*driverpay.EscrowAccount, error) {
+		return entity, nil
+	}
+	repo.appendTransaction = func(_ context.Context, entity *driverpay.EscrowTransaction) (*driverpay.EscrowTransaction, error) {
+		appended = entity
+		return entity, nil
+	}
+	svc.escrowRepo = repo
+
+	updated, err := svc.CloseEscrowAccount(
+		t.Context(),
+		pagination.TenantInfo{},
+		account.ID,
+		testActor(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, appended)
+
+	assert.Equal(t, driverpay.EscrowTransactionTypeRefund, appended.Type)
+	assert.EqualValues(t, -75_000, appended.AmountMinor)
+	assert.EqualValues(t, 0, appended.BalanceAfterMinor)
+	assert.Equal(t, driverpay.EscrowAccountStatusClosed, updated.Status)
+	require.NotNil(t, updated.ClosedDate)
+	assert.EqualValues(t, 0, updated.BalanceMinor)
+	assert.Len(t, audit.logged, 1)
+}
+
+func TestCloseEscrowAccount_ZeroBalanceSkipsRefund(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	account := activeEscrowAccount(0)
+	appendCalls := 0
+	repo := &fakeEscrowRepo{
+		getByID: func(context.Context, repositories.GetEscrowAccountByIDRequest) (*driverpay.EscrowAccount, error) {
+			return account, nil
+		},
+	}
+	repo.update = func(_ context.Context, entity *driverpay.EscrowAccount) (*driverpay.EscrowAccount, error) {
+		return entity, nil
+	}
+	repo.appendTransaction = func(_ context.Context, entity *driverpay.EscrowTransaction) (*driverpay.EscrowTransaction, error) {
+		appendCalls++
+		return entity, nil
+	}
+	svc.escrowRepo = repo
+
+	updated, err := svc.CloseEscrowAccount(
+		t.Context(),
+		pagination.TenantInfo{},
+		account.ID,
+		testActor(),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, appendCalls)
+	assert.Equal(t, driverpay.EscrowAccountStatusClosed, updated.Status)
+}
+
+func TestAccrueEscrowInterest_SkipsIneligibleAccounts(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		mutate func(a *driverpay.EscrowAccount)
+	}{
+		{
+			name:   "closed account",
+			mutate: func(a *driverpay.EscrowAccount) { a.Status = driverpay.EscrowAccountStatusClosed },
+		},
+		{
+			name:   "zero balance",
+			mutate: func(a *driverpay.EscrowAccount) { a.BalanceMinor = 0 },
+		},
+		{
+			name:   "zero rate",
+			mutate: func(a *driverpay.EscrowAccount) { a.AnnualInterestRate = decimal.Zero },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			svc, _ := newTestService()
+
+			account := activeEscrowAccount(100_000)
+			account.AnnualInterestRate = decimal.NewFromInt(5)
+			tc.mutate(account)
+
+			svc.escrowRepo = &fakeEscrowRepo{
+				getByID: func(context.Context, repositories.GetEscrowAccountByIDRequest) (*driverpay.EscrowAccount, error) {
+					return account, nil
+				},
+			}
+
+			result, err := svc.AccrueEscrowInterest(
+				t.Context(),
+				pagination.TenantInfo{},
+				account.ID,
+			)
+			require.NoError(t, err)
+			assert.Same(t, account, result)
+		})
+	}
+}
+
+func TestAccrueEscrowInterest_AccruesOneYearOfInterest(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	oneYearAgo := time.Now().Add(-365 * 24 * time.Hour).Unix()
+	account := activeEscrowAccount(1_000_000)
+	account.AnnualInterestRate = decimal.NewFromInt(5)
+	account.LastInterestAccrualDate = &oneYearAgo
+
+	repo := &fakeEscrowRepo{
+		getByID: func(context.Context, repositories.GetEscrowAccountByIDRequest) (*driverpay.EscrowAccount, error) {
+			return account, nil
+		},
+	}
+	var appended *driverpay.EscrowTransaction
+	repo.update = func(_ context.Context, entity *driverpay.EscrowAccount) (*driverpay.EscrowAccount, error) {
+		return entity, nil
+	}
+	repo.appendTransaction = func(_ context.Context, entity *driverpay.EscrowTransaction) (*driverpay.EscrowTransaction, error) {
+		appended = entity
+		return entity, nil
+	}
+	svc.escrowRepo = repo
+
+	updated, err := svc.AccrueEscrowInterest(t.Context(), pagination.TenantInfo{}, account.ID)
+	require.NoError(t, err)
+	require.NotNil(t, appended)
+
+	assert.Equal(t, driverpay.EscrowTransactionTypeInterestAccrual, appended.Type)
+	assert.EqualValues(t, 50_000, appended.AmountMinor)
+	assert.EqualValues(t, 1_050_000, updated.BalanceMinor)
+	require.NotNil(t, updated.LastInterestAccrualDate)
+	assert.Greater(t, *updated.LastInterestAccrualDate, oneYearAgo)
+}
+
+func TestAccrueEscrowInterest_TinyElapsedOnlyAdvancesAccrualDate(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService()
+
+	justNow := timeutils.NowUnix() - 1
+	account := activeEscrowAccount(1_000)
+	account.AnnualInterestRate = decimal.NewFromInt(5)
+	account.LastInterestAccrualDate = &justNow
+
+	appendCalls := 0
+	repo := &fakeEscrowRepo{
+		getByID: func(context.Context, repositories.GetEscrowAccountByIDRequest) (*driverpay.EscrowAccount, error) {
+			return account, nil
+		},
+	}
+	repo.update = func(_ context.Context, entity *driverpay.EscrowAccount) (*driverpay.EscrowAccount, error) {
+		return entity, nil
+	}
+	repo.appendTransaction = func(_ context.Context, entity *driverpay.EscrowTransaction) (*driverpay.EscrowTransaction, error) {
+		appendCalls++
+		return entity, nil
+	}
+	svc.escrowRepo = repo
+
+	updated, err := svc.AccrueEscrowInterest(t.Context(), pagination.TenantInfo{}, account.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, appendCalls)
+	assert.EqualValues(t, 1_000, updated.BalanceMinor)
+	require.NotNil(t, updated.LastInterestAccrualDate)
+	assert.GreaterOrEqual(t, *updated.LastInterestAccrualDate, justNow)
+}

--- a/services/tms/internal/core/services/driverpayservice/testsupport_test.go
+++ b/services/tms/internal/core/services/driverpayservice/testsupport_test.go
@@ -1,0 +1,238 @@
+package driverpayservice
+
+import (
+	"context"
+
+	"github.com/emoss08/trenova/internal/core/domain/driverpay"
+	"github.com/emoss08/trenova/internal/core/domain/tenant"
+	"github.com/emoss08/trenova/internal/core/ports"
+	"github.com/emoss08/trenova/internal/core/ports/repositories"
+	serviceports "github.com/emoss08/trenova/internal/core/ports/services"
+	"github.com/emoss08/trenova/pkg/pagination"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/uptrace/bun"
+	"go.uber.org/zap"
+)
+
+type fakeDB struct{}
+
+func (fakeDB) DB() *bun.DB { return nil }
+
+func (fakeDB) DBForContext(context.Context) bun.IDB { return nil }
+
+func (fakeDB) WithTx(
+	ctx context.Context,
+	_ ports.TxOptions,
+	fn func(context.Context, bun.Tx) error,
+) error {
+	return fn(ctx, bun.Tx{})
+}
+
+func (fakeDB) HealthCheck(context.Context) error { return nil }
+
+func (fakeDB) IsHealthy(context.Context) bool { return true }
+
+func (fakeDB) Close() error { return nil }
+
+type fakeAuditService struct {
+	serviceports.AuditService
+	logged []*serviceports.LogActionParams
+}
+
+func (f *fakeAuditService) LogAction(
+	params *serviceports.LogActionParams,
+	_ ...serviceports.LogOption,
+) error {
+	f.logged = append(f.logged, params)
+	return nil
+}
+
+type fakeEscrowRepo struct {
+	repositories.EscrowAccountRepository
+	getByID func(
+		ctx context.Context,
+		req repositories.GetEscrowAccountByIDRequest,
+	) (*driverpay.EscrowAccount, error)
+	getActiveForWorker func(
+		ctx context.Context,
+		req repositories.GetActiveEscrowAccountForWorkerRequest,
+	) (*driverpay.EscrowAccount, error)
+	create func(
+		ctx context.Context,
+		entity *driverpay.EscrowAccount,
+	) (*driverpay.EscrowAccount, error)
+	update func(
+		ctx context.Context,
+		entity *driverpay.EscrowAccount,
+	) (*driverpay.EscrowAccount, error)
+	appendTransaction func(
+		ctx context.Context,
+		entity *driverpay.EscrowTransaction,
+	) (*driverpay.EscrowTransaction, error)
+}
+
+func (f *fakeEscrowRepo) GetByID(
+	ctx context.Context,
+	req repositories.GetEscrowAccountByIDRequest,
+) (*driverpay.EscrowAccount, error) {
+	return f.getByID(ctx, req)
+}
+
+func (f *fakeEscrowRepo) GetActiveForWorker(
+	ctx context.Context,
+	req repositories.GetActiveEscrowAccountForWorkerRequest,
+) (*driverpay.EscrowAccount, error) {
+	return f.getActiveForWorker(ctx, req)
+}
+
+func (f *fakeEscrowRepo) Create(
+	ctx context.Context,
+	entity *driverpay.EscrowAccount,
+) (*driverpay.EscrowAccount, error) {
+	return f.create(ctx, entity)
+}
+
+func (f *fakeEscrowRepo) Update(
+	ctx context.Context,
+	entity *driverpay.EscrowAccount,
+) (*driverpay.EscrowAccount, error) {
+	return f.update(ctx, entity)
+}
+
+func (f *fakeEscrowRepo) AppendTransaction(
+	ctx context.Context,
+	entity *driverpay.EscrowTransaction,
+) (*driverpay.EscrowTransaction, error) {
+	return f.appendTransaction(ctx, entity)
+}
+
+type fakeSettlementControlRepo struct {
+	repositories.SettlementControlRepository
+	getOrCreate func(
+		ctx context.Context,
+		tenantInfo pagination.TenantInfo,
+	) (*tenant.SettlementControl, error)
+}
+
+func (f *fakeSettlementControlRepo) GetOrCreate(
+	ctx context.Context,
+	tenantInfo pagination.TenantInfo,
+) (*tenant.SettlementControl, error) {
+	return f.getOrCreate(ctx, tenantInfo)
+}
+
+type fakeAssignmentRepo struct {
+	repositories.WorkerPayAssignmentRepository
+	getByID func(
+		ctx context.Context,
+		tenantInfo pagination.TenantInfo,
+		id pulid.ID,
+	) (*driverpay.WorkerPayAssignment, error)
+	listOverlapping func(
+		ctx context.Context,
+		entity *driverpay.WorkerPayAssignment,
+	) ([]*driverpay.WorkerPayAssignment, error)
+	create func(
+		ctx context.Context,
+		entity *driverpay.WorkerPayAssignment,
+	) (*driverpay.WorkerPayAssignment, error)
+	update func(
+		ctx context.Context,
+		entity *driverpay.WorkerPayAssignment,
+	) (*driverpay.WorkerPayAssignment, error)
+}
+
+func (f *fakeAssignmentRepo) GetByID(
+	ctx context.Context,
+	tenantInfo pagination.TenantInfo,
+	id pulid.ID,
+) (*driverpay.WorkerPayAssignment, error) {
+	return f.getByID(ctx, tenantInfo, id)
+}
+
+func (f *fakeAssignmentRepo) ListOverlapping(
+	ctx context.Context,
+	entity *driverpay.WorkerPayAssignment,
+) ([]*driverpay.WorkerPayAssignment, error) {
+	return f.listOverlapping(ctx, entity)
+}
+
+func (f *fakeAssignmentRepo) Create(
+	ctx context.Context,
+	entity *driverpay.WorkerPayAssignment,
+) (*driverpay.WorkerPayAssignment, error) {
+	return f.create(ctx, entity)
+}
+
+func (f *fakeAssignmentRepo) Update(
+	ctx context.Context,
+	entity *driverpay.WorkerPayAssignment,
+) (*driverpay.WorkerPayAssignment, error) {
+	return f.update(ctx, entity)
+}
+
+type fakeProfileRepo struct {
+	repositories.PayProfileRepository
+	getByID func(
+		ctx context.Context,
+		req repositories.GetPayProfileByIDRequest,
+	) (*driverpay.PayProfile, error)
+}
+
+func (f *fakeProfileRepo) GetByID(
+	ctx context.Context,
+	req repositories.GetPayProfileByIDRequest,
+) (*driverpay.PayProfile, error) {
+	return f.getByID(ctx, req)
+}
+
+type fakeAdvanceRepo struct {
+	repositories.PayAdvanceRepository
+	getByID func(
+		ctx context.Context,
+		req repositories.GetPayAdvanceByIDRequest,
+	) (*driverpay.PayAdvance, error)
+	create func(
+		ctx context.Context,
+		entity *driverpay.PayAdvance,
+	) (*driverpay.PayAdvance, error)
+	update func(
+		ctx context.Context,
+		entity *driverpay.PayAdvance,
+	) (*driverpay.PayAdvance, error)
+}
+
+func (f *fakeAdvanceRepo) GetByID(
+	ctx context.Context,
+	req repositories.GetPayAdvanceByIDRequest,
+) (*driverpay.PayAdvance, error) {
+	return f.getByID(ctx, req)
+}
+
+func (f *fakeAdvanceRepo) Create(
+	ctx context.Context,
+	entity *driverpay.PayAdvance,
+) (*driverpay.PayAdvance, error) {
+	return f.create(ctx, entity)
+}
+
+func (f *fakeAdvanceRepo) Update(
+	ctx context.Context,
+	entity *driverpay.PayAdvance,
+) (*driverpay.PayAdvance, error) {
+	return f.update(ctx, entity)
+}
+
+func newTestService() (*Service, *fakeAuditService) {
+	audit := &fakeAuditService{}
+	svc := &Service{
+		l:            zap.NewNop(),
+		db:           fakeDB{},
+		auditService: audit,
+	}
+	return svc, audit
+}
+
+func testActor() *serviceports.RequestActor {
+	return &serviceports.RequestActor{UserID: pulid.MustNew("usr_")}
+}


### PR DESCRIPTION
# Description

Third slice of the codebase completeness review: first test coverage for the driver-pay vertical, which previously had zero tests across ~5,000 LOC of money math. Coverage goes from 0% → 61.3% on the `driverpay` domain package and 0% → 49.8% on `driverpayservice` (~2,600 lines of tests).

**Domain** (`internal/core/domain/driverpay`): escrow account/transaction validation including per-type sign rules (contributions and interest accruals must be positive; applications and refunds negative), funded-percent math and full-funding detection, pay-advance outstanding-balance math and status-sync transitions, pay-code pattern rules, reimbursement classification and the system code catalog, pay-profile component validation, mileage-band validation and rate resolution (including band boundaries and open-ended bands), worker-pay-assignment effective windows and rate overrides, and recurring deduction/earning cap math with next-amount clamping.

**Service** (`internal/core/services/driverpayservice`): escrow open (default interest rate from settlement control, duplicate-active-account rejection), adjust (balance-floor enforcement, transaction append with correct `BalanceAfterMinor`), close (refund of the remaining balance per 49 CFR 376.12(k), no refund on zero balance), interest accrual (exact year-fraction math, accrual-date advancement, ineligible-account no-ops), assignment overlap handling (earlier open assignments get ended at the new effective date; later-starting ones are rejected), rate-override component validation, advance issue/update/write-off transitions, and deduction pay-code direction checks with escrow auto-linking.

The generated mocks don't yet cover the driver-pay repositories (and `CLAUDE.md` forbids a full mockery regeneration), so the service tests use package-local interface fakes — the same pattern `bankreceiptbatchservice`'s tests use.

**Bug found and fixed by the new tests**: `validateBands` rejected contiguous mileage bands (`next.MinMiles == previous.MaxMiles`) as overlapping, but `ResolveMileageRate` treats `MaxMiles` as exclusive — so the only encoding that produces gap-free mileage coverage could not pass validation, silently forcing 1-mile rate gaps in every banded pay profile. The check is now `band.MinMiles < prevMax`, which still rejects genuine overlaps.

## Related Issue or Discussion

Found during a codebase completeness review; maintainer-driven session. Follow-up to #557 and #558.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Tests
- [ ] Build, CI, or infrastructure

## Scope

- `services/tms/internal/core/domain/driverpay` — 6 new test files + the one-line `validateBands` fix in `payprofile.go`
- `services/tms/internal/core/services/driverpayservice` — 4 new test files + shared test fakes

## Validation

- [x] Other: `go test -cover` for both packages (all pass; coverage above), `go vet`, `go build ./internal/...`, `go test -run TestFullSeedRunOnSQLite ./internal/infrastructure/database/seeder/` (the dev seed still validates after the band fix), gofmt clean, golines applied with the repo's formatter settings. `golangci-lint` could not run in this environment (binary built with Go 1.25, repo targets Go 1.26).
- [ ] `cd services/tms && task test` — full suite not run in this environment; changed-package tests pass.
- [ ] `cd services/tms && task lint` — see above.
- [ ] `cd client && pnpm build` — not run; no client changes.
- [ ] `cd client && pnpm lint` — not run; no client changes.

## Deployment Notes

- The `validateBands` change only loosens validation (contiguous bands now accepted); every previously-valid pay profile remains valid. No schema, config, or API changes.

## Checklist

- [x] I kept the change focused and reviewable.
- [x] I followed `AGENTS.md`, `CLAUDE.md`, and existing repository patterns.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I updated relevant documentation, examples, migrations, or configuration.
- [x] I did not include secrets, credentials, private customer data, unrelated refactors, or placeholder code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015houJkqb8SuqPW4YpLoWCq

---
_Generated by [Claude Code](https://claude.ai/code/session_015houJkqb8SuqPW4YpLoWCq)_