### PR TITLE
fix(billing): show where a shipment sits in the billing queue

### DIFF
--- a/client/apps/web/src/components/documents/__tests__/shipment-billing-readiness-panel.test.tsx
+++ b/client/apps/web/src/components/documents/__tests__/shipment-billing-readiness-panel.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { Shipment, ShipmentBillingReadiness } from "@trenova/shared/types/shipment";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ShipmentBillingReadinessPanel } from "../shipment-billing-readiness-panel";
+
+afterEach(cleanup);
+
+const readiness = {
+  shipmentId: "shp_1",
+  shipmentStatus: "ReadyToInvoice",
+  policy: {},
+  requirements: [],
+  missingRequirements: [],
+  validationFailures: [],
+  warnings: [],
+  serviceFailureContext: { hasUnresolved: false, unresolvedCount: 0, serviceFailureIds: [] },
+  canMarkReadyToInvoice: true,
+  shouldAutoMarkReadyToInvoice: false,
+  shouldAutoTransferToBilling: false,
+} as unknown as ShipmentBillingReadiness;
+
+function renderPanel(shipment: Partial<Shipment>) {
+  return render(
+    <ShipmentBillingReadinessPanel
+      readiness={readiness}
+      shipment={{ id: "shp_1", ...shipment } as Shipment}
+      onUploadRequired={vi.fn()}
+      onMarkReadyToInvoice={vi.fn()}
+      isMarkingReady={false}
+    />,
+  );
+}
+
+describe("ShipmentBillingReadinessPanel status hint", () => {
+  it("reports the billing queue state once billing holds the shipment", () => {
+    renderPanel({ status: "ReadyToInvoice", billingTransferStatus: "SentBackToOps" });
+
+    expect(screen.getByTitle("Billing queue: Sent Back to Ops")).toBeInTheDocument();
+    expect(screen.queryByText("Ready to invoice")).not.toBeInTheDocument();
+  });
+
+  it("still says ready to invoice before the shipment is transferred", () => {
+    renderPanel({ status: "ReadyToInvoice", billingTransferStatus: null });
+
+    expect(screen.getByText("Ready to invoice")).toBeInTheDocument();
+  });
+});

--- a/client/apps/web/src/components/documents/shipment-billing-readiness-panel.tsx
+++ b/client/apps/web/src/components/documents/shipment-billing-readiness-panel.tsx
@@ -14,6 +14,7 @@ import {
   ExternalLinkIcon,
   UploadIcon,
 } from "lucide-react";
