### PR TITLE
fix(security): bound the control-plane provisioning body before authentication

### DIFF
--- a/services/tms/config/config.example.yaml
+++ b/services/tms/config/config.example.yaml
@@ -20,6 +20,7 @@ platform:
     heartbeatInterval: 5m
     tenantSyncInterval: 1h
     failOpenOnError: false # Development only
+    maxProvisioningBodyBytes: 1048576 # Max /control-plane/tenants/provision body (bytes); bounded before the HMAC check
 
 # HTTP Server configuration
 server:

--- a/services/tms/internal/api/handlers/controlplaneprovisioninghandler/handler.go
+++ b/services/tms/internal/api/handlers/controlplaneprovisioninghandler/handler.go
@@ -58,8 +58,16 @@ func (h *Handler) RegisterPublicRoutes(rg *gin.RouterGroup) {
 }
 
 func (h *Handler) provisionTenant(c *gin.Context) {
-	body, err := io.ReadAll(c.Request.Body)
+	body, err := helpers.ReadBoundedRequestBody(
+		c,
+		h.cfg.Platform.ControlPlane.GetMaxProvisioningBodyBytes(),
+	)
 	if err != nil {
+		if helpers.IsRequestTooLargeError(err) {
+			h.eh.HandleError(c, err)
+			return
+		}
+
 		h.eh.HandleError(c, errortypes.NewValidationError(
 			"payload",
 			errortypes.ErrInvalid,

--- a/services/tms/internal/api/handlers/controlplaneprovisioninghandler/handler_test.go
+++ b/services/tms/internal/api/handlers/controlplaneprovisioninghandler/handler_test.go
@@ -3,9 +3,11 @@ package controlplaneprovisioninghandler
 import (
 	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
+
+const testMaxProvisioningBodyBytes = 4096
 
 type fakeProvisioningService struct {
 	called bool
@@ -85,6 +89,112 @@ func TestHandler_ProvisionTenant(t *testing.T) {
 	})
 }
 
+func TestHandler_ProvisionTenantBodyLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("rejects a declared oversized body without reading it", func(t *testing.T) {
+		service := &fakeProvisioningService{}
+		handler := newTestHandler(service)
+		router := gin.New()
+		handler.RegisterPublicRoutes(router.Group("/api/v1"))
+
+		payload := bytes.Repeat([]byte("a"), testMaxProvisioningBodyBytes*16)
+		source := &countingReader{r: bytes.NewReader(payload)}
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/api/v1/control-plane/tenants/provision",
+			source,
+		)
+		req.ContentLength = int64(len(payload))
+		rec := httptest.NewRecorder()
+
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+		require.False(t, service.called)
+		require.Zero(t, source.read)
+	})
+
+	t.Run("rejects an oversized chunked body with no content length", func(t *testing.T) {
+		service := &fakeProvisioningService{}
+		handler := newTestHandler(service)
+		router := gin.New()
+		handler.RegisterPublicRoutes(router.Group("/api/v1"))
+
+		source := &countingReader{
+			r: bytes.NewReader(bytes.Repeat([]byte("a"), testMaxProvisioningBodyBytes*16)),
+		}
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/api/v1/control-plane/tenants/provision",
+			source,
+		)
+		req.ContentLength = -1
+		req.TransferEncoding = []string{"chunked"}
+		rec := httptest.NewRecorder()
+
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+		require.False(t, service.called)
+		require.LessOrEqual(t, source.read, int64(testMaxProvisioningBodyBytes)+1)
+	})
+
+	t.Run("rejects a signed oversized body", func(t *testing.T) {
+		service := &fakeProvisioningService{}
+		handler := newTestHandler(service)
+		router := gin.New()
+		handler.RegisterPublicRoutes(router.Group("/api/v1"))
+		body := bytes.Repeat([]byte("a"), testMaxProvisioningBodyBytes+1)
+
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/api/v1/control-plane/tenants/provision",
+			bytes.NewReader(body),
+		)
+		signTestRequest(req, "cp_secret", body, time.Unix(100, 0))
+		rec := httptest.NewRecorder()
+
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+		require.False(t, service.called)
+	})
+
+	t.Run("accepts a signed body at the configured limit", func(t *testing.T) {
+		service := &fakeProvisioningService{}
+		handler := newTestHandler(service)
+		router := gin.New()
+		handler.RegisterPublicRoutes(router.Group("/api/v1"))
+		body := paddedProvisioningBody(t, testMaxProvisioningBodyBytes)
+		require.Len(t, body, testMaxProvisioningBodyBytes)
+
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/api/v1/control-plane/tenants/provision",
+			bytes.NewReader(body),
+		)
+		signTestRequest(req, "cp_secret", body, time.Unix(100, 0))
+		rec := httptest.NewRecorder()
+
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusAccepted, rec.Code)
+		require.True(t, service.called)
+	})
+}
+
+type countingReader struct {
+	r    io.Reader
+	read int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.read += int64(n)
+	return n, err
+}
+
 func newTestHandler(service services.TenantProvisioningService) *Handler {
 	cfg := &config.Config{
 		App: config.AppConfig{
@@ -93,7 +203,8 @@ func newTestHandler(service services.TenantProvisioningService) *Handler {
 		Platform: config.PlatformConfig{
 			InstanceID: "inst_test",
 			ControlPlane: config.PlatformControlPlaneConfig{
-				APIKey: "cp_secret",
+				APIKey:                   "cp_secret",
+				MaxProvisioningBodyBytes: testMaxProvisioningBodyBytes,
 			},
 		},
 	}
@@ -113,6 +224,21 @@ func newTestHandler(service services.TenantProvisioningService) *Handler {
 func mustProvisioningBody(t *testing.T) []byte {
 	t.Helper()
 
+	return mustProvisioningBodyWithPadding(t, 0)
+}
+
+func paddedProvisioningBody(t *testing.T, size int) []byte {
+	t.Helper()
+
+	base := mustProvisioningBodyWithPadding(t, 0)
+	require.Less(t, len(base), size)
+
+	return mustProvisioningBodyWithPadding(t, size-len(base))
+}
+
+func mustProvisioningBodyWithPadding(t *testing.T, padding int) []byte {
+	t.Helper()
+
 	customerID := pulid.MustNew("bu_")
 	body, err := sonic.Marshal(services.TenantProvisioningRequest{
 		InstanceID: "inst_test",
@@ -124,7 +250,7 @@ func mustProvisioningBody(t *testing.T) []byte {
 		Workspace: services.TenantProvisioningWorkspace{
 			ID:             pulid.MustNew("org_"),
 			BusinessUnitID: customerID,
-			Name:           "Acme Northeast",
+			Name:           "Acme Northeast" + strings.Repeat("a", padding),
 			State:          "NY",
 			AddressLine1:   "100 Main Street",
 			City:           "Albany",

--- a/services/tms/internal/api/helpers/classifier.go
+++ b/services/tms/internal/api/helpers/classifier.go
@@ -46,6 +46,7 @@ func (c *ChainClassifier) Classify(err error) ProblemType {
 func NewDefaultClassifier() *ChainClassifier {
 	return NewChainClassifier(
 		ClassifierFunc(classifyTimeout),
+		ClassifierFunc(classifyRequestTooLarge),
 		ClassifierFunc(classifyValidation),
 		ClassifierFunc(classifyFormula),
 		ClassifierFunc(classifyBadRequest),
@@ -69,6 +70,13 @@ func classifyTimeout(err error) (ProblemType, bool) {
 		return ProblemTypeTimeout, true
 	}
 
+	return "", false
+}
+
+func classifyRequestTooLarge(err error) (ProblemType, bool) {
+	if IsRequestTooLargeError(err) {
+		return ProblemTypeRequestTooLarge, true
+	}
 	return "", false
 }
 

--- a/services/tms/internal/api/helpers/problemtypes.go
+++ b/services/tms/internal/api/helpers/problemtypes.go
@@ -5,17 +5,18 @@ import "net/http"
 type ProblemType string
 
 const (
-	ProblemTypeBlank          = ProblemType("about:blank")
-	ProblemTypeValidation     = ProblemType("validation-error")
-	ProblemTypeBusiness       = ProblemType("business-rule-violation")
-	ProblemTypeDatabase       = ProblemType("database-error")
-	ProblemTypeAuthentication = ProblemType("authentication-error")
-	ProblemTypeAuthorization  = ProblemType("authorization-error")
-	ProblemTypeNotFound       = ProblemType("resource-not-found")
-	ProblemTypeRateLimit      = ProblemType("rate-limit-exceeded")
-	ProblemTypeConflict       = ProblemType("resource-conflict")
-	ProblemTypeTimeout        = ProblemType("request-timeout")
-	ProblemTypeInternal       = ProblemType("internal-error")
+	ProblemTypeBlank           = ProblemType("about:blank")
+	ProblemTypeValidation      = ProblemType("validation-error")
+	ProblemTypeBusiness        = ProblemType("business-rule-violation")
+	ProblemTypeDatabase        = ProblemType("database-error")
+	ProblemTypeAuthentication  = ProblemType("authentication-error")
+	ProblemTypeAuthorization   = ProblemType("authorization-error")
+	ProblemTypeNotFound        = ProblemType("resource-not-found")
+	ProblemTypeRequestTooLarge = ProblemType("request-entity-too-large")
+	ProblemTypeRateLimit       = ProblemType("rate-limit-exceeded")
+	ProblemTypeConflict        = ProblemType("resource-conflict")
+	ProblemTypeTimeout         = ProblemType("request-timeout")
+	ProblemTypeInternal        = ProblemType("internal-error")
 )
 
 type ProblemTypeInfo struct {
@@ -61,6 +62,12 @@ var problemTypeRegistry = map[ProblemType]ProblemTypeInfo{ //nolint:exhaustive /
 		Title:      "Resource Not Found",
 		StatusCode: http.StatusNotFound,
 		ShouldLog:  false,
+	},
+	ProblemTypeRequestTooLarge: {
+		Type:       ProblemTypeRequestTooLarge,
+		Title:      "Request Entity Too Large",
+		StatusCode: http.StatusRequestEntityTooLarge,
+		ShouldLog:  true,
 	},
 	ProblemTypeRateLimit: {
 		Type:       ProblemTypeRateLimit,

--- a/services/tms/internal/api/helpers/requestbody.go
+++ b/services/tms/internal/api/helpers/requestbody.go
@@ -1,0 +1,64 @@
+package helpers
+
+import (
+	"bytes"
+	"errors"
+	"math"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+const defaultBodyBufferBytes = 512
+
+type RequestTooLargeError struct {
+	Limit int64
+}
+
+func NewRequestTooLargeError(limit int64) *RequestTooLargeError {
+	return &RequestTooLargeError{Limit: limit}
+}
+
+func (e *RequestTooLargeError) Error() string {
+	return "request body exceeds the " + strconv.FormatInt(e.Limit, 10) + " byte limit"
+}
+
+func ReadBoundedRequestBody(c *gin.Context, limit int64) ([]byte, error) {
+	if c.Request.ContentLength > limit {
+		return nil, NewRequestTooLargeError(limit)
+	}
+
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, limit)
+
+	buf := bytes.NewBuffer(
+		make([]byte, 0, bodyBufferCapacity(c.Request.ContentLength, limit)),
+	)
+	if _, err := buf.ReadFrom(c.Request.Body); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			return nil, NewRequestTooLargeError(limit)
+		}
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func IsRequestTooLargeError(err error) bool {
+	var tooLargeErr *RequestTooLargeError
+	if errors.As(err, &tooLargeErr) {
+		return true
+	}
+
+	var maxBytesErr *http.MaxBytesError
+	return errors.As(err, &maxBytesErr)
+}
+
+func bodyBufferCapacity(contentLength, limit int64) int {
+	if contentLength <= 0 || contentLength > limit || contentLength > math.MaxInt {
+		return defaultBodyBufferBytes
+	}
+
+	return int(contentLength)
+}

--- a/services/tms/internal/api/helpers/requestbody_test.go
+++ b/services/tms/internal/api/helpers/requestbody_test.go
@@ -1,0 +1,172 @@
+package helpers_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/emoss08/trenova/internal/api/helpers"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type countingReader struct {
+	r    io.Reader
+	read int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.read += int64(n)
+	return n, err
+}
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) {
+	return 0, errors.New("boom")
+}
+
+func newBodyContext(body io.Reader, contentLength int64) *gin.Context {
+	gin.SetMode(gin.TestMode)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/", body)
+	c.Request.ContentLength = contentLength
+
+	return c
+}
+
+func TestReadBoundedRequestBody(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reads a body under the limit", func(t *testing.T) {
+		t.Parallel()
+		payload := []byte(`{"ok":true}`)
+		c := newBodyContext(bytes.NewReader(payload), int64(len(payload)))
+
+		body, err := helpers.ReadBoundedRequestBody(c, 1024)
+
+		require.NoError(t, err)
+		assert.Equal(t, payload, body)
+	})
+
+	t.Run("reads a body exactly at the limit", func(t *testing.T) {
+		t.Parallel()
+		payload := bytes.Repeat([]byte("a"), 64)
+		c := newBodyContext(bytes.NewReader(payload), int64(len(payload)))
+
+		body, err := helpers.ReadBoundedRequestBody(c, 64)
+
+		require.NoError(t, err)
+		assert.Equal(t, payload, body)
+	})
+
+	t.Run("rejects a declared content length over the limit without reading", func(t *testing.T) {
+		t.Parallel()
+		payload := bytes.Repeat([]byte("a"), 128)
+		source := &countingReader{r: bytes.NewReader(payload)}
+		c := newBodyContext(source, int64(len(payload)))
+
+		body, err := helpers.ReadBoundedRequestBody(c, 64)
+
+		require.Error(t, err)
+		assert.Nil(t, body)
+		assert.True(t, helpers.IsRequestTooLargeError(err))
+		assert.Zero(t, source.read)
+	})
+
+	t.Run("rejects an unknown content length over the limit", func(t *testing.T) {
+		t.Parallel()
+		source := &countingReader{r: bytes.NewReader(bytes.Repeat([]byte("a"), 1<<20))}
+		c := newBodyContext(source, -1)
+
+		body, err := helpers.ReadBoundedRequestBody(c, 64)
+
+		require.Error(t, err)
+		assert.Nil(t, body)
+		assert.True(t, helpers.IsRequestTooLargeError(err))
+		assert.LessOrEqual(t, source.read, int64(65))
+	})
+
+	t.Run("does not preallocate the limit for an unknown content length", func(t *testing.T) {
+		t.Parallel()
+		payload := []byte("small")
+		c := newBodyContext(bytes.NewReader(payload), -1)
+
+		body, err := helpers.ReadBoundedRequestBody(c, 1<<20)
+
+		require.NoError(t, err)
+		assert.Equal(t, payload, body)
+		assert.Less(t, cap(body), 1<<20)
+	})
+
+	t.Run("propagates a transport read failure unchanged", func(t *testing.T) {
+		t.Parallel()
+		c := newBodyContext(failingReader{}, -1)
+
+		body, err := helpers.ReadBoundedRequestBody(c, 64)
+
+		require.Error(t, err)
+		assert.Nil(t, body)
+		assert.False(t, helpers.IsRequestTooLargeError(err))
+	})
+}
+
+func TestRequestTooLargeError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("names the limit it enforced", func(t *testing.T) {
+		t.Parallel()
+		err := helpers.NewRequestTooLargeError(1024)
+
+		assert.Equal(t, "request body exceeds the 1024 byte limit", err.Error())
+	})
+
+	t.Run("is recognized through a wrapping error", func(t *testing.T) {
+		t.Parallel()
+		wrapped := errors.Join(errors.New("context"), helpers.NewRequestTooLargeError(1024))
+
+		assert.True(t, helpers.IsRequestTooLargeError(wrapped))
+	})
+
+	t.Run("recognizes the stdlib max bytes error", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, helpers.IsRequestTooLargeError(&http.MaxBytesError{Limit: 1024}))
+	})
+
+	t.Run("does not match unrelated errors", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, helpers.IsRequestTooLargeError(errors.New("boom")))
+		assert.False(t, helpers.IsRequestTooLargeError(nil))
+	})
+}
+
+func TestClassifyRequestTooLarge(t *testing.T) {
+	t.Parallel()
+
+	classifier := helpers.NewDefaultClassifier()
+
+	t.Run("maps the bounded reader error to 413", func(t *testing.T) {
+		t.Parallel()
+		problemType := classifier.Classify(helpers.NewRequestTooLargeError(1024))
+
+		assert.Equal(t, helpers.ProblemTypeRequestTooLarge, problemType)
+		assert.Equal(
+			t,
+			http.StatusRequestEntityTooLarge,
+			helpers.ProblemTypeRequestTooLarge.Info().StatusCode,
+		)
+	})
+
+	t.Run("maps the stdlib max bytes error to 413", func(t *testing.T) {
+		t.Parallel()
+		problemType := classifier.Classify(&http.MaxBytesError{Limit: 1024})
+
+		assert.Equal(t, helpers.ProblemTypeRequestTooLarge, problemType)
+	})
+}

--- a/services/tms/internal/infrastructure/config/config.go
+++ b/services/tms/internal/infrastructure/config/config.go
@@ -1283,14 +1283,25 @@ func (c *PlatformConfig) IsDevelopmentDeployment() bool {
 	return c.GetMode() == PlatformModeDevelopment
 }
 
+const defaultControlPlaneMaxProvisioningBodyBytes int64 = 1 << 20
+
 type PlatformControlPlaneConfig struct {
-	Enabled            bool          `mapstructure:"enabled"`
-	Endpoint           string        `mapstructure:"endpoint"           validate:"omitempty,url,no_trailing_slash"`
-	APIKey             string        `mapstructure:"apiKey"`
-	Timeout            time.Duration `mapstructure:"timeout"`
-	HeartbeatInterval  time.Duration `mapstructure:"heartbeatInterval"`
-	TenantSyncInterval time.Duration `mapstructure:"tenantSyncInterval"`
-	FailOpenOnError    bool          `mapstructure:"failOpenOnError"`
+	Enabled                  bool          `mapstructure:"enabled"`
+	Endpoint                 string        `mapstructure:"endpoint"                 validate:"omitempty,url,no_trailing_slash"`
+	APIKey                   string        `mapstructure:"apiKey"`
+	Timeout                  time.Duration `mapstructure:"timeout"`
+	HeartbeatInterval        time.Duration `mapstructure:"heartbeatInterval"`
+	TenantSyncInterval       time.Duration `mapstructure:"tenantSyncInterval"`
+	FailOpenOnError          bool          `mapstructure:"failOpenOnError"`
+	MaxProvisioningBodyBytes int64         `mapstructure:"maxProvisioningBodyBytes" validate:"omitempty,min=1024"`
+}
+
+func (c *PlatformControlPlaneConfig) GetMaxProvisioningBodyBytes() int64 {
+	if c.MaxProvisioningBodyBytes <= 0 {
+		return defaultControlPlaneMaxProvisioningBodyBytes
+	}
+
+	return c.MaxProvisioningBodyBytes
 }
 
 func (c *PlatformControlPlaneConfig) GetTimeout() time.Duration {


### PR DESCRIPTION
# Description

`POST /api/v1/control-plane/tenants/provision` is a public route (registered on the public group in `router.go:589`, no auth middleware ahead of it) that authenticates with HMAC headers. The handler buffered the entire request body with `io.ReadAll` *before* `verifySignature` ran, and applied no application-level byte ceiling. An unauthenticated caller could make the process allocate memory proportional to an attacker-chosen body before being answered `403`.

The 30s server `ReadTimeout` bounds request *duration*, not request *bytes*, and the request-count rate limiter (60/min, burst 10) bounds requests, not bytes per request.

This adds a shared bounded-body helper and uses it in the handler. Two details worth review attention:

- The limit is enforced twice: a short-circuit when a declared `Content-Length` exceeds it (rejects without reading a byte), and `http.MaxBytesReader` on the reader itself. The second is load-bearing — a chunked request carries no `Content-Length`, so a length check alone is trivially bypassed.
- The read buffer is preallocated from `Content-Length`, **not** from the limit. Sizing it to the limit would let a one-byte chunked request reserve the whole ceiling and reintroduce the amplification this is meant to remove.

The HMAC body hash is still computed over exactly the bytes read, so signature verification is unchanged for valid requests.

## Related Issue or Discussion

Fixes `GHSA-3r6h-w3x4-fm4c` (private advisory). Reported by Sevban Donmez (@jankesec).

Affected range verified against tag history: introduced in `6ce1a3b6` (2026-05-21), which added the handler with the unbounded read. First released in `v0.0.4`; present in every release through `v0.7.1`. `v0.0.1`–`v0.0.3` predate the handler and are unaffected.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Tests
- [ ] Build, CI, or infrastructure

## Scope

- `services/tms/internal/api/helpers/requestbody.go` (new) — `ReadBoundedRequestBody`, `RequestTooLargeError`, `IsRequestTooLargeError`
- `services/tms/internal/api/helpers/problemtypes.go` — new `request-entity-too-large` problem type mapping to HTTP 413
- `services/tms/internal/api/helpers/classifier.go` — classifies `*RequestTooLargeError` and `*http.MaxBytesError` to that type
- `services/tms/internal/api/handlers/controlplaneprovisioninghandler/handler.go` — the fix
- `services/tms/internal/infrastructure/config/config.go` — `platform.controlPlane.maxProvisioningBodyBytes`, default 1 MiB
- `services/tms/config/config.example.yaml` — documents the new key

Any handler that adopts the helper now gets a correct RFC 9457 `413` for free.

## Validation

- [ ] `cd services/tms && task test`
- [ ] `cd services/tms && task lint`
- [ ] `cd client && pnpm build`
- [ ] `cd client && pnpm lint`
- [x] Other: see below

Run directly rather than through `task`:

- `go build ./internal/... ./pkg/...` — clean
- `go test ./internal/api/handlers/controlplaneprovisioninghandler/... ./internal/api/helpers/... ./internal/infrastructure/config/...` — all pass
- `gofmt -l` on the changed packages — clean
- **Reverted the handler to the pre-fix `io.ReadAll` and re-ran the new tests**: 3 of 4 fail, returning `403` *after fully buffering the body* — the reported behavior, reproduced. The 4th (signed body at exactly the limit → `202`) passes both before and after; it is the control proving legitimate traffic still works.

New regression tests in `TestHandler_ProvisionTenantBodyLimit`:

| Case | Asserts |
|---|---|
| Oversized declared `Content-Length` | `413`, service not called, **zero** bytes read from the client stream |
| Oversized chunked, no `Content-Length` | `413`, service not called, at most `limit+1` bytes read |
| Oversized *signed* body | `413` — the cap applies regardless of credentials |
| Signed body at exactly the limit | `202`, service called |

Plus unit coverage in `helpers` for the reader, the error type, and the 413 classification.

**`task lint` was not run.** The sandbox's `golangci-lint` is built for Go 1.25 and the repo targets 1.26, so it refuses to load the config: `the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26)`. This is a pre-existing environment limitation, not a result of this change. `gofmt` is clean, but please run `task lint` before merging — the struct-tag realignment in `PlatformControlPlaneConfig` is exactly the kind of thing `golines` reformats.

Client checks were not run; this change touches no client code.

## Deployment Notes

- No migration.
- New optional config key `platform.controlPlane.maxProvisioningBodyBytes`. Defaults to 1 MiB when unset or `<= 0`, so **existing deployments need no config change**.
- Behavior change: provisioning requests over the limit now receive `413` instead of being buffered and then rejected with `403`. Legitimate provisioning payloads are far below 1 MiB. If a deployment has an unusually large payload, raise the key rather than removing the bound.
- Consider lowering the default once there is production data on the largest real payload.

## Checklist

- [x] I kept the change focused and reviewable.
- [x] I followed `AGENTS.md`, `CLAUDE.md`, and existing repository patterns.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I updated relevant documentation, examples, migrations, or configuration.
- [x] I did not include secrets, credentials, private customer data, unrelated refactors, or placeholder code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JA7VXNR32wbjXSHRRyYyKw


---
_Generated by [Claude Code](https://claude.ai/code/session_01JA7VXNR32wbjXSHRRyYyKw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable 1 MiB limit for tenant provisioning request bodies.
  - Oversized provisioning requests now return `413 Request Entity Too Large`.
  - Request-size validation applies to both declared and streamed request bodies.

- **Bug Fixes**
  - Prevented oversized requests from reaching provisioning services.
  - Added consistent error classification and handling for request-size violations.

- **Documentation**
  - Updated the example configuration with the provisioning body-size limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->