### PR TITLE
fix(shipment): give billing queue state its own command center column

### DIFF
--- a/client/apps/web/src/lib/choices.ts
+++ b/client/apps/web/src/lib/choices.ts
@@ -685,6 +685,13 @@ export const billingQueueStatusChoices = [
   { label: "Canceled", value: "Canceled", color: "#b91c1c" },
 ] satisfies ReadonlyArray<GenericSelectOption<BillingQueueStatus>>;
 
+// The queue hides posted items behind its own toggle, so its status filter omits
+// Posted; a shipment's billing state includes it.
+export const shipmentBillingStatusChoices = [
+  ...billingQueueStatusChoices,
+  { label: "Posted", value: "Posted", color: "#0d9488" },
+] satisfies ReadonlyArray<GenericSelectOption<BillingQueueStatus>>;
+
 export const moveStatusChoices = [
   { label: "New", value: "New", color: "#3b82f6" },
   { label: "Assigned", value: "Assigned", color: "#16a34a" },

--- a/client/apps/web/src/routes/shipment/_components/__tests__/shipment-columns-billing.test.ts
+++ b/client/apps/web/src/routes/shipment/_components/__tests__/shipment-columns-billing.test.ts
@@ -1,0 +1,31 @@
+import { getColumns } from "@/routes/shipment/_components/shipment-columns";
+import { describe, expect, it } from "vitest";
+
+describe("shipment billing column", () => {
+  const columns = getColumns([]);
+  const column = columns.find((entry) => entry.id === "billing");
+
+  it("sits right after the tender column", () => {
+    const ids = columns.map((entry) => entry.id);
+
+    expect(ids.indexOf("billing")).toBe(ids.indexOf("tenderStatus") + 1);
+  });
+
+  it("filters on the shipment's billing transfer status, Posted included", () => {
+    expect(column?.header).toBe("Billing");
+    expect(column?.meta?.apiField).toBe("billingTransferStatus");
+    expect(column?.meta?.filterType).toBe("select");
+    expect(column?.meta?.filterOptions?.map((option) => option.value)).toEqual(
+      expect.arrayContaining([
+        "ReadyForReview",
+        "InReview",
+        "Approved",
+        "Posted",
+        "OnHold",
+        "SentBackToOps",
+        "Exception",
+        "Canceled",
+      ]),
+    );
+  });
+});

--- a/client/apps/web/src/routes/shipment/_components/command-center/cells/billing-cell.test.tsx
+++ b/client/apps/web/src/routes/shipment/_components/command-center/cells/billing-cell.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { Shipment } from "@trenova/shared/types/shipment";
+import { afterEach, describe, expect, it } from "vitest";
+import { BillingCell } from "./billing-cell";
+
+afterEach(cleanup);
+
+function renderCell(overrides: Partial<Shipment>) {
+  return render(
+    <BillingCell shipment={{ id: "shp_1", status: "ReadyToInvoice", ...overrides } as Shipment} />,
+  );
+}
+
+describe("BillingCell", () => {
+  it.each([
+    ["ReadyForReview", "Ready for Review"],
+    ["InReview", "In Review"],
+    ["Approved", "Approved"],
+    ["Posted", "Posted"],
+    ["OnHold", "On Hold"],
+    ["SentBackToOps", "Sent Back to Ops"],
+    ["Exception", "Exception"],
+    ["Canceled", "Canceled"],
+  ] as const)("labels %s as %s", (billingTransferStatus, label) => {
+    renderCell({ billingTransferStatus });
+
+    expect(screen.getByText(label)).toBeInTheDocument();
+    expect(screen.getByTitle(`Billing queue: ${label}`)).toBeInTheDocument();
+  });
+
+  it("shows a dash for a shipment billing has never received", () => {
+    renderCell({ billingTransferStatus: null });
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(document.querySelector("[title^='Billing queue']")).toBeNull();
+  });
+});

--- a/client/apps/web/src/routes/shipment/_components/command-center/cells/billing-cell.tsx
+++ b/client/apps/web/src/routes/shipment/_components/command-center/cells/billing-cell.tsx
@@ -1,0 +1,28 @@
+import { ColorOptionValue } from "@/components/fields/select-components";
+import { shipmentBillingStatusChoices } from "@/lib/choices";
+import { useT } from "@trenova/shared/i18n/use-t";
+import type { Shipment } from "@trenova/shared/types/shipment";
+
+export function BillingCell({ shipment }: { shipment: Shipment }) {
+  const t = useT();
+  const choice = shipmentBillingStatusChoices.find(
+    (option) => option.value === shipment.billingTransferStatus,
+  );
+
+  if (!choice) {
+    return <span className="font-table text-muted-foreground text-[11.5px]">—</span>;
+  }
+
+  const label = t(choice.label);
+
+  return (
+    <div title={t("Billing queue: {0}", label)}>
+      <ColorOptionValue
+        value={label}
+        color={choice.color}
+        className="h-auto"
+        textClassName="font-table text-[11.5px]"
+      />
+    </div>
+  );
+}

--- a/client/apps/web/src/routes/shipment/_components/command-center/cells/status-cell.test.tsx
+++ b/client/apps/web/src/routes/shipment/_components/command-center/cells/status-cell.test.tsx
@@ -5,33 +5,18 @@ import { StatusCell } from "./status-cell";
 
 afterEach(cleanup);
 
-function makeShipment(overrides: Partial<Shipment>): Shipment {
-  return { id: "shp_1", status: "ReadyToInvoice", ...overrides } as Shipment;
-}
-
 describe("StatusCell", () => {
-  it("shows where the shipment sits in the billing queue under its status", () => {
-    render(<StatusCell shipment={makeShipment({ billingTransferStatus: "InReview" })} />);
-
-    const billing = screen.getByText("In Review");
-    expect(billing.closest("[title]")).toHaveAttribute("title", "Billing queue: In Review");
-  });
-
-  it("shows a posted invoice as Posted", () => {
+  // Billing has its own column; the status cell holds the shipment's status alone.
+  it("shows the shipment status without the billing queue state", () => {
     render(
       <StatusCell
-        shipment={makeShipment({ status: "Invoiced", billingTransferStatus: "Posted" })}
+        shipment={
+          { id: "shp_1", status: "ReadyToInvoice", billingTransferStatus: "InReview" } as Shipment
+        }
       />,
     );
 
-    expect(screen.getByTitle("Billing queue: Posted")).toBeInTheDocument();
-  });
-
-  it("shows nothing extra for a shipment billing has never received", () => {
-    const { container } = render(
-      <StatusCell shipment={makeShipment({ billingTransferStatus: null })} />,
-    );
-
-    expect(container.querySelector("[title^='Billing queue']")).toBeNull();
+    expect(screen.getByText("Ready to Invoice")).toBeInTheDocument();
+    expect(screen.queryByText("In Review")).not.toBeInTheDocument();
   });
 });

--- a/client/apps/web/src/routes/shipment/_components/command-center/cells/status-cell.tsx
+++ b/client/apps/web/src/routes/shipment/_components/command-center/cells/status-cell.tsx
@@ -1,12 +1,10 @@
 import { ShipmentStatusBadge } from "@trenova/shared/components/status-badge";
 import type { Shipment } from "@trenova/shared/types/shipment";
-import { ShipmentBillingQueueBadge } from "../../shipment-billing-queue-status";
 
 export function StatusCell({ shipment }: { shipment: Shipment }) {
   return (
     <div className="inline-flex flex-col items-start gap-1">
       <ShipmentStatusBadge status={shipment.status} />
-      <ShipmentBillingQueueBadge status={shipment.billingTransferStatus} />
     </div>
   );
 }

--- a/client/apps/web/src/routes/shipment/_components/shipment-columns.tsx
+++ b/client/apps/web/src/routes/shipment/_components/shipment-columns.tsx
@@ -1,7 +1,11 @@
 import { translate } from "@trenova/shared/i18n/runtime";
 import { EntityRefCell } from "@/components/data-table/_components/entity-ref-link";
 import { ShipmentTenderStatusBadge } from "@trenova/shared/components/status-badge";
-import { shipmentStatusChoices, shipmentTenderStatusChoices } from "@/lib/choices";
+import {
+  shipmentBillingStatusChoices,
+  shipmentStatusChoices,
+  shipmentTenderStatusChoices,
+} from "@/lib/choices";
 import { formatToUserTimezone } from "@trenova/shared/lib/date";
 import { getDestinationStop, getOriginStop } from "@/lib/shipment-utils";
 import type { Customer } from "@trenova/shared/types/customer";
@@ -9,6 +13,7 @@ import type { RowAction, ColumnDef } from "@trenova/shared/types/data-table";
 import type { Shipment, Stop } from "@trenova/shared/types/shipment";
 import { Link } from "react-router";
 import { ActionsCell } from "./command-center/cells/actions-cell";
+import { BillingCell } from "./command-center/cells/billing-cell";
 import { DriverCell } from "./command-center/cells/driver-cell";
 import { EtaCell } from "./command-center/cells/eta-cell";
 import { LaneCell } from "./command-center/cells/lane-cell";
@@ -94,6 +99,24 @@ export function getColumns(rowActions: RowAction<Shipment>[]): ColumnDef<Shipmen
       size: 130,
       minSize: 120,
       maxSize: 170,
+    },
+    {
+      id: "billing",
+      accessorKey: "billingTransferStatus",
+      header: "Billing",
+      cell: ({ row }) => <BillingCell shipment={row.original} />,
+      meta: {
+        apiField: "billingTransferStatus",
+        label: "Billing",
+        filterable: true,
+        sortable: true,
+        filterType: "select",
+        filterOptions: shipmentBillingStatusChoices,
+        defaultFilterOperator: "eq",
+      },
+      size: 140,
+      minSize: 120,
+      maxSize: 180,
     },
     {
       id: "proBol",


### PR DESCRIPTION
Follow-up to #590. A full billing queue badge stacked under the shipment status looked like a second status and crowded the status cell.

## Change

- **Status column** shows only the shipment status again.
- **New Billing column** sits right after Tender. It shows a colored dot and label in table type, reusing `ColorOptionValue`, for example "● In Review". Hovering shows "Billing queue: …", and a shipment billing never received shows "—".
- **Filtering and sorting:** the column filters on `billingTransferStatus` over every billing queue state, and is sortable.
  - The filter uses a new `shipmentBillingStatusChoices`, built from `billingQueueStatusChoices` plus Posted.
  - The billing queue sidebar keeps its own list without Posted, because the queue hides posted items behind a separate toggle.
- **Full badge** is still used in the shipment panel header (next to the queue link) and the Documents tab readiness panel.

## Verification

- New tests for the billing cell labels and dash, the column's position after Tender and its filter options (Posted included), and the status cell no longer showing billing. Each failed against the pre-change code first.
- `tsc -b` is clean for web, oxlint is clean on touched files, and the shipment and documents suites pass (29 files, 191 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtZ2HUFVwg3rNof8gefYG8
