### PR TITLE
test(dash): extract and cover portal money and HOS logic, drop passWithNoTests

### DIFF
--- a/client/apps/dash/package.json
+++ b/client/apps/dash/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc -b",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "build": "tsc -b && vite build",
     "preview": "pnpm run build && wrangler dev",
     "lint": "oxlint",

--- a/client/apps/dash/src/_components/use-loads.test.ts
+++ b/client/apps/dash/src/_components/use-loads.test.ts
@@ -1,0 +1,84 @@
+import type { PortalLoad, PortalStop } from "@trenova/shared/lib/graphql/driver-portal";
+import { describe, expect, it } from "vitest";
+
+import {
+  destinationStop,
+  directionsUrl,
+  formatMiles,
+  isLikelyUSAddress,
+  originStop,
+  stopPlace,
+} from "./use-loads";
+
+function stop(overrides: Partial<PortalStop>): PortalStop {
+  return { locationName: "", addressLine: "", ...overrides } as PortalStop;
+}
+
+function load(stops: PortalStop[]): PortalLoad {
+  return { stops } as PortalLoad;
+}
+
+describe("origin and destination stops", () => {
+  const pickup = stop({ locationName: "Origin DC" });
+  const delivery = stop({ locationName: "Destination DC" });
+
+  it("uses the first stop as origin", () => {
+    expect(originStop(load([pickup, delivery]))).toBe(pickup);
+  });
+
+  it("uses the last stop as destination only when there is more than one", () => {
+    expect(destinationStop(load([pickup, delivery]))).toBe(delivery);
+    expect(destinationStop(load([pickup]))).toBeUndefined();
+    expect(destinationStop(load([]))).toBeUndefined();
+  });
+});
+
+describe("stopPlace", () => {
+  it("prefers the location name, then the address, then a dash", () => {
+    expect(stopPlace(stop({ locationName: "Yard 4", addressLine: "1 Main St" }))).toBe("Yard 4");
+    expect(stopPlace(stop({ addressLine: "1 Main St" }))).toBe("1 Main St");
+    expect(stopPlace(stop({}))).toBe("—");
+    expect(stopPlace(undefined)).toBe("—");
+  });
+});
+
+describe("isLikelyUSAddress", () => {
+  it("matches state and zip endings", () => {
+    expect(isLikelyUSAddress("123 Main St, Atlanta, GA 30303")).toBe(true);
+    expect(isLikelyUSAddress("123 Main St, Atlanta, GA 30303-1234")).toBe(true);
+    expect(isLikelyUSAddress("123 Main St, Atlanta, GA 30303, USA")).toBe(true);
+  });
+
+  it("rejects non-US shapes", () => {
+    expect(isLikelyUSAddress("10 Downing Street, London SW1A 2AA")).toBe(false);
+    expect(isLikelyUSAddress("Somewhere")).toBe(false);
+  });
+});
+
+describe("directionsUrl", () => {
+  it("routes US addresses to TruckMap", () => {
+    const url = directionsUrl(stop({ addressLine: "123 Main St, Atlanta, GA 30303" }));
+    expect(url).toContain("truckmap.com/search/");
+    expect(url).toContain(encodeURIComponent("123 Main St, Atlanta, GA 30303"));
+  });
+
+  it("routes everything else to Google Maps", () => {
+    const url = directionsUrl(stop({ locationName: "Toronto Yard" }));
+    expect(url).toContain("google.com/maps/dir");
+    expect(url).toContain(encodeURIComponent("Toronto Yard"));
+  });
+});
+
+describe("formatMiles", () => {
+  it("formats positive mileage with grouping", () => {
+    expect(formatMiles(1234.6)).toBe("1,235 mi");
+    expect(formatMiles(1)).toBe("1 mi");
+  });
+
+  it("returns null for missing or non-positive values", () => {
+    expect(formatMiles(0)).toBeNull();
+    expect(formatMiles(-5)).toBeNull();
+    expect(formatMiles(null)).toBeNull();
+    expect(formatMiles(undefined)).toBeNull();
+  });
+});