+import { ShipmentBillingQueueBadge } from "@/routes/shipment/_components/shipment-billing-queue-status";
 
 interface ShipmentBillingReadinessPanelProps {
   readiness: ShipmentBillingReadiness;
@@ -134,7 +135,11 @@ export function ShipmentBillingReadinessPanel({
       <div className="border-b px-4 py-3">
         <div className="flex items-center justify-between gap-4">
           <span className="text-sm font-semibold">{t("Billing Readiness")}</span>
-          <span className="text-2xs text-muted-foreground">{statusHint}</span>
+          {shipment?.billingTransferStatus ? (
+            <ShipmentBillingQueueBadge status={shipment.billingTransferStatus} />
+          ) : (
+            <span className="text-2xs text-muted-foreground">{statusHint}</span>
+          )}
         </div>
 
         <div className="mt-3 space-y-1.5">

--- a/client/apps/web/src/lib/choices.ts
+++ b/client/apps/web/src/lib/choices.ts
@@ -685,16 +685,6 @@ export const billingQueueStatusChoices = [
   { label: "Canceled", value: "Canceled", color: "#b91c1c" },
 ] satisfies ReadonlyArray<GenericSelectOption<BillingQueueStatus>>;
 
-export const billingTransferStatusChoices = [
-  { label: "Ready for Review", value: "ReadyForReview", color: "#3b82f6" },
-  { label: "In Review", value: "InReview", color: "#0891b2" },
-  { label: "Approved", value: "Approved", color: "#16a34a" },
-  { label: "On Hold", value: "OnHold", color: "#f59e0b" },
-  { label: "Sent Back to Ops", value: "SentBackToOps", color: "#f97316" },
-  { label: "Exception", value: "Exception", color: "#dc2626" },
-  { label: "Canceled", value: "Canceled", color: "#b91c1c" },
-] satisfies ReadonlyArray<GenericSelectOption<string>>;
-
 export const moveStatusChoices = [
   { label: "New", value: "New", color: "#3b82f6" },
   { label: "Assigned", value: "Assigned", color: "#16a34a" },

--- a/client/apps/web/src/routes/shipment/_components/__tests__/shipment-billing-queue-status.test.tsx
+++ b/client/apps/web/src/routes/shipment/_components/__tests__/shipment-billing-queue-status.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { Shipment } from "@trenova/shared/types/shipment";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it } from "vitest";
+import { ShipmentBillingQueueStatus } from "../shipment-billing-queue-status";
+
+afterEach(cleanup);
+
+function renderStatus(shipment: Partial<Shipment>) {
+  return render(
+    <MemoryRouter>
+      <ShipmentBillingQueueStatus
+        shipment={{ id: "shp_1", proNumber: "PRO 1001/A", ...shipment } as Shipment}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("ShipmentBillingQueueStatus", () => {
+  it("shows the billing queue state and links to the shipment in the queue", () => {
+    renderStatus({ status: "ReadyToInvoice", billingTransferStatus: "SentBackToOps" });
+
+    expect(screen.getByText("Sent Back to Ops")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /view in billing queue/i })).toHaveAttribute(
+      "href",
+      "/billing/queue?query=PRO%201001%2FA&includePosted=true",
+    );
+  });
+
+  it("renders nothing for a shipment that was never transferred", () => {
+    const { container } = renderStatus({ status: "Completed", billingTransferStatus: null });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/client/apps/web/src/routes/shipment/_components/__tests__/shipment-form-billing-lock.test.tsx
+++ b/client/apps/web/src/routes/shipment/_components/__tests__/shipment-form-billing-lock.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { Shipment } from "@trenova/shared/types/shipment";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import type { ReactNode } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ShipmentForm } from "../shipment-form";
+
+vi.mock("../shipment-service-details", () => ({ default: () => null }));
+vi.mock("../shipment-billing-details", () => ({ default: () => <p>billing details</p> }));
+vi.mock("../additional-charges/shipment-additional-charges", () => ({ default: () => null }));
+vi.mock("../shipment-general-information", () => ({ default: () => null }));
+vi.mock("../shipment-commodities", () => ({ default: () => null }));
+vi.mock("../load-envelope-panel", () => ({ default: () => null }));
+vi.mock("../move/shipment-move-details", () => ({ default: () => null }));
+vi.mock("../trailer-loading/trailer-loading-drawer", () => ({ default: () => null }));
+vi.mock("../recurring-shipment-suggestion", () => ({ RecurringShipmentSuggestion: () => null }));
+
+afterEach(cleanup);
+
+function Harness({ values, children }: { values: Partial<Shipment>; children: ReactNode }) {
+  const form = useForm<Shipment>({ defaultValues: values as Shipment });
+  return (
+    <NuqsTestingAdapter>
+      <FormProvider {...form}>{children}</FormProvider>
+    </NuqsTestingAdapter>
+  );
+}
+
+function renderForm(values: Partial<Shipment>) {
+  return render(
+    <Harness values={values}>
+      <ShipmentForm />
+    </Harness>,
+  );
+}
+
+describe("ShipmentForm billing lock", () => {
+  it.each(["Approved", "Posted"] as const)(
+    "locks the charges of a shipment whose invoice is %s",
+    async (billingTransferStatus) => {
+      renderForm({ status: "Invoiced", billingTransferStatus });
+
+      expect(await screen.findByText("billing details")).toBeInTheDocument();
+      expect(screen.getByText("Locked — shipment has been invoiced")).toBeInTheDocument();
+      expect(screen.queryByText("Under Billing Review")).not.toBeInTheDocument();
+    },
+  );
+
+  it("leaves a shipment billing sent back to operations editable", async () => {
+    renderForm({ status: "ReadyToInvoice", billingTransferStatus: "SentBackToOps" });
+
+    expect(await screen.findByText("billing details")).toBeInTheDocument();
+    expect(screen.queryByText("Locked — shipment has been invoiced")).not.toBeInTheDocument();
+    expect(screen.queryByText("Under Billing Review")).not.toBeInTheDocument();
+  });
+});

--- a/client/apps/web/src/routes/shipment/_components/command-center/cells/status-cell.test.tsx
+++ b/client/apps/web/src/routes/shipment/_components/command-center/cells/status-cell.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { Shipment } from "@trenova/shared/types/shipment";
+import { afterEach, describe, expect, it } from "vitest";
+import { StatusCell } from "./status-cell";
+
+afterEach(cleanup);
+
+function makeShipment(overrides: Partial<Shipment>): Shipment {
+  return { id: "shp_1", status: "ReadyToInvoice", ...overrides } as Shipment;
+}
+
+describe("StatusCell", () => {
+  it("shows where the shipment sits in the billing queue under its status", () => {
+    render(<StatusCell shipment={makeShipment({ billingTransferStatus: "InReview" })} />);
+
+    const billing = screen.getByText("In Review");
+    expect(billing.closest("[title]")).toHaveAttribute("title", "Billing queue: In Review");
+  });
+
+  it("shows a posted invoice as Posted", () => {
+    render(
+      <StatusCell
+        shipment={makeShipment({ status: "Invoiced", billingTransferStatus: "Posted" })}
+      />,
+    );
+
+    expect(screen.getByTitle("Billing queue: Posted")).toBeInTheDocument();
+  });
+
+  it("shows nothing extra for a shipment billing has never received", () => {
+    const { container } = render(
+      <StatusCell shipment={makeShipment({ billingTransferStatus: null })} />,
+    );
+
+    expect(container.querySelector("[title^='Billing queue']")).toBeNull();
+  });
+});

--- a/client/apps/web/src/routes/shipment/_components/command-center/cells/status-cell.tsx
+++ b/client/apps/web/src/routes/shipment/_components/command-center/cells/status-cell.tsx
@@ -1,10 +1,12 @@
 import { ShipmentStatusBadge } from "@trenova/shared/components/status-badge";
 import type { Shipment } from "@trenova/shared/types/shipment";
+import { ShipmentBillingQueueBadge } from "../../shipment-billing-queue-status";
 
 export function StatusCell({ shipment }: { shipment: Shipment }) {
   return (
     <div className="inline-flex flex-col items-start gap-1">
       <ShipmentStatusBadge status={shipment.status} />
+      <ShipmentBillingQueueBadge status={shipment.billingTransferStatus} />
     </div>
   );
 }

--- a/client/apps/web/src/routes/shipment/_components/shipment-billing-queue-status.tsx
+++ b/client/apps/web/src/routes/shipment/_components/shipment-billing-queue-status.tsx
@@ -1,0 +1,41 @@
+import { useT } from "@trenova/shared/i18n/use-t";
+import {
+  BillingQueueStatusBadge,
+  billingQueueStatusBadges,
+} from "@trenova/shared/components/status-badge";
+import type { BillingQueueStatus } from "@trenova/shared/types/billing-queue";
+import type { Shipment } from "@trenova/shared/types/shipment";
+import { ExternalLinkIcon } from "lucide-react";
+import { Link } from "react-router";
+
+export function ShipmentBillingQueueBadge({ status }: { status?: BillingQueueStatus | null }) {
+  const t = useT();
+
+  if (!status) return null;
+
+  return (
+    <BillingQueueStatusBadge
+      status={status}
+      title={t("Billing queue: {0}", billingQueueStatusBadges[status].text)}
+    />
+  );
+}
+
+export function ShipmentBillingQueueStatus({ shipment }: { shipment: Shipment }) {
+  const t = useT();
+
+  if (!shipment.billingTransferStatus) return null;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <ShipmentBillingQueueBadge status={shipment.billingTransferStatus} />
+      <Link
+        to={`/billing/queue?query=${encodeURIComponent(shipment.proNumber ?? "")}&includePosted=true`}
+        className="text-2xs text-primary inline-flex items-center gap-0.5 underline-offset-4 hover:underline"
+      >
+        {t("View in billing queue")}
+        <ExternalLinkIcon className="size-3" />
+      </Link>
+    </div>
+  );
+}

--- a/client/apps/web/src/routes/shipment/_components/shipment-form.tsx
+++ b/client/apps/web/src/routes/shipment/_components/shipment-form.tsx
@@ -1,5 +1,6 @@
 "use no memo";
 import { useT } from "@trenova/shared/i18n/use-t";
+import type { BillingQueueStatus } from "@trenova/shared/types/billing-queue";
 import type { Shipment } from "@trenova/shared/types/shipment";
 import { FileTextIcon, LockIcon } from "lucide-react";
 import { parseAsBoolean, useQueryState } from "nuqs";
@@ -19,7 +20,12 @@ const LoadEnvelopePanel = lazy(() => import("./load-envelope-panel"));
 const ShipmentMoveDetails = lazy(() => import("./move/shipment-move-details"));
 const LoadPlannerDialog = lazy(() => import("./trailer-loading/trailer-loading-drawer"));
 
-const BILLING_REVIEW_STATUSES = new Set(["ReadyForReview", "InReview", "OnHold", "Exception"]);
+const BILLING_REVIEW_STATUSES: ReadonlySet<BillingQueueStatus> = new Set([
+  "ReadyForReview",
+  "InReview",
+  "OnHold",
+  "Exception",
+]);
 
 export function ShipmentForm() {
   const t = useT();
@@ -32,8 +38,9 @@ export function ShipmentForm() {
   const { control } = useFormContext<Shipment>();
   const billingTransferStatus = useWatch({ control, name: "billingTransferStatus" });
 
-  const isInBillingReview = BILLING_REVIEW_STATUSES.has(billingTransferStatus as string);
-  const isInvoiced = billingTransferStatus === "Approved";
+  const isInBillingReview =
+    !!billingTransferStatus && BILLING_REVIEW_STATUSES.has(billingTransferStatus);
+  const isInvoiced = billingTransferStatus === "Approved" || billingTransferStatus === "Posted";
   const isCanceled = billingTransferStatus === "Canceled";
   const isFullyLocked = isInBillingReview || isCanceled;
 

--- a/client/apps/web/src/routes/shipment/_components/shipment-panel.tsx
+++ b/client/apps/web/src/routes/shipment/_components/shipment-panel.tsx
@@ -27,6 +27,7 @@ import { parseAsBoolean, useQueryState } from "nuqs";
 import { lazy } from "react";
 import { useForm } from "react-hook-form";
 import { ShipmentBillingActionsMenu } from "./shipment-billing-actions-menu";
+import { ShipmentBillingQueueStatus } from "./shipment-billing-queue-status";
 import { ShipmentForm } from "./shipment-form";
 
 const AuditTab = lazy(() => import("@/components/audit-tab"));
@@ -215,7 +216,12 @@ export function ShipmentPanel({ open, onOpenChange, mode, row }: DataTablePanelP
         mutationFn={(values, currentRow) =>
           apiService.shipmentService.update(currentRow.id!, values as ShipmentUpdateInput)
         }
-        descriptionExtra={<OwnerDisplay ownerId={row?.ownerId} />}
+        descriptionExtra={
+          <div className="flex items-center gap-3">
+            {row && <ShipmentBillingQueueStatus shipment={row} />}
+            <OwnerDisplay ownerId={row?.ownerId} />
+          </div>
+        }
         headerActions={
           <>
             {row && <ShipmentBillingActionsMenu shipment={row} />}

--- a/client/packages/shared/src/components/status-badge.tsx
+++ b/client/packages/shared/src/components/status-badge.tsx
@@ -314,56 +314,61 @@ export function ShipmentTenderStatusBadge({
   );
 }
 
+export const billingQueueStatusBadges: Record<BillingQueueStatus, BadgeAttrProps> = {
+  ReadyForReview: {
+    variant: "info",
+    text: "Ready for Review",
+  },
+  InReview: {
+    variant: "purple",
+    text: "In Review",
+  },
+  Approved: {
+    variant: "active",
+    text: "Approved",
+  },
+  Posted: {
+    variant: "teal",
+    text: "Posted",
+  },
+  OnHold: {
+    variant: "warning",
+    text: "On Hold",
+  },
+  SentBackToOps: {
+    variant: "orange",
+    text: "Sent Back to Ops",
+  },
+  Exception: {
+    variant: "inactive",
+    text: "Exception",
+  },
+  Canceled: {
+    variant: "inactive",
+    text: "Canceled",
+  },
+};
+
 export function BillingQueueStatusBadge({
   status,
   className,
+  title,
 }: {
-  status?: BillingQueueStatus;
+  status?: BillingQueueStatus | null;
   className?: string;
+  title?: string;
 }) {
   if (!status) return null;
 
-  const statusAttributes: Record<BillingQueueStatus, BadgeAttrProps> = {
-    ReadyForReview: {
-      variant: "info",
-      text: "Ready for Review",
-    },
-    InReview: {
-      variant: "purple",
-      text: "In Review",
-    },
-    Approved: {
-      variant: "active",
-      text: "Approved",
-    },
-    Posted: {
-      variant: "teal",
-      text: "Posted",
-    },
-    OnHold: {
-      variant: "warning",
-      text: "On Hold",
-    },
-    SentBackToOps: {
-      variant: "orange",
-      text: "Sent Back to Ops",
-    },
-    Exception: {
-      variant: "inactive",
-      text: "Exception",
-    },
-    Canceled: {
-      variant: "inactive",
-      text: "Canceled",
-    },
-  };
+  const { variant, text } = billingQueueStatusBadges[status];
 
   return (
-    <Badge variant={statusAttributes[status].variant} className={cn(className, "max-h-5")}>
-      {statusAttributes[status].text}
+    <Badge variant={variant} title={title} className={cn(className, "max-h-5")}>
+      {text}
     </Badge>
   );
 }
+
 export function PlainBillingQueueStatusBadge({ status }: { status: BillingQueueStatus }) {
   const statusAttributes: Record<BillingQueueStatus, PlainBadgeAttrProps> = {
     ReadyForReview: {

--- a/client/packages/shared/src/types/billing-queue-status.ts
+++ b/client/packages/shared/src/types/billing-queue-status.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const billingQueueStatusSchema = z.enum([
+  "ReadyForReview",
+  "InReview",
+  "Approved",
+  "Posted",
+  "OnHold",
+  "SentBackToOps",
+  "Exception",
+  "Canceled",
+]);
+export type BillingQueueStatus = z.infer<typeof billingQueueStatusSchema>;

--- a/client/packages/shared/src/types/billing-queue.ts
+++ b/client/packages/shared/src/types/billing-queue.ts
@@ -1,22 +1,12 @@
 import { z } from "zod";
 import { billTypeSchema } from "./bill-type";
+import { billingQueueStatusSchema } from "./billing-queue-status";
 import { decimalStringSchema, nullableStringSchema, optionalStringSchema } from "./helpers";
 import { shipmentSchema } from "./shipment";
 import { userSchema } from "./user";
 
 export { billTypeSchema, defaultBillTypeSchema, type BillType } from "./bill-type";
-
-export const billingQueueStatusSchema = z.enum([
-  "ReadyForReview",
-  "InReview",
-  "Approved",
-  "Posted",
-  "OnHold",
-  "SentBackToOps",
-  "Exception",
-  "Canceled",
-]);
-export type BillingQueueStatus = z.infer<typeof billingQueueStatusSchema>;
+export { billingQueueStatusSchema, type BillingQueueStatus } from "./billing-queue-status";
 
 export const exceptionReasonCodeSchema = z.enum([
   "MissingDocumentation",

--- a/client/packages/shared/src/types/shipment.ts
+++ b/client/packages/shared/src/types/shipment.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 import { accessorialChargeMethodSchema, type AccessorialCharge } from "./accessorial-charge";
 import { defaultBillTypeSchema } from "./bill-type";
+import { billingQueueStatusSchema } from "./billing-queue-status";
 import type { Commodity } from "./commodity";
 import { customerSchema } from "./customer";
 import { formulaReceiptSchema, formulaTemplateSchema } from "./formula-template";
 import {
   decimalNumberSchema,
   decimalStringSchema,
+  nullableEnumSchema,
   nullableIntegerSchema,
   nullableStringSchema,
   optionalStringSchema,
@@ -560,7 +562,7 @@ const shipmentBaseSchema = z.object({
   actualDeliveryDate: nullableIntegerSchema,
   actualShipDate: nullableIntegerSchema,
   canceledAt: nullableIntegerSchema,
-  billingTransferStatus: nullableStringSchema,
+  billingTransferStatus: nullableEnumSchema(billingQueueStatusSchema),
   transferredToBillingAt: nullableIntegerSchema,
   markedReadyToBillAt: nullableIntegerSchema,
   billedAt: nullableIntegerSchema,

--- a/services/tms/internal/core/domain/shipment/enums.go
+++ b/services/tms/internal/core/domain/shipment/enums.go
@@ -42,6 +42,7 @@ const (
 	BillingTransferException      = BillingTransferStatus("Exception")
 	BillingTransferSentBackToOps  = BillingTransferStatus("SentBackToOps")
 	BillingTransferApproved       = BillingTransferStatus("Approved")
+	BillingTransferPosted         = BillingTransferStatus("Posted")
 	BillingTransferCanceled       = BillingTransferStatus("Canceled")
 )
 
@@ -202,6 +203,7 @@ func (v BillingTransferStatus) IsValid() bool {
 		BillingTransferException,
 		BillingTransferSentBackToOps,
 		BillingTransferApproved,
+		BillingTransferPosted,
 		BillingTransferCanceled:
 		return true
 	default:

--- a/services/tms/internal/core/services/billingqueueservice/service.go
+++ b/services/tms/internal/core/services/billingqueueservice/service.go
@@ -258,16 +258,6 @@ func (s *service) TransferToBilling(
 		return nil, err
 	}
 
-	now := timeutils.NowUnix()
-	shp.BillingTransferStatus = shipment.BillingTransferReadyForReview
-	shp.TransferredToBillingAt = &now
-	if _, err = s.shipmentRepo.UpdateDerivedState(ctx, shp); err != nil {
-		s.l.Warn("failed to update shipment billing tracking fields",
-			zap.String("shipmentId", shp.ID.String()),
-			zap.Error(err),
-		)
-	}
-
 	s.autoAssignDefaultBiller(ctx, created, shp.CustomerID, req.TenantInfo, actor)
 
 	if req.AutoApprove {
@@ -539,8 +529,6 @@ func (s *service) UpdateStatus(
 		return nil, err
 	}
 
-	s.syncShipmentBillingStatus(ctx, updated, req.NewStatus)
-
 	if req.NewStatus == billingqueue.StatusSentBackToOps {
 		s.createOpsComment(ctx, updated, actor)
 	}
@@ -596,62 +584,6 @@ func (s *service) completeReplacementReview(
 	adjustment.ReplacementReviewStatus = invoiceadjustment.ReplacementReviewStatusCompleted
 	_, err = s.adjustmentRepo.UpdateAdjustment(ctx, adjustment)
 	return err
-}
-
-func (s *service) syncShipmentBillingStatus(
-	ctx context.Context,
-	entity *billingqueue.BillingQueueItem,
-	newStatus billingqueue.Status,
-) {
-	shp, err := s.shipmentRepo.GetByID(ctx, &repositories.GetShipmentByIDRequest{
-		ID: entity.ShipmentID,
-		TenantInfo: pagination.TenantInfo{
-			OrgID: entity.OrganizationID,
-			BuID:  entity.BusinessUnitID,
-		},
-		ShipmentOptions: repositories.ShipmentOptions{
-			ExpandShipmentDetails: true,
-		},
-	})
-	if err != nil {
-		s.l.Warn("failed to fetch shipment for billing status sync",
-			zap.String("shipmentId", entity.ShipmentID.String()),
-			zap.Error(err),
-		)
-		return
-	}
-
-	shp.BillingTransferStatus = shipmentBillingTransferStatus(newStatus)
-
-	if _, err = s.shipmentRepo.UpdateDerivedState(ctx, shp); err != nil {
-		s.l.Warn("failed to sync shipment billing transfer status",
-			zap.String("shipmentId", shp.ID.String()),
-			zap.Error(err),
-		)
-	}
-}
-
-func shipmentBillingTransferStatus(status billingqueue.Status) shipment.BillingTransferStatus {
-	switch status {
-	case billingqueue.StatusReadyForReview:
-		return shipment.BillingTransferReadyForReview
-	case billingqueue.StatusInReview:
-		return shipment.BillingTransferInReview
-	case billingqueue.StatusApproved:
-		return shipment.BillingTransferApproved
-	case billingqueue.StatusPosted:
-		return shipment.BillingTransferApproved
-	case billingqueue.StatusOnHold:
-		return shipment.BillingTransferOnHold
-	case billingqueue.StatusException:
-		return shipment.BillingTransferException
-	case billingqueue.StatusSentBackToOps:
-		return shipment.BillingTransferSentBackToOps
-	case billingqueue.StatusCanceled:
-		return shipment.BillingTransferCanceled
-	default:
-		return shipment.BillingTransferNone
-	}
 }
 
 func (s *service) createOpsComment(

--- a/services/tms/internal/core/services/invoiceservice/grouped_invoice_integration_test.go
+++ b/services/tms/internal/core/services/invoiceservice/grouped_invoice_integration_test.go
@@ -346,6 +346,16 @@ func TestGroupedInvoiceFromOrderEndToEnd(t *testing.T) {
 		Scan(ctx, &postedCount))
 	assert.Equal(t, 2, postedCount, "both leg billing-queue items should be Posted")
 
+	// Each leg's shipment shows its billing-queue item as Posted.
+	var postedLegCount int
+	require.NoError(t, db.NewSelect().
+		Table("shipments").
+		ColumnExpr("count(*)").
+		Where("id IN (?)", bun.List([]pulid.ID{legRows[0].ID, legRows[1].ID})).
+		Where("billing_transfer_status = ?", "Posted").
+		Scan(ctx, &postedLegCount))
+	assert.Equal(t, 2, postedLegCount, "both leg shipments should show Posted")
+
 	// Every leg was marked Invoiced.
 	assert.True(t, invoicedLegs[legRows[0].ID], "leg 0 should be invoiced")
 	assert.True(t, invoicedLegs[legRows[1].ID], "leg 1 should be invoiced")

--- a/services/tms/internal/infrastructure/postgres/migrations/20261217000000_shipment_billing_transfer_backfill.tx.down.sql
+++ b/services/tms/internal/infrastructure/postgres/migrations/20261217000000_shipment_billing_transfer_backfill.tx.down.sql
@@ -1,0 +1,7 @@
+--
+-- Copyright 2023-2025 Eric Moss
+-- Licensed under FSL-1.1-ALv2 (Functional Source License 1.1, Apache 2.0 Future)
+-- Full license: https://github.com/emoss08/Trenova/blob/master/LICENSE.md--
+-- The backfill corrected drifted values in place; the drifted values are not kept,
+-- and the corrected ones are valid under the previous code, so there is nothing to undo.
+SELECT 1;

--- a/services/tms/internal/infrastructure/postgres/migrations/20261217000000_shipment_billing_transfer_backfill.tx.up.sql
+++ b/services/tms/internal/infrastructure/postgres/migrations/20261217000000_shipment_billing_transfer_backfill.tx.up.sql
@@ -1,0 +1,30 @@
+--
+-- Copyright 2023-2025 Eric Moss
+-- Licensed under FSL-1.1-ALv2 (Functional Source License 1.1, Apache 2.0 Future)
+-- Full license: https://github.com/emoss08/Trenova/blob/master/LICENSE.md--
+-- A shipment's billing_transfer_status mirrors its latest invoice billing-queue item.
+-- Before the billing queue repository became its only writer, assigning a biller,
+-- posting an invoice and invoicing directly all changed the item without the
+-- shipment, so existing rows are re-derived from the items once here.
+UPDATE "shipments" AS sp
+SET "billing_transfer_status" = latest."status"::text,
+    "transferred_to_billing_at" = latest."created_at"
+FROM (
+    SELECT DISTINCT ON (bqi."shipment_id", bqi."organization_id", bqi."business_unit_id")
+        bqi."shipment_id",
+        bqi."organization_id",
+        bqi."business_unit_id",
+        bqi."status",
+        bqi."created_at"
+    FROM "billing_queue_items" AS bqi
+    WHERE bqi."bill_type" = 'Invoice'
+    ORDER BY
+        bqi."shipment_id",
+        bqi."organization_id",
+        bqi."business_unit_id",
+        bqi."created_at" DESC,
+        bqi."id" DESC
+) AS latest
+WHERE sp."id" = latest."shipment_id"
+    AND sp."organization_id" = latest."organization_id"
+    AND sp."business_unit_id" = latest."business_unit_id";

--- a/services/tms/internal/infrastructure/postgres/repositories/billingqueuerepository/billingqueue.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/billingqueuerepository/billingqueue.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/emoss08/trenova/internal/core/domain/billingqueue"
+	"github.com/emoss08/trenova/internal/core/domain/shipment"
 	"github.com/emoss08/trenova/internal/core/ports/repositories"
 	"github.com/emoss08/trenova/internal/infrastructure/postgres"
 	"github.com/emoss08/trenova/pkg/buncolgen"
@@ -124,6 +125,14 @@ func (r *repository) Create(
 		return nil, fmt.Errorf("insert billing queue item: %w", err)
 	}
 
+	if err := r.syncShipmentTransferState(
+		ctx,
+		tenantInfo(entity),
+		[]pulid.ID{entity.ShipmentID},
+	); err != nil {
+		return nil, err
+	}
+
 	return r.GetByID(ctx, &repositories.GetBillingQueueItemByIDRequest{
 		ItemID:     entity.ID,
 		TenantInfo: tenantInfo(entity),
@@ -165,6 +174,14 @@ func (r *repository) Update(
 		entity.ID.String(),
 	); rowsErr != nil {
 		return nil, rowsErr
+	}
+
+	if err = r.syncShipmentTransferState(
+		ctx,
+		tenantInfo(entity),
+		[]pulid.ID{entity.ShipmentID},
+	); err != nil {
+		return nil, err
 	}
 
 	return r.GetByID(ctx, &repositories.GetBillingQueueItemByIDRequest{
@@ -248,19 +265,61 @@ func (r *repository) markPosted(
 		Where(bqi.Status.Ne(), billingqueue.StatusPosted).
 		Where(bqi.Status.Ne(), billingqueue.StatusCanceled).
 		Set(bqi.Status.Set(), billingqueue.StatusPosted).
-		Set(bqi.Version.Inc(1))
+		Set(bqi.Version.Inc(1)).
+		Returning(bqi.ShipmentID.Bare())
 
-	result, err := scope(q).Exec(ctx)
-	if err != nil {
+	shipmentIDs := make([]pulid.ID, 0)
+	if _, err := scope(q).Exec(ctx, &shipmentIDs); err != nil {
 		return 0, fmt.Errorf("mark billing queue items posted: %w", err)
 	}
 
-	affected, err := result.RowsAffected()
-	if err != nil {
-		return 0, fmt.Errorf("rows affected: %w", err)
+	if err := r.syncShipmentTransferState(ctx, tenantInfo, shipmentIDs); err != nil {
+		return 0, err
 	}
 
-	return affected, nil
+	return int64(len(shipmentIDs)), nil
+}
+
+// syncShipmentTransferState copies each shipment's billing-queue state onto the
+// shipment from its latest invoice item, inside the caller's transaction. Every write
+// to a billing queue item goes through this repository, so this is the only writer of
+// the shipment's billing_transfer_status and transferred_to_billing_at columns.
+func (r *repository) syncShipmentTransferState(
+	ctx context.Context,
+	ti pagination.TenantInfo,
+	shipmentIDs []pulid.ID,
+) error {
+	if len(shipmentIDs) == 0 {
+		return nil
+	}
+
+	bqi := buncolgen.BillingQueueItemColumns
+	sp := buncolgen.ShipmentColumns
+	db := r.db.DBForContext(ctx)
+
+	latest := db.NewSelect().
+		Model((*billingqueue.BillingQueueItem)(nil)).
+		DistinctOn(bqi.ShipmentID.Qualified()).
+		Column(bqi.ShipmentID.Bare(), bqi.Status.Bare(), bqi.CreatedAt.Bare()).
+		Apply(buncolgen.BillingQueueItemApplyTenant(ti)).
+		Where(bqi.ShipmentID.In(), bun.List(shipmentIDs)).
+		Where(bqi.BillType.Eq(), billingqueue.BillTypeInvoice).
+		Order(bqi.ShipmentID.OrderAsc(), bqi.CreatedAt.OrderDesc(), bqi.ID.OrderDesc())
+
+	if _, err := db.NewUpdate().
+		Model((*shipment.Shipment)(nil)).
+		TableExpr("(?) AS latest", latest).
+		Set(sp.BillingTransferStatus.SetExpr("latest.status::text")).
+		Set(sp.TransferredToBillingAt.SetExpr("latest.created_at")).
+		WhereGroup(" AND ", func(uq *bun.UpdateQuery) *bun.UpdateQuery {
+			return buncolgen.ShipmentScopeTenantUpdate(uq, ti).
+				Where(sp.ID.Expr("{} = latest.shipment_id"))
+		}).
+		Exec(ctx); err != nil {
+		return fmt.Errorf("sync shipment billing transfer state: %w", err)
+	}
+
+	return nil
 }
 
 func (r *repository) ExistsByShipmentAndType(

--- a/services/tms/internal/infrastructure/postgres/repositories/billingqueuerepository/shipment_sync_integration_test.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/billingqueuerepository/shipment_sync_integration_test.go
@@ -1,0 +1,225 @@
+//go:build integration
+
+package billingqueuerepository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/emoss08/trenova/internal/core/domain/billingqueue"
+	"github.com/emoss08/trenova/internal/core/domain/shipment"
+	"github.com/emoss08/trenova/internal/core/ports/repositories"
+	"github.com/emoss08/trenova/internal/infrastructure/config"
+	"github.com/emoss08/trenova/internal/infrastructure/database/common"
+	"github.com/emoss08/trenova/internal/infrastructure/database/seeder"
+	"github.com/emoss08/trenova/internal/infrastructure/database/seeds"
+	"github.com/emoss08/trenova/internal/infrastructure/postgres"
+	"github.com/emoss08/trenova/internal/infrastructure/postgres/repositories/shipmentrepository"
+	"github.com/emoss08/trenova/internal/testutil/seedtest"
+	"github.com/emoss08/trenova/pkg/pagination"
+	"github.com/emoss08/trenova/shared/pulid"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"go.uber.org/zap"
+)
+
+type syncTenant struct {
+	ID             pulid.ID `bun:"id"`
+	BusinessUnitID pulid.ID `bun:"business_unit_id"`
+}
+
+type syncShipmentRow struct {
+	BillingTransferStatus  *string `bun:"billing_transfer_status"`
+	TransferredToBillingAt *int64  `bun:"transferred_to_billing_at"`
+}
+
+type syncFixture struct {
+	ctx          context.Context
+	db           *bun.DB
+	repo         *repository
+	shipmentRepo repositories.ShipmentRepository
+	tenant       pagination.TenantInfo
+	shipmentID   pulid.ID
+}
+
+func setupSyncFixture(t *testing.T) *syncFixture {
+	t.Helper()
+
+	ctx, db, cleanup := seedtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	registry := seeder.NewRegistry()
+	seeds.Register(registry)
+	engine := seeder.NewEngine(
+		db,
+		registry,
+		&config.Config{System: config.SystemConfig{SystemUserPassword: "test-system-password"}},
+	)
+	_, err := engine.Execute(ctx, seeder.ExecuteOptions{Environment: common.EnvDevelopment})
+	require.NoError(t, err)
+
+	var org syncTenant
+	require.NoError(t, db.NewSelect().
+		Table("organizations").Column("id", "business_unit_id").Limit(1).Scan(ctx, &org))
+
+	var shipmentID pulid.ID
+	require.NoError(t, db.NewSelect().
+		Table("shipments").Column("id").
+		Where("organization_id = ?", org.ID).
+		Where("business_unit_id = ?", org.BusinessUnitID).
+		Order("created_at ASC").
+		Limit(1).Scan(ctx, &shipmentID))
+
+	conn := postgres.NewTestConnection(db)
+	logger := zap.NewNop()
+
+	return &syncFixture{
+		ctx:          ctx,
+		db:           db,
+		repo:         New(Params{DB: conn, Logger: logger}).(*repository),
+		shipmentRepo: shipmentrepository.New(shipmentrepository.Params{DB: conn, Logger: logger}),
+		tenant:       pagination.TenantInfo{OrgID: org.ID, BuID: org.BusinessUnitID},
+		shipmentID:   shipmentID,
+	}
+}
+
+func (f *syncFixture) createItem(
+	t *testing.T,
+	number string,
+	status billingqueue.Status,
+	billType billingqueue.BillType,
+) *billingqueue.BillingQueueItem {
+	t.Helper()
+
+	item, err := f.repo.Create(f.ctx, &billingqueue.BillingQueueItem{
+		OrganizationID: f.tenant.OrgID,
+		BusinessUnitID: f.tenant.BuID,
+		ShipmentID:     f.shipmentID,
+		Status:         status,
+		BillType:       billType,
+		Number:         number,
+	})
+	require.NoError(t, err)
+	return item
+}
+
+func (f *syncFixture) updateStatus(
+	t *testing.T,
+	item *billingqueue.BillingQueueItem,
+	status billingqueue.Status,
+) *billingqueue.BillingQueueItem {
+	t.Helper()
+
+	item.Status = status
+	updated, err := f.repo.Update(f.ctx, item)
+	require.NoError(t, err)
+	return updated
+}
+
+func (f *syncFixture) shipmentRow(t *testing.T) syncShipmentRow {
+	t.Helper()
+
+	var row syncShipmentRow
+	require.NoError(t, f.db.NewSelect().
+		Table("shipments").
+		Column("billing_transfer_status", "transferred_to_billing_at").
+		Where("id = ?", f.shipmentID).
+		Scan(f.ctx, &row))
+	return row
+}
+
+func requireTransferStatus(t *testing.T, row syncShipmentRow, want billingqueue.Status) {
+	t.Helper()
+
+	require.NotNil(t, row.BillingTransferStatus)
+	require.Equal(t, string(want), *row.BillingTransferStatus)
+}
+
+func TestShipmentMirrorsItsBillingQueueItem(t *testing.T) {
+	f := setupSyncFixture(t)
+
+	item := f.createItem(
+		t,
+		"BQ-SYNC-0001",
+		billingqueue.StatusReadyForReview,
+		billingqueue.BillTypeInvoice,
+	)
+
+	row := f.shipmentRow(t)
+	requireTransferStatus(t, row, billingqueue.StatusReadyForReview)
+	require.NotNil(t, row.TransferredToBillingAt)
+	require.Equal(t, item.CreatedAt, *row.TransferredToBillingAt)
+
+	item = f.updateStatus(t, item, billingqueue.StatusInReview)
+	requireTransferStatus(t, f.shipmentRow(t), billingqueue.StatusInReview)
+
+	item = f.updateStatus(t, item, billingqueue.StatusApproved)
+	requireTransferStatus(t, f.shipmentRow(t), billingqueue.StatusApproved)
+
+	f.updateStatus(t, item, billingqueue.StatusPosted)
+	requireTransferStatus(t, f.shipmentRow(t), billingqueue.StatusPosted)
+}
+
+func TestShipmentFollowsItsLatestInvoiceItem(t *testing.T) {
+	f := setupSyncFixture(t)
+
+	older := f.createItem(
+		t,
+		"BQ-SYNC-0101",
+		billingqueue.StatusReadyForReview,
+		billingqueue.BillTypeInvoice,
+	)
+	older = f.updateStatus(t, older, billingqueue.StatusSentBackToOps)
+
+	newer := f.createItem(
+		t,
+		"BQ-SYNC-0102",
+		billingqueue.StatusReadyForReview,
+		billingqueue.BillTypeInvoice,
+	)
+	requireTransferStatus(t, f.shipmentRow(t), billingqueue.StatusReadyForReview)
+
+	f.updateStatus(t, older, billingqueue.StatusCanceled)
+
+	row := f.shipmentRow(t)
+	requireTransferStatus(t, row, billingqueue.StatusReadyForReview)
+	require.Equal(t, newer.CreatedAt, *row.TransferredToBillingAt)
+}
+
+func TestCreditMemoItemsDoNotMoveTheShipment(t *testing.T) {
+	f := setupSyncFixture(t)
+
+	f.createItem(t, "BQ-SYNC-0201", billingqueue.StatusInReview, billingqueue.BillTypeInvoice)
+	f.createItem(t, "BQ-SYNC-0202", billingqueue.StatusPosted, billingqueue.BillTypeCreditMemo)
+
+	requireTransferStatus(t, f.shipmentRow(t), billingqueue.StatusInReview)
+}
+
+func TestShipmentWritesCannotOverwriteTheMirror(t *testing.T) {
+	f := setupSyncFixture(t)
+
+	f.createItem(t, "BQ-SYNC-0301", billingqueue.StatusInReview, billingqueue.BillTypeInvoice)
+	transferredAt := f.shipmentRow(t).TransferredToBillingAt
+
+	entity, err := f.shipmentRepo.GetByID(f.ctx, &repositories.GetShipmentByIDRequest{
+		ID:              f.shipmentID,
+		TenantInfo:      f.tenant,
+		ShipmentOptions: repositories.ShipmentOptions{ExpandShipmentDetails: true},
+	})
+	require.NoError(t, err)
+
+	entity.BillingTransferStatus = shipment.BillingTransferSentBackToOps
+	entity.TransferredToBillingAt = nil
+	entity, err = f.shipmentRepo.Update(f.ctx, entity)
+	require.NoError(t, err)
+
+	row := f.shipmentRow(t)
+	requireTransferStatus(t, row, billingqueue.StatusInReview)
+	require.Equal(t, transferredAt, row.TransferredToBillingAt)
+
+	entity.BillingTransferStatus = shipment.BillingTransferNone
+	_, err = f.shipmentRepo.UpdateDerivedState(f.ctx, entity)
+	require.NoError(t, err)
+
+	requireTransferStatus(t, f.shipmentRow(t), billingqueue.StatusInReview)
+}

--- a/services/tms/internal/infrastructure/postgres/repositories/shipmentrepository/shipment.go
+++ b/services/tms/internal/infrastructure/postgres/repositories/shipmentrepository/shipment.go
@@ -490,7 +490,11 @@ func (r *repository) Update(
 
 		results, err := r.db.DBForContext(c).NewUpdate().
 			Model(entity).
-			ExcludeColumn(sp.CreatedAt.Bare()).
+			ExcludeColumn(
+				sp.CreatedAt.Bare(),
+				sp.BillingTransferStatus.Bare(),
+				sp.TransferredToBillingAt.Bare(),
+			).
 			WhereGroup(" AND ", func(uq *bun.UpdateQuery) *bun.UpdateQuery {
 				return buncolgen.ShipmentScopeTenantUpdate(uq, pagination.TenantInfo{
 					OrgID: entity.OrganizationID,
@@ -598,8 +602,6 @@ func (r *repository) UpdateDerivedState(
 				sp.OtherChargeAmount.Bare(),
 				sp.TotalChargeAmount.Bare(),
 				sp.RatingDetail.Bare(),
-				sp.BillingTransferStatus.Bare(),
-				sp.TransferredToBillingAt.Bare(),
 				sp.MarkedReadyToBillAt.Bare(),
 				sp.BilledAt.Bare(),
 				sp.Version.Bare(),

--- a/services/tms/internal/infrastructure/sqlite/migrations/20261217000000_shipment_billing_transfer_backfill.tx.down.sql
+++ b/services/tms/internal/infrastructure/sqlite/migrations/20261217000000_shipment_billing_transfer_backfill.tx.down.sql
@@ -1,0 +1,6 @@
+-- Code generated from the PostgreSQL migrations by
+-- scripts/dialect-convert/convert.py. Hand-edits are preserved only if you
+-- stop regenerating this file; see docs/databases.md.
+-- Source: 20261217000000_shipment_billing_transfer_backfill.tx.down.sql
+
+SELECT 1;

--- a/services/tms/internal/infrastructure/sqlite/migrations/20261217000000_shipment_billing_transfer_backfill.tx.up.sql
+++ b/services/tms/internal/infrastructure/sqlite/migrations/20261217000000_shipment_billing_transfer_backfill.tx.up.sql
@@ -1,0 +1,37 @@
+-- Code generated from the PostgreSQL migrations by
+-- scripts/dialect-convert/convert.py. Hand-edits are preserved only if you
+-- stop regenerating this file; see docs/databases.md.
+-- Source: 20261217000000_shipment_billing_transfer_backfill.tx.up.sql
+--
+-- Hand-completed: SQLite has no DISTINCT ON or UPDATE ... FROM with a derived
+-- ordering, so the latest invoice item is picked with correlated subqueries.
+
+UPDATE "shipments"
+SET "billing_transfer_status" = (
+        SELECT bqi."status"
+        FROM "billing_queue_items" AS bqi
+        WHERE bqi."shipment_id" = "shipments"."id"
+            AND bqi."organization_id" = "shipments"."organization_id"
+            AND bqi."business_unit_id" = "shipments"."business_unit_id"
+            AND bqi."bill_type" = 'Invoice'
+        ORDER BY bqi."created_at" DESC, bqi."id" DESC
+        LIMIT 1
+    ),
+    "transferred_to_billing_at" = (
+        SELECT bqi."created_at"
+        FROM "billing_queue_items" AS bqi
+        WHERE bqi."shipment_id" = "shipments"."id"
+            AND bqi."organization_id" = "shipments"."organization_id"
+            AND bqi."business_unit_id" = "shipments"."business_unit_id"
+            AND bqi."bill_type" = 'Invoice'
+        ORDER BY bqi."created_at" DESC, bqi."id" DESC
+        LIMIT 1
+    )
+WHERE EXISTS (
+    SELECT 1
+    FROM "billing_queue_items" AS bqi
+    WHERE bqi."shipment_id" = "shipments"."id"
+        AND bqi."organization_id" = "shipments"."organization_id"
+        AND bqi."business_unit_id" = "shipments"."business_unit_id"
+        AND bqi."bill_type" = 'Invoice'
+);


### PR DESCRIPTION
There was no way to tell from a shipment whether billing held it. This adds no new shipment status: `Shipment.Status` is the operational lifecycle that order status, EDI and analytics key off, and the billing queue already has its own eight states. The shipment already had a mirror of its queue item, `billing_transfer_status`; this makes that mirror correct and shows it.

## The mirror drifted

Only the billing queue's status-change path wrote it, after the transaction committed and logging a warning on failure. Several paths never wrote it:

- assigning a biller (item → In Review)
- posting an invoice, including the sibling sweep for grouped invoices
- direct invoicing (`invoiceservice/delivery.go` creates items as Approved)

`Posted` had no shipment value; it was folded into Approved. And a shipment save wrote the column from client input, so a save could overwrite it.

## Fix

- **One writer.** Every billing queue item create, update and post goes through the billing queue repository. It now re-derives the shipment's `billing_transfer_status` and `transferred_to_billing_at` from the shipment's **latest invoice item**, inside the caller's transaction. Using the latest item keeps it right when an older item is canceled after a newer one exists. Credit and debit memo items don't move it. The service-level sync is removed.
- **`Posted`** is now a shipment billing transfer status and stays locked, like Approved.
- **Shipment `Update` and `UpdateDerivedState`** no longer write those two columns.
- **GraphQL schema unchanged:** the field stays `String`, so no codegen and no breaking diff.

## UI

- **Command center status column:** a billing queue badge under the shipment status, with a "Billing queue: …" tooltip.
- **Shipment panel header:** the same badge plus a "View in billing queue" link. It searches the queue by PRO number, because a shipment doesn't carry its queue item ID.
- **Documents tab:** once billing holds the shipment, the readiness panel shows the queue state instead of always saying "Ready to invoice".
- **Shipment form:** `Posted` locks charges like `Approved`.

This reuses the existing (previously unused) `BillingQueueStatusBadge`. Its labels are now exported so the tooltip shares them, and `billingQueueStatusSchema` moved to its own file to avoid a `billing-queue.ts` ↔ `shipment.ts` import cycle. The duplicate `billingTransferStatusChoices` is removed.

## Migrations

- `20261217000000_shipment_billing_transfer_backfill` re-derives every shipment's billing transfer status and transfer time from its latest invoice item. The SQLite mirror is hand-written with correlated subqueries, since SQLite has no `DISTINCT ON`.

## Behavior to be aware of

The sync does not increase the shipment's version. A shipment panel that is already open refreshes through the usual invalidation, not a version change.

## Verification

- **Go:** `billingqueueservice`, `shipmentservice`, `invoiceservice`, the shipment domain and repository, and migration tests pass. `go vet` is clean.
- **Integration tests (not run locally, no Docker; compiled with `go vet -tags=integration`):**
  - new `billingqueuerepository/shipment_sync_integration_test.go`: status changes reach the shipment, the latest invoice item wins, credit memos are ignored, shipment writes can't overwrite the mirror
  - the grouped-invoice test now asserts both legs show `Posted`
- **Client:** 4 new tests (status cell badge, panel queue link, readiness hint, Posted form lock), each shown failing against the pre-change code first. `tsc -b` is clean for web and dash, oxlint is clean on the touched files, and the related suites pass (97 files, 784 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtZ2HUFVwg3rNof8gefYG8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Shipment screens now display billing queue status alongside shipment status.
  - Billing queue statuses link directly to the filtered billing queue.
  - Posted invoices are recognized as a completed billing state.

- **Bug Fixes**
  - Shipment billing status now stays synchronized with the latest billing queue activity.
  - Invoiced shipments are locked appropriately, while shipments sent back to operations remain editable.
  - Existing shipment records are updated to reflect their current billing queue status.

- **Tests**
  - Added coverage for billing status displays, navigation, invoice locking, and status synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->