### PR TITLE
fix(client): regenerate error enums for the new problem type

### DIFF
--- a/client/packages/shared/src/types/generated/error-enums.ts
+++ b/client/packages/shared/src/types/generated/error-enums.ts
@@ -41,6 +41,7 @@ export const ProblemType = z.enum([
   "authentication-error",
   "authorization-error",
   "resource-not-found",
+  "request-entity-too-large",
   "rate-limit-exceeded",
   "resource-conflict",
   "request-timeout",


### PR DESCRIPTION
# Description

One generated line. `master` has been failing the `GraphQL Codegen` check since v0.8.0 shipped, and this is the whole cause.

The security fix in #575 added `ProblemTypeRequestTooLarge` to `services/tms/internal/api/helpers/problemtypes.go`. That file is a declared source for the generated client enum, but the artifact was never regenerated, so `error-enums.ts` has been one line stale on every commit since:

```diff
   "resource-not-found",
+  "request-entity-too-large",
   "rate-limit-exceeded",
```

This commit was part of #576 but missed the merge — that PR landed at the moment it was being pushed, so only two of its three commits went in. Rebased onto the current `master` and unchanged otherwise.

Regenerated with `pnpm --filter @trenova/graphql codegen`; the resulting diff was exactly the one line above, which confirms nothing else was stale.

## Related Issue or Discussion

Follow-up to #575 (GHSA-3r6h-w3x4-fm4c) and #576. Same class as #537, which regenerated these artifacts for the same reason.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Tests
- [x] Build, CI, or infrastructure

## Scope

- `client/packages/shared/src/types/generated/error-enums.ts` — generated, one line

## Validation

- [ ] `cd services/tms && task test`
- [ ] `cd services/tms && task lint`
- [ ] `cd client && pnpm build`
- [ ] `cd client && pnpm lint`
- [x] Other: see below

Ran the failing CI check itself rather than an approximation of it:

| Check | Before | After |
|---|---|---|
| `pnpm --filter @trenova/graphql codegen:check` | fails, `error-enums.ts \| 1 +` | **exit 0**, clean tree |
| `tsc -b` — `@trenova/web` | exit 0 | exit 0 |
| `tsc -b` — `@trenova/shared` | exit 0 | exit 0 |

Both were re-run after the rebase onto current `master`.

Note for anyone reproducing: `assert-codegen-clean.mjs` asserts a clean working tree, so `codegen:check` keeps failing until the regenerated file is actually committed — regenerating alone is not enough to make it pass locally.

`task test` / `task lint` were not run; this touches no Go code.

## Deployment Notes

- No migration, no config change, no runtime behaviour change. The enum gains one member that the API can already return; the client previously had no name for it.

## Checklist

- [x] I kept the change focused and reviewable.
- [x] I followed `AGENTS.md`, `CLAUDE.md`, and existing repository patterns.
- [ ] I added or updated tests for behavior changes, or explained why tests are not applicable — no tests; this is a regenerated artifact, and `codegen:check` in CI is the test.
- [x] I updated relevant documentation, examples, migrations, or configuration.
- [x] I did not include secrets, credentials, private customer data, unrelated refactors, or placeholder code.

---

Worth flagging beyond this diff: this staleness has now broken CI twice (#537, and here). The generator derives from `problemtypes.go` and `errortypes/enums.go`, so any Go change touching either silently breaks a client check with no local signal. A pre-commit hook running `codegen:check`, or a line in `CLAUDE.md` beside the error-handling section, would stop it recurring — not included here to keep this reviewable as a one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JA7VXNR32wbjXSHRRyYyKw


---
_Generated by [Claude Code](https://claude.ai/code/session_01JA7VXNR32wbjXSHRRyYyKw)_