--- a/client/apps/dash/src/lib/hos.test.ts
+++ b/client/apps/dash/src/lib/hos.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { HOUR_MS, dutyStatusInfo, gaugeTone, timeAgo, toDateKey } from "./hos";
+
+describe("toDateKey", () => {
+  it("formats with zero padding", () => {
+    expect(toDateKey(new Date(2026, 0, 5))).toBe("2026-01-05");
+    expect(toDateKey(new Date(2026, 10, 28))).toBe("2026-11-28");
+  });
+});
+
+describe("timeAgo", () => {
+  const nowMs = 1_700_000_000_000;
+  const nowSeconds = nowMs / 1000;
+
+  it("reads just now under a minute", () => {
+    expect(timeAgo(nowSeconds, nowMs)).toBe("just now");
+    expect(timeAgo(nowSeconds - 59, nowMs)).toBe("just now");
+  });
+
+  it("buckets minutes, hours, and days", () => {
+    expect(timeAgo(nowSeconds - 60, nowMs)).toBe("1m ago");
+    expect(timeAgo(nowSeconds - 59 * 60, nowMs)).toBe("59m ago");
+    expect(timeAgo(nowSeconds - 60 * 60, nowMs)).toBe("1h ago");
+    expect(timeAgo(nowSeconds - 23 * 60 * 60, nowMs)).toBe("23h ago");
+    expect(timeAgo(nowSeconds - 24 * 60 * 60, nowMs)).toBe("1d ago");
+    expect(timeAgo(nowSeconds - 90 * 24 * 60 * 60, nowMs)).toBe("90d ago");
+  });
+
+  it("never goes negative for future timestamps", () => {
+    expect(timeAgo(nowSeconds + 600, nowMs)).toBe("just now");
+  });
+});
+
+describe("gaugeTone", () => {
+  it("goes critical under one hour", () => {
+    expect(gaugeTone(0, "brand")).toBe("critical");
+    expect(gaugeTone(HOUR_MS - 1, "brand")).toBe("critical");
+  });
+
+  it("warns under two hours", () => {
+    expect(gaugeTone(HOUR_MS, "brand")).toBe("warning");
+    expect(gaugeTone(2 * HOUR_MS - 1, "brand")).toBe("warning");
+  });
+
+  it("keeps the default tone with two or more hours left", () => {
+    expect(gaugeTone(2 * HOUR_MS, "brand")).toBe("brand");
+    expect(gaugeTone(11 * HOUR_MS, "warning")).toBe("warning");
+  });
+});
+
+describe("dutyStatusInfo", () => {
+  it("maps known duty statuses", () => {
+    expect(dutyStatusInfo("driving")).toEqual({ label: "Driving", variant: "info" });
+    expect(dutyStatusInfo("sleeperBed")).toEqual({ label: "Sleeper Berth", variant: "purple" });
+    expect(dutyStatusInfo("onDuty")).toEqual({ label: "On Duty", variant: "warning" });
+  });
+
+  it("title-cases unknown statuses", () => {
+    const info = dutyStatusInfo("waitingAtShipper");
+    expect(info.variant).toBe("secondary");
+    expect(info.label.toLowerCase()).toContain("waiting");
+  });
+
+  it("falls back to Unknown when missing", () => {
+    expect(dutyStatusInfo(null)).toEqual({ label: "Unknown", variant: "secondary" });
+    expect(dutyStatusInfo(undefined)).toEqual({ label: "Unknown", variant: "secondary" });
+    expect(dutyStatusInfo("")).toEqual({ label: "Unknown", variant: "secondary" });
+  });
+});

