### PR TITLE
fix(seed): select the retained earnings account the GLAccount guard requires

### DIFF
--- a/services/tms/internal/infrastructure/database/seeds/base/04_gl_account.go
+++ b/services/tms/internal/infrastructure/database/seeds/base/04_gl_account.go
@@ -3,6 +3,7 @@ package base
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/emoss08/trenova/internal/core/domain/accounttype"
 	"github.com/emoss08/trenova/internal/core/domain/costingcontrol"
@@ -134,7 +135,9 @@ func (s *GLAccountSeed) applyAccountingDefaults(
 		Column("id", "account_code").
 		Where("organization_id = ?", orgID).
 		Where("business_unit_id = ?", buID).
-		Where("account_code IN (?)", bun.List([]string{"1110", "6940"})).
+		// Every code the switch below reads has to be selected here, or its id
+		// stays nil and the guard fails for an account that was seeded correctly.
+		Where("account_code IN (?)", bun.List([]string{"1110", "6940", "3030"})).
 		Scan(ctx, &rows); err != nil {
 		return err
 	}
@@ -152,8 +155,21 @@ func (s *GLAccountSeed) applyAccountingDefaults(
 			retainedEarningsAccountID = rows[i].ID
 		}
 	}
-	if arAccountID.IsNil() || writeOffAccountID.IsNil() || retainedEarningsAccountID.IsNil() {
-		return fmt.Errorf("required accounting default accounts were not created")
+	missing := make([]string, 0, 3)
+	if arAccountID.IsNil() {
+		missing = append(missing, "1110 (AR)")
+	}
+	if writeOffAccountID.IsNil() {
+		missing = append(missing, "6940 (write-off)")
+	}
+	if retainedEarningsAccountID.IsNil() {
+		missing = append(missing, "3030 (retained earnings)")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"required accounting default accounts were not created: %s",
+			strings.Join(missing, ", "),
+		)
 	}
 
 	_, err := tx.NewUpdate().


### PR DESCRIPTION
`task db-seed` has failed since #582:

```
Seeding completed with errors: 16 applied, 0 skipped, 1 failed
Error: seed "GLAccount" failed during execution: GLAccount seed failed:
apply accounting control defaults for org Trenova Logistics:
required accounting default accounts were not created
```

— on a database where every one of those accounts *was* created.

## Cause

`applyAccountingDefaults` selects the accounts it needs by code, then reads them out of a switch:

```go
Where("account_code IN (?)", bun.List([]string{"1110", "6940"})).
...
switch rows[i].Code {
case "1110": arAccountID = rows[i].ID
case "6940": writeOffAccountID = rows[i].ID
case "3030": retainedEarningsAccountID = rows[i].ID   // never selected
}
if arAccountID.IsNil() || writeOffAccountID.IsNil() || retainedEarningsAccountID.IsNil() {
    return fmt.Errorf("required accounting default accounts were not created")
}
```

#582 added retained earnings to the switch and to the guard, but not to the `IN` clause. Account `3030` is seeded (`04_gl_account.go:774`) and was simply never fetched, so `retainedEarningsAccountID` was unconditionally nil and the guard could only fail. It has never passed since that commit.

## Fix

Add `3030` to the `IN` list, and make the guard name the accounts it could not find. The old message said only that something was missing, which sends the reader to the seed data — where all three accounts are present and correct — rather than to the query.

## Verification

Ran the seed against a live database:

- before: `16 applied, 0 skipped, 1 failed`
- after: **`23 applied, 15 skipped, 0 failed`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRNHv25GPL7ecKiUoBcBwz