--- a/client/apps/dash/src/lib/hos.ts
+++ b/client/apps/dash/src/lib/hos.ts
@@ -1,0 +1,45 @@
+import type { BadgeVariant } from "@trenova/shared/components/ui/badge";
+import type { RingGaugeTone } from "@trenova/shared/components/ui/ring-gauge";
+import { toTitleCase } from "@trenova/shared/lib/utils";
+
+export const HOUR_MS = 60 * 60 * 1000;
+
+export function toDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function timeAgo(unixSeconds: number, nowMs: number = Date.now()): string {
+  const seconds = Math.max(0, Math.floor(nowMs / 1000) - unixSeconds);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function gaugeTone(remainingMs: number, defaultTone: RingGaugeTone): RingGaugeTone {
+  if (remainingMs < HOUR_MS) return "critical";
+  if (remainingMs < 2 * HOUR_MS) return "warning";
+  return defaultTone;
+}
+
+export type DutyStatusInfo = { label: string; variant: BadgeVariant };
+
+const dutyStatuses: Record<string, DutyStatusInfo> = {
+  driving: { label: "Driving", variant: "info" },
+  onDuty: { label: "On Duty", variant: "warning" },
+  offDuty: { label: "Off Duty", variant: "secondary" },
+  sleeperBed: { label: "Sleeper Berth", variant: "purple" },
+  yardMove: { label: "Yard Move", variant: "teal" },
+  personalConveyance: { label: "Personal Conveyance", variant: "teal" },
+};
+
+export function dutyStatusInfo(status: string | null | undefined): DutyStatusInfo {
+  if (!status) return { label: "Unknown", variant: "secondary" };
+  return dutyStatuses[status] ?? { label: toTitleCase(status), variant: "secondary" };
+}

--- a/client/apps/dash/src/lib/settlement.test.ts
+++ b/client/apps/dash/src/lib/settlement.test.ts
@@ -1,0 +1,112 @@
+import type { PortalSettlementLine } from "@trenova/shared/lib/graphql/driver-portal";
+import { describe, expect, it } from "vitest";
+
+import {
+  canWithdrawDispute,
+  escrowProgressPercent,
+  groupSettlementLines,
+  isDeductionCategory,
+  lineAmountVariant,
+  lineDetail,
+  settlementCategoryLabels,
+  settlementCategoryOrder,
+  signedLineAmountMinor,
+} from "./settlement";
+
+describe("groupSettlementLines", () => {
+  it("groups lines in the canonical category order regardless of input order", () => {
+    const groups = groupSettlementLines([
+      { category: "Deduction" },
+      { category: "Earning" },
+      { category: "EscrowContribution" },
+      { category: "Earning" },
+    ]);
+
+    expect(groups.map((group) => group.category)).toEqual([
+      "Earning",
+      "Deduction",
+      "EscrowContribution",
+    ]);
+    expect(groups[0].lines).toHaveLength(2);
+  });
+
+  it("drops empty categories and categories outside the catalog", () => {
+    const unknown = "SomethingElse" as PortalSettlementLine["category"];
+    expect(groupSettlementLines([{ category: unknown }])).toEqual([]);
+    expect(groupSettlementLines([])).toEqual([]);
+  });
+
+  it("has a label for every ordered category", () => {
+    for (const category of settlementCategoryOrder) {
+      expect(settlementCategoryLabels[category]).toBeTruthy();
+    }
+  });
+});
+
+describe("signed line amounts", () => {
+  it("negates deduction-family categories", () => {
+    for (const category of ["Deduction", "EscrowContribution", "AdvanceRecovery"] as const) {
+      expect(isDeductionCategory(category)).toBe(true);
+      expect(signedLineAmountMinor({ category, amountMinor: 12_500 })).toBe(-12_500);
+      expect(lineAmountVariant(category)).toBe("negative");
+    }
+  });
+
+  it("keeps earning-family categories positive", () => {
+    for (const category of [
+      "Earning",
+      "Reimbursement",
+      "GuaranteeTopUp",
+      "CarryForward",
+    ] as const) {
+      expect(isDeductionCategory(category)).toBe(false);
+      expect(signedLineAmountMinor({ category, amountMinor: 12_500 })).toBe(12_500);
+      expect(lineAmountVariant(category)).toBe("neutral");
+    }
+  });
+});
+
+describe("lineDetail", () => {
+  it("joins pro number and quantity times rate", () => {
+    expect(lineDetail({ proNumber: "PRO-1", quantity: "412", rate: "0.55" })).toBe(
+      "PRO-1 · 412 × 0.55",
+    );
+  });
+
+  it("omits the quantity segment when quantity or rate is not positive", () => {
+    expect(lineDetail({ proNumber: "PRO-1", quantity: "0", rate: "0.55" })).toBe("PRO-1");
+    expect(lineDetail({ proNumber: "PRO-1", quantity: "412", rate: "0" })).toBe("PRO-1");
+  });
+
+  it("omits the pro number when empty", () => {
+    expect(lineDetail({ proNumber: "", quantity: "2", rate: "50" })).toBe("2 × 50");
+    expect(lineDetail({ proNumber: "", quantity: "0", rate: "0" })).toBe("");
+  });
+});
+
+describe("canWithdrawDispute", () => {
+  it("allows withdrawal only while open or in review", () => {
+    expect(canWithdrawDispute("Open")).toBe(true);
+    expect(canWithdrawDispute("InReview")).toBe(true);
+    expect(canWithdrawDispute("Resolved")).toBe(false);
+    expect(canWithdrawDispute("Denied")).toBe(false);
+    expect(canWithdrawDispute("Withdrawn")).toBe(false);
+  });
+});
+
+describe("escrowProgressPercent", () => {
+  it("returns zero without a positive target", () => {
+    expect(escrowProgressPercent(50_000, 0)).toBe(0);
+    expect(escrowProgressPercent(50_000, -1)).toBe(0);
+  });
+
+  it("computes the funded percentage", () => {
+    expect(escrowProgressPercent(25_000, 100_000)).toBe(25);
+    expect(escrowProgressPercent(100_000, 100_000)).toBe(100);
+  });
+
+  it("clamps to the 0-100 range", () => {
+    expect(escrowProgressPercent(150_000, 100_000)).toBe(100);
+    expect(escrowProgressPercent(-5_000, 100_000)).toBe(0);
+  });
+});

--- a/client/apps/dash/src/lib/settlement.ts
+++ b/client/apps/dash/src/lib/settlement.ts
@@ -1,0 +1,81 @@
+import type { PortalSettlementLine } from "@trenova/shared/lib/graphql/driver-portal";
+
+export const settlementCategoryOrder = [
+  "Earning",
+  "GuaranteeTopUp",
+  "Reimbursement",
+  "Adjustment",
+  "CarryForward",
+  "Deduction",
+  "EscrowContribution",
+  "AdvanceRecovery",
+] as const;
+
+export type SettlementCategory = (typeof settlementCategoryOrder)[number];
+
+export const settlementCategoryLabels: Record<string, string> = {
+  Earning: "Earnings",
+  GuaranteeTopUp: "Guarantee top-up",
+  Reimbursement: "Reimbursements",
+  Adjustment: "Adjustments",
+  CarryForward: "Carry forward",
+  Deduction: "Deductions",
+  EscrowContribution: "Escrow",
+  AdvanceRecovery: "Advance recovery",
+};
+
+const deductionCategories = new Set<string>([
+  "Deduction",
+  "EscrowContribution",
+  "AdvanceRecovery",
+]);
+
+export function isDeductionCategory(category: string): boolean {
+  return deductionCategories.has(category);
+}
+
+export type SettlementLineGroup<T extends Pick<PortalSettlementLine, "category">> = {
+  category: SettlementCategory;
+  lines: T[];
+};
+
+export function groupSettlementLines<T extends Pick<PortalSettlementLine, "category">>(
+  lines: readonly T[],
+): SettlementLineGroup<T>[] {
+  return settlementCategoryOrder
+    .map((category) => ({
+      category,
+      lines: lines.filter((line) => line.category === category),
+    }))
+    .filter((group) => group.lines.length > 0);
+}
+
+export function signedLineAmountMinor(
+  line: Pick<PortalSettlementLine, "category" | "amountMinor">,
+): number {
+  return isDeductionCategory(line.category) ? -line.amountMinor : line.amountMinor;
+}
+
+export function lineAmountVariant(category: string): "negative" | "neutral" {
+  return isDeductionCategory(category) ? "negative" : "neutral";
+}
+
+export function lineDetail(
+  line: Pick<PortalSettlementLine, "proNumber" | "quantity" | "rate">,
+): string {
+  return [
+    line.proNumber || null,
+    Number(line.quantity) > 0 && Number(line.rate) > 0 ? `${line.quantity} × ${line.rate}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+export function canWithdrawDispute(status: string): boolean {
+  return status === "Open" || status === "InReview";
+}
+
+export function escrowProgressPercent(balanceMinor: number, targetAmountMinor: number): number {
+  if (targetAmountMinor <= 0) return 0;
+  return Math.min(100, Math.max(0, (balanceMinor / targetAmountMinor) * 100));
+}

--- a/client/apps/dash/src/routes/hos.tsx
+++ b/client/apps/dash/src/routes/hos.tsx
@@ -1,6 +1,5 @@
 import { Alert, AlertDescription, AlertTitle } from "@trenova/shared/components/ui/alert";
 import { Badge } from "@trenova/shared/components/ui/badge";
-import type { BadgeVariant } from "@trenova/shared/components/ui/badge";
 import { Button } from "@trenova/shared/components/ui/button";
 import { RingGauge } from "@trenova/shared/components/ui/ring-gauge";
 import type { RingGaugeTone } from "@trenova/shared/components/ui/ring-gauge";
@@ -19,42 +18,9 @@ import { useQuery } from "@tanstack/react-query";
 import { CircleCheckIcon, Clock4Icon, GaugeIcon, TriangleAlertIcon, TruckIcon } from "lucide-react";
 import { m } from "motion/react";
 import { useState } from "react";
+import { dutyStatusInfo, gaugeTone, timeAgo, toDateKey } from "../lib/hos";
 
-const HOUR_MS = 60 * 60 * 1000;
 const DAY_SECONDS = 24 * 60 * 60;
-
-function toDateKey(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
-
-function timeAgo(unixSeconds: number): string {
-  const seconds = Math.max(0, Math.floor(Date.now() / 1000) - unixSeconds);
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
-
-function gaugeTone(remainingMs: number, defaultTone: RingGaugeTone): RingGaugeTone {
-  if (remainingMs < HOUR_MS) return "critical";
-  if (remainingMs < 2 * HOUR_MS) return "warning";
-  return defaultTone;
-}
-
-const DUTY_STATUS: Record<string, { label: string; variant: BadgeVariant }> = {
-  driving: { label: "Driving", variant: "info" },
-  onDuty: { label: "On Duty", variant: "warning" },
-  offDuty: { label: "Off Duty", variant: "secondary" },
-  sleeperBed: { label: "Sleeper Berth", variant: "purple" },
-  yardMove: { label: "Yard Move", variant: "teal" },
-  personalConveyance: { label: "Personal Conveyance", variant: "teal" },
-};
 
 type ClockGaugeProps = {
   label: string;
@@ -90,8 +56,7 @@ function ClockGauge({ label, remainingMs, limitMs, defaultTone }: ClockGaugeProp
 }
 
 function ClockHero({ state }: { state: MyHosState }) {
-  const duty = state.dutyStatus ? DUTY_STATUS[state.dutyStatus] : null;
-  const dutyLabel = duty?.label ?? (state.dutyStatus ? toTitleCase(state.dutyStatus) : "Unknown");
+  const duty = dutyStatusInfo(state.dutyStatus);
 
   return (
     <m.section
@@ -128,7 +93,7 @@ function ClockHero({ state }: { state: MyHosState }) {
       </div>
 
       <div className="mt-5 flex flex-wrap items-center gap-2 border-t border-border pt-4">
-        <Badge variant={duty?.variant ?? "secondary"}>{dutyLabel}</Badge>
+        <Badge variant={duty.variant}>{duty.label}</Badge>
         {state.currentVehicleId ? (
           <span className="inline-flex max-w-40 items-center gap-1 rounded-full border border-border bg-muted/50 px-2.5 py-1 text-xs text-muted-foreground">
             <TruckIcon className="size-3.5 shrink-0" />

--- a/client/apps/dash/src/routes/money.tsx
+++ b/client/apps/dash/src/routes/money.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 import { ExpensesSection } from "../_components/expenses-section";
 import { useDashFeatures } from "../_components/use-dash-features";
 import { DisputeStatusBadge, disputeCategoryLabels } from "../_components/portal-badges";
+import { canWithdrawDispute, escrowProgressPercent } from "../lib/settlement";
 
 export function DashMoneyPage() {
   const features = useDashFeatures();
@@ -61,9 +62,9 @@ export function DashMoneyPage() {
             {escrow.data.account.targetAmountMinor > 0 ? (
               <Progress
                 className="mt-3"
-                value={Math.min(
-                  100,
-                  (escrow.data.account.balanceMinor / escrow.data.account.targetAmountMinor) * 100,
+                value={escrowProgressPercent(
+                  escrow.data.account.balanceMinor,
+                  escrow.data.account.targetAmountMinor,
                 )}
               />
             ) : null}
@@ -159,7 +160,7 @@ type DisputeItemProps = {
 function DisputeItem({ dispute }: DisputeItemProps) {
   const queryClient = useQueryClient();
   const [pending, setPending] = useState(false);
-  const canWithdraw = dispute.status === "Open" || dispute.status === "InReview";
+  const canWithdraw = canWithdrawDispute(dispute.status);
 
   const handleWithdraw = async () => {
     setPending(true);

--- a/client/apps/dash/src/routes/settlement.tsx
+++ b/client/apps/dash/src/routes/settlement.tsx
@@ -16,30 +16,13 @@ import { Link, useParams } from "react-router";
 import { DisputeDrawer } from "../_components/dispute-drawer";
 import { useDashFeatures } from "../_components/use-dash-features";
 import { DisputeStatusBadge } from "../_components/portal-badges";
-
-const categoryOrder = [
-  "Earning",
-  "GuaranteeTopUp",
-  "Reimbursement",
-  "Adjustment",
-  "CarryForward",
-  "Deduction",
-  "EscrowContribution",
-  "AdvanceRecovery",
-] as const;
-
-const categoryLabels: Record<string, string> = {
-  Earning: "Earnings",
-  GuaranteeTopUp: "Guarantee top-up",
-  Reimbursement: "Reimbursements",
-  Adjustment: "Adjustments",
-  CarryForward: "Carry forward",
-  Deduction: "Deductions",
-  EscrowContribution: "Escrow",
-  AdvanceRecovery: "Advance recovery",
-};
-
-const deductionCategories = new Set(["Deduction", "EscrowContribution", "AdvanceRecovery"]);
+import {
+  groupSettlementLines,
+  lineAmountVariant,
+  lineDetail,
+  settlementCategoryLabels,
+  signedLineAmountMinor,
+} from "../lib/settlement";
 
 export function DashSettlementPage() {
   const { settlementId = "" } = useParams();
@@ -62,15 +45,10 @@ export function DashSettlementPage() {
     [disputes.data, settlementId],
   );
 
-  const groupedLines = useMemo(() => {
-    const lines = settlement.data?.lines ?? [];
-    return categoryOrder
-      .map((category) => ({
-        category,
-        lines: lines.filter((line) => line.category === category),
-      }))
-      .filter((group) => group.lines.length > 0);
-  }, [settlement.data]);
+  const groupedLines = useMemo(
+    () => groupSettlementLines(settlement.data?.lines ?? []),
+    [settlement.data],
+  );
 
   const openDispute = (line: PortalSettlementLine | null) => {
     setDisputedLine(line);
@@ -176,31 +154,20 @@ export function DashSettlementPage() {
       {groupedLines.map((group) => (
         <section key={group.category} className="rounded-2xl border border-border bg-card">
           <h2 className="px-4 pt-3 text-xs font-medium text-muted-foreground uppercase">
-            {categoryLabels[group.category] ?? group.category}
+            {settlementCategoryLabels[group.category] ?? group.category}
           </h2>
           <ul className="divide-y divide-border">
             {group.lines.map((line) => (
               <li key={line.id} className="flex items-center gap-2 px-4 py-3">
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-sm">{line.description}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {[
-                      line.proNumber || null,
-                      Number(line.quantity) > 0 && Number(line.rate) > 0
-                        ? `${line.quantity} × ${line.rate}`
-                        : null,
-                    ]
-                      .filter(Boolean)
-                      .join(" · ")}
-                  </p>
+                  <p className="text-xs text-muted-foreground">{lineDetail(line)}</p>
                 </div>
                 <span className="text-sm font-medium tabular-nums">
                   <AmountDisplay
-                    value={
-                      deductionCategories.has(line.category) ? -line.amountMinor : line.amountMinor
-                    }
+                    value={signedLineAmountMinor(line)}
                     currency={data.currencyCode}
-                    variant={deductionCategories.has(line.category) ? "negative" : "neutral"}
+                    variant={lineAmountVariant(line.category)}
                   />
                 </span>
                 {features.allowSettlementDisputes ? (


### PR DESCRIPTION
# Description

Fourth slice of the codebase completeness review. The driver portal (`apps/dash`) shipped with zero test files and its CI test script ran `vitest run --passWithNoTests`, so the suite was green by construction for the app that renders driver pay. This adds the first tests and removes the gate:

- **Extracted the inline logic into `apps/dash/src/lib/`** per the shared-code rules in `CLAUDE.md` (utilities don't live inline in components): settlement category grouping/ordering, deduction-family sign-flipping, line detail formatting, dispute withdrawability, and escrow progress into `lib/settlement.ts`; date keys, relative time, gauge-tone thresholds, and duty-status mapping into `lib/hos.ts`. The `money`, `settlement`, and `hos` routes now consume the extracted functions — behavior unchanged.
- **31 tests across three files**: the extracted settlement and HOS logic plus the already-pure load helpers in `_components/use-loads.ts` (origin/destination stop selection, US-address detection, TruckMap vs Google Maps directions routing, mileage formatting).
- **Removed `--passWithNoTests`**, so an empty dash suite fails CI again.

## Related Issue or Discussion

Found during a codebase completeness review; maintainer-driven session. Follow-up to #557–#559.

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [x] Tests
- [ ] Build, CI, or infrastructure

## Scope

- `client/apps/dash/src/lib/` (new: `settlement.ts`, `hos.ts` + tests)
- `client/apps/dash/src/routes/{money,settlement,hos}.tsx`
- `client/apps/dash/src/_components/use-loads.test.ts` (new)
- `client/apps/dash/package.json`

## Validation

- [x] Other: `pnpm --filter @trenova/dash test` (31 passed), `pnpm --filter @trenova/dash typecheck`, `pnpm --filter @trenova/dash lint` (0 errors; pre-existing tailwind class-order warnings untouched), `pnpm --filter @trenova/dash build`.
- [ ] `cd services/tms && task test` — not run; no backend changes.
- [ ] `cd services/tms && task lint` — not run; no backend changes.
- [x] `cd client && pnpm build` — dash app built; web unaffected by this diff.
- [x] `cd client && pnpm lint` — dash lint clean.

## Screenshots or Recordings

Not applicable — behavior-preserving extraction; no visual changes.

## Deployment Notes

- None. No API, config, or schema changes; the routes render identically.

## Checklist

- [x] I kept the change focused and reviewable.
- [x] I followed `AGENTS.md`, `CLAUDE.md`, and existing repository patterns.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable — this is a behavior-preserving extraction whose new tests pin the current behavior.
- [x] I updated relevant documentation, examples, migrations, or configuration.
- [x] I did not include secrets, credentials, private customer data, unrelated refactors, or placeholder code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015houJkqb8SuqPW4YpLoWCq

---
_Generated by [Claude Code](https://claude.ai/code/session_015houJkqb8SuqPW4YpLoWCq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer settlement line grouping, labels, amount formatting, and escrow progress calculations.
  * Improved Hours of Service displays with relative timestamps, duty-status labels, and gauge states.
  * Added consistent stop details, mileage formatting, and map directions handling.

* **Tests**
  * Added comprehensive automated coverage for dashboard, HOS, settlement, and load-related utilities.
  * Test runs now fail when no tests are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